### PR TITLE
Refactor LAR collection from Iterator to Iterable

### DIFF
--- a/model/shared/src/main/scala/hmda/model/fi/FIData.scala
+++ b/model/shared/src/main/scala/hmda/model/fi/FIData.scala
@@ -5,7 +5,7 @@ import hmda.model.fi.ts.TransmittalSheet
 import scala.scalajs.js.annotation.JSExport
 import scala.scalajs.js.JSConverters._
 
-case class FIData(ts: TransmittalSheet, lars: Iterator[LoanApplicationRegister]) {
+case class FIData(ts: TransmittalSheet, lars: Iterable[LoanApplicationRegister]) {
   def toCSV: String = {
     s"${ts.toCSV}\n" +
       s"${lars.map(lar => lar.toCSV + "\n")}"

--- a/parser/shared/src/main/scala/hmda/parser/fi/FIDataCsvParser.scala
+++ b/parser/shared/src/main/scala/hmda/parser/fi/FIDataCsvParser.scala
@@ -16,7 +16,7 @@ class FIDataCsvParser extends FIDataParser[String] {
   def parseLines(lines: Iterable[String]): FIData = {
     val tsLine = lines.head
     val ts = TsCsvParser(tsLine)
-    val lars = lines.tail.iterator.map(l => LarCsvParser(l))
+    val lars = lines.tail.map(l => LarCsvParser(l))
     FIData(ts, lars)
   }
 

--- a/parser/shared/src/main/scala/hmda/parser/fi/FIDataDatParser.scala
+++ b/parser/shared/src/main/scala/hmda/parser/fi/FIDataDatParser.scala
@@ -21,7 +21,7 @@ class FIDataDatParser extends FIDataParser[String] {
   def parseLines(lines: Iterable[String]): FIData = {
     val tsLine = lines.head
     val ts = TsDatParser(tsLine)
-    val lars = lines.tail.iterator.map(l => LarDatParser(l))
+    val lars = lines.tail.map(l => LarDatParser(l))
     FIData(ts, lars)
   }
 }

--- a/parser/shared/src/test/scala/hmda/parser/fi/FIDataGenerators.scala
+++ b/parser/shared/src/test/scala/hmda/parser/fi/FIDataGenerators.scala
@@ -12,7 +12,7 @@ trait FIDataGenerators extends TsGenerators with LarGenerators {
       ts <- tsGen
       n <- Gen.choose(1, 1000)
       lars <- Gen.listOfN(n, larGen)
-    } yield FIData(ts, lars.iterator)
+    } yield FIData(ts, lars)
   }
 
 }

--- a/platform-test/js/src/main/scala/hmda/js/parser/ParserExample.scala
+++ b/platform-test/js/src/main/scala/hmda/js/parser/ParserExample.scala
@@ -106,7 +106,7 @@ object ParserExample {
     document.getElementById("contactEmail").innerHTML = ts.contact.email
   }
 
-  def addLarsToTable(lars: Iterator[LoanApplicationRegister]): Unit = {
+  def addLarsToTable(lars: Iterable[LoanApplicationRegister]): Unit = {
     val larTable = dom.document.getElementById("larTable")
     val document = dom.document
     lars.foreach { lar =>


### PR DESCRIPTION
`Iterator` inherits from `TraversableOnce`, which means that once consumed it cannot be reused. Changing to `Iterable`, which extends `Traversable` and allows consuming the collection several times. 