### PR TITLE
refactor empty Predicate: simplify String case, throw error in others

### DIFF
--- a/validation/src/main/scala/hmda/validation/dsl/CommonDsl.scala
+++ b/validation/src/main/scala/hmda/validation/dsl/CommonDsl.scala
@@ -59,7 +59,7 @@ trait CommonDsl {
   def numeric[T]: Predicate[T] = new Predicate[T] {
     override def validate: (T) => Boolean = _.asInstanceOf[AnyRef] match {
       case n: Number => true
-      case _ => false
+      case _ => throw new NotImplementedError("'numeric' doesn't handle string (or other) values yet")
     }
     override def failure: String = s"is not numeric"
   }

--- a/validation/src/main/scala/hmda/validation/dsl/CommonDsl.scala
+++ b/validation/src/main/scala/hmda/validation/dsl/CommonDsl.scala
@@ -66,9 +66,8 @@ trait CommonDsl {
 
   def empty[T]: Predicate[T] = new Predicate[T] {
     override def validate: (T) => Boolean = _.asInstanceOf[AnyRef] match {
-      case s: String =>
-        if (s.isEmpty) true else false
-      case _ => false
+      case s: String => s.isEmpty
+      case _ => throw new NotImplementedError("'empty' doesn't handle non-string values yet")
     }
     override def failure: String = "is not empty"
   }


### PR DESCRIPTION
This PR combines two changes, which is perhaps not ideal, but they are both small and I'd made them days ago (in the context of reviewing one of the larger validation-related PRs), so it seemed good to go ahead and get them in.  The first is pretty clear: simplify an `if (bool-expression) true else false` that had snuck in.

The second might be controversial (but if so, potentially educational about the intent of the code).  The type signature suggests that `empty` is eventually intended to apply to more than just Strings.  That's cool, if so.  (It's easy to imagine how the concept could apply to, say, a Contact or the like.)  However, those cases are not yet implemented.  So, with this change, instead of silently returning `false`, the code explicitly says that those other cases are not yet implemented.