### PR TITLE
refactor: rename Rule to Subject

### DIFF
--- a/validation/src/main/scala/hmda/validation/dsl/CommonDsl.scala
+++ b/validation/src/main/scala/hmda/validation/dsl/CommonDsl.scala
@@ -1,7 +1,7 @@
 package hmda.validation.dsl
 
 trait CommonDsl {
-  implicit class Rule[T](data: T) {
+  implicit class Subject[T](data: T) {
     private def test(predicate: Predicate[T]): Result = {
       predicate.validate(data) match {
         case true => Success()


### PR DESCRIPTION
#258 

This turned out to be a one-line change. (I gave it a try, since I am quickly tiring of repetition as I implement validity checks, and am definitely pondering ways to refactor. I suspect `Rule` may not be the right name there either, but we might as well update this one.)

All this talk of rule and subjects feels quite regal!