### PR TITLE
V375 purchaser loan; V262 (tests and refactoring)

### DIFF
--- a/validation/src/main/scala/hmda/validation/dsl/CommonDsl.scala
+++ b/validation/src/main/scala/hmda/validation/dsl/CommonDsl.scala
@@ -74,10 +74,6 @@ trait CommonDsl {
   }
 
   def when(condition: Result)(thenTest: => Result): Result = {
-    condition match {
-      case Success() => thenTest
-      case Failure(_) => Success()
-    }
+    condition.implies(thenTest)
   }
-
 }

--- a/validation/src/main/scala/hmda/validation/dsl/CommonDsl.scala
+++ b/validation/src/main/scala/hmda/validation/dsl/CommonDsl.scala
@@ -73,7 +73,7 @@ trait CommonDsl {
     override def failure: String = "is not empty"
   }
 
-  def when(condition: Result, thenTest: => Result): Result = {
+  def when(condition: Result)(thenTest: => Result): Result = {
     condition match {
       case Success() => thenTest
       case Failure(_) => Success()

--- a/validation/src/main/scala/hmda/validation/dsl/CommonDsl.scala
+++ b/validation/src/main/scala/hmda/validation/dsl/CommonDsl.scala
@@ -73,4 +73,11 @@ trait CommonDsl {
     override def failure: String = "is not empty"
   }
 
+  def when(condition: Result, thenTest: => Result): Result = {
+    condition match {
+      case Success() => thenTest
+      case Failure(_) => Success()
+    }
+  }
+
 }

--- a/validation/src/main/scala/hmda/validation/dsl/Result.scala
+++ b/validation/src/main/scala/hmda/validation/dsl/Result.scala
@@ -15,6 +15,13 @@ sealed trait Result {
       Failure(s"$this $that")
   }
 
+  def implies(that: => Result): Result = {
+    this match {
+      case Success() => that
+      case Failure(_) => Success()
+    }
+  }
+
 }
 case class Success() extends Result
 case class Failure(message: String) extends Result

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V262.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V262.scala
@@ -1,15 +1,13 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
-import hmda.validation.dsl.{ CommonDsl, Result, Success }
+import hmda.validation.dsl.{ CommonDsl, Result }
 
 object V262 extends CommonDsl {
   def apply(lar: LoanApplicationRegister): Result = {
     val applicationDate = lar.loan.applicationDate
-    if (applicationDate == "NA") {
+    when(applicationDate is equalTo("NA")) {
       lar.actionTakenType is equalTo(6)
-    } else {
-      Success()
     }
   }
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V375.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V375.scala
@@ -8,6 +8,6 @@ object V375 extends CommonDsl {
   val okLoanTypes = List(2, 3, 4)
 
   def apply(lar: LoanApplicationRegister): Result = {
-    when(lar.purchaserType is equalTo(2), lar.loan.loanType is containedIn(okLoanTypes))
+    when(lar.purchaserType is equalTo(2)) { lar.loan.loanType is containedIn(okLoanTypes) }
   }
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V375.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V375.scala
@@ -1,17 +1,22 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
-import hmda.validation.dsl.{ CommonDsl, Result, Success }
+import hmda.validation.dsl.{ Failure, CommonDsl, Result, Success }
 
 object V375 extends CommonDsl {
 
   val okLoanTypes = List(2, 3, 4)
 
   def apply(lar: LoanApplicationRegister): Result = {
-    if (lar.purchaserType == 2) {
-      lar.loan.loanType is containedIn(okLoanTypes)
-    } else {
-      Success()
+    when(lar.purchaserType is equalTo(2), lar.loan.loanType is containedIn(okLoanTypes))
+  }
+
+  // if we like this then let's move it up to CommonDsl. one question: are commas better, or a curried something? yum.
+  // another question/idea: would we want to introduce a "then" concept to make it read better?
+  def when(condition: Result, thenTest: Result): Result = {
+    condition match {
+      case Success() => thenTest
+      case Failure(_) => Success()
     }
   }
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V375.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V375.scala
@@ -1,7 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
-import hmda.validation.dsl.{ Failure, CommonDsl, Result, Success }
+import hmda.validation.dsl.{ CommonDsl, Result }
 
 object V375 extends CommonDsl {
 
@@ -9,14 +9,5 @@ object V375 extends CommonDsl {
 
   def apply(lar: LoanApplicationRegister): Result = {
     when(lar.purchaserType is equalTo(2), lar.loan.loanType is containedIn(okLoanTypes))
-  }
-
-  // if we like this then let's move it up to CommonDsl. one question: are commas better, or a curried something? yum.
-  // another question/idea: would we want to introduce a "then" concept to make it read better?
-  def when(condition: Result, thenTest: Result): Result = {
-    condition match {
-      case Success() => thenTest
-      case Failure(_) => Success()
-    }
   }
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V375.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V375.scala
@@ -1,0 +1,17 @@
+package hmda.validation.rules.lar.validity
+
+import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.validation.dsl.{ CommonDsl, Result, Success }
+
+object V375 extends CommonDsl {
+
+  val okLoanTypes = List(2, 3, 4)
+
+  def apply(lar: LoanApplicationRegister): Result = {
+    if (lar.purchaserType == 2) {
+      lar.loan.loanType is containedIn(okLoanTypes)
+    } else {
+      Success()
+    }
+  }
+}

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V262Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V262Spec.scala
@@ -27,10 +27,10 @@ class V262Spec extends PropSpec with PropertyChecks with MustMatchers with LarGe
   }
 
   property("If date application received != NA, V262 should pass") {
-    forAll(larGen) { lar =>
-      whenever(lar.id == 2 && lar.loan.applicationDate != "NA") {
-        V262(lar) mustBe Success()
-      }
+    forAll(larGen, dateGen) { (lar, altDate) =>
+      val datedLoan = lar.loan.copy(applicationDate = altDate.toString)
+      val datedLar = lar.copy(loan = datedLoan)
+      V262(datedLar) mustBe Success()
     }
   }
 }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V262Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V262Spec.scala
@@ -1,8 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.parser.fi.lar.LarGenerators
-import hmda.validation.dsl.Success
-import org.scalacheck.Gen
+import hmda.validation.dsl.{ Failure, Success }
 import org.scalatest.{ MustMatchers, PropSpec }
 import org.scalatest.prop.PropertyChecks
 
@@ -13,6 +12,16 @@ class V262Spec extends PropSpec with PropertyChecks with MustMatchers with LarGe
         val naLoan = lar.loan.copy(applicationDate = "NA")
         val v262Lar = lar.copy(loan = naLoan, actionTakenType = 6)
         V262(v262Lar) mustBe Success()
+      }
+    }
+  }
+
+  property("Must fail if date application received = NA and action taken type is not 6") {
+    forAll(larGen) { lar =>
+      whenever(lar.actionTakenType != 6) {
+        val naLoan = lar.loan.copy(applicationDate = "NA")
+        val v262Lar = lar.copy(loan = naLoan)
+        V262(v262Lar) mustBe a[Failure]
       }
     }
   }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V375Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V375Spec.scala
@@ -1,0 +1,29 @@
+package hmda.validation.rules.lar.validity
+
+import hmda.parser.fi.lar.LarGenerators
+import hmda.validation.dsl.{ Failure, Success }
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{ MustMatchers, PropSpec }
+
+class V375Spec extends PropSpec with PropertyChecks with MustMatchers with LarGenerators {
+
+  property("if purchaser type is 2, then loan type must be 2, 3, or 4") {
+    forAll(larGen) { lar =>
+      val newLar = lar.copy(purchaserType = 2)
+      if (List(2, 3, 4).contains(newLar.loan.loanType)) {
+        V375(newLar) mustBe Success()
+      } else {
+        V375(newLar) mustBe a[Failure]
+      }
+    }
+  }
+
+  property("if purchaser type is not 2, then any loan type succeeds") {
+    forAll(larGen) { lar =>
+      whenever(lar.purchaserType != 2) {
+        V375(lar) mustBe Success()
+      }
+    }
+  }
+
+}

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V375Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V375Spec.scala
@@ -7,14 +7,20 @@ import org.scalatest.{ MustMatchers, PropSpec }
 
 class V375Spec extends PropSpec with PropertyChecks with MustMatchers with LarGenerators {
 
-  property("if purchaser type is 2, then loan type must be 2, 3, or 4") {
+  property("if purchaser type is 2, then loan type 2, 3, or 4 must succeed") {
     forAll(larGen) { lar =>
       val newLar = lar.copy(purchaserType = 2)
-      if (List(2, 3, 4).contains(newLar.loan.loanType)) {
+      whenever(List(2, 3, 4).contains(newLar.loan.loanType)) {
         V375(newLar) mustBe Success()
-      } else {
-        V375(newLar) mustBe a[Failure]
       }
+    }
+  }
+
+  property("if purchaser type is 2, then loan type other than 2, 3, or 4 must fail") {
+    forAll(larGen) { lar =>
+      val newLoan = lar.loan.copy(loanType = 1)
+      val newLar = lar.copy(purchaserType = 2, loan = newLoan)
+      V375(newLar) mustBe a[Failure]
     }
   }
 


### PR DESCRIPTION
addresses #160 and #126 

with @schbetsy:
Implemented V375, which led to creating a `when` part of the DSL.  Then refactored V262 to use it, updating its tests first.

We'd take feedback on the `when` syntax (as we did try two different versions), or any other aspect.