### PR TITLE
Symmetrical test of LarCsvParser and lar.toCSV

### DIFF
--- a/parser/shared/src/test/scala/hmda/parser/fi/lar/LarCsvParserSpec.scala
+++ b/parser/shared/src/test/scala/hmda/parser/fi/lar/LarCsvParserSpec.scala
@@ -1,8 +1,14 @@
 package hmda.parser.fi.lar
 
+import hmda.model.fi.lar.LoanApplicationRegister
 import org.scalatest.{ PropSpec, MustMatchers }
 import org.scalatest.prop.PropertyChecks
 
-class LarCsvParserSpec extends PropSpec with PropertyChecks with MustMatchers {
-  property("Loan Application Register must be parsed from CSV")(pending)
+class LarCsvParserSpec extends PropSpec with PropertyChecks with MustMatchers with LarGenerators {
+
+  property("Loan Application Register must be parsed from CSV") {
+    forAll(larGen) { (lar: LoanApplicationRegister) =>
+      LarCsvParser(lar.toCSV) mustBe lar
+    }
+  }
 }


### PR DESCRIPTION
#72 

Modeled after [Transmittal Sheet CSV parser spec](https://github.com/cfpb/hmda-platform/blob/master/parser/shared/src/test/scala/hmda/parser/fi/ts/TsCsvParserSpec.scala)