### PR TITLE
add TS DAT parser test, with fake data in real/correct format

### DIFF
--- a/parser/shared/src/test/scala/hmda/parser/fi/ts/TsDatParserSpec.scala
+++ b/parser/shared/src/test/scala/hmda/parser/fi/ts/TsDatParserSpec.scala
@@ -1,10 +1,48 @@
 package hmda.parser.fi.ts
 
+import hmda.parser.util.FITestData
 import org.scalatest._
-import org.scalatest.prop.PropertyChecks
 
-class TsDatParserSpec extends PropSpec with PropertyChecks with MustMatchers with TsGenerators {
+class TsDatParserSpec extends FlatSpec with MustMatchers {
 
-  property("Transmittal Sheet must be parsed from CSV")(pending)
+  import FITestData._
 
+  val tsData = TsDatParser(tsDAT)
+
+  "TS Parser" should "parse transmittal sheet respondent info" in {
+    val respondent = tsData.respondent
+    respondent.id mustBe "0011013201"
+    respondent.name mustBe "SMALL BANK USA, NA"
+    respondent.address mustBe "1850 TYSONS BLVD., SUITE 50"
+    respondent.city mustBe "MCLEAN"
+    respondent.state mustBe "VA"
+    respondent.zipCode mustBe "22102"
+  }
+
+  it should "parse other info about the respondent" in {
+    tsData.taxId mustBe "20-1177984"
+  }
+
+  it should "parse transmittal info" in {
+    tsData.agencyCode mustBe 9
+    tsData.timestamp mustBe 201501171330L
+    tsData.activityYear mustBe 2013
+    tsData.totalLines mustBe 551
+  }
+
+  it should "parse parent info" in {
+    val parent = tsData.parent
+    parent.name mustBe "BIGS USA, INC."
+    parent.address mustBe "412 THIRD AVENUE"
+    parent.city mustBe "NEW YORK"
+    parent.zipCode mustBe "10012"
+  }
+
+  it should "parse contact info" in {
+    val contact = tsData.contact
+    contact.name mustBe "Bob Smith"
+    contact.phone mustBe "555-555-5555"
+    contact.fax mustBe "999-999-9999"
+    contact.email mustBe "bob.smith@bank.com"
+  }
 }

--- a/parser/shared/src/test/scala/hmda/parser/util/FITestData.scala
+++ b/parser/shared/src/test/scala/hmda/parser/util/FITestData.scala
@@ -2,7 +2,8 @@ package hmda.parser.util
 
 object FITestData {
 
-  val tsDAT = "101234567899201301171330 201399-99999990000900MIKES SMALL BANK   XXXXXXXXXXX1234 Main St       XXXXXXXXXXXXXXXXXXXXXSacramento         XXXXXXCA99999-9999MIKES SMALL INC    XXXXXXXXXXX1234 Kearney St    XXXXXXXXXXXXXXXXXXXXXSan Francisco      XXXXXXCA99999-1234Mrs. Krabappel     XXXXXXXXXXX916-999-9999999-753-9999krabappel@gmail.comXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+  val tsDAT =
+    "100110132019201501171330 201320-1177984  551  SMALL BANK USA, NA            1850 TYSONS BLVD., SUITE 50             MCLEAN                   VA22102     BIGS USA, INC.                412 THIRD AVENUE                        NEW YORK                 NY10012     Bob Smith                     555-555-5555999-999-9999bob.smith@bank.com                                                "
 
   val larsDAT = Seq(
     "201234567899ABCDEFGHIJKLMNOPQRSTUVWXY20130117432110000152013011906920060340100.01457432187654129000098701.0524B                                                                                                                                                                                                                                                                            x",


### PR DESCRIPTION
#73 
implemented the test, currently covering just the happy all-data-is-present case.