### PR TITLE
refactor: remove duplication in (some) engines

### DIFF
--- a/validation/src/main/scala/hmda/validation/api/ValidationApi.scala
+++ b/validation/src/main/scala/hmda/validation/api/ValidationApi.scala
@@ -8,8 +8,8 @@ import scalaz.Scalaz._
 
 trait ValidationApi {
 
-  def doCheck[T](check: EditCheck[T], input: T): ValidationNel[ValidationError, T] = {
-    convertResult(input, check(input), check.name)
+  def check[T](editCheck: EditCheck[T], input: T): ValidationNel[ValidationError, T] = {
+    convertResult(input, editCheck(input), editCheck.name)
   }
 
   def convertResult[T](input: T, result: Result, ruleName: String): ValidationNel[ValidationError, T] = {

--- a/validation/src/main/scala/hmda/validation/api/ValidationApi.scala
+++ b/validation/src/main/scala/hmda/validation/api/ValidationApi.scala
@@ -2,10 +2,15 @@ package hmda.validation.api
 
 import hmda.validation.dsl.{ Failure, Result, Success }
 import hmda.validation.engine.ValidationError
+import hmda.validation.rules.EditCheck
 import scalaz._
 import scalaz.Scalaz._
 
 trait ValidationApi {
+
+  def doCheck[T](check: EditCheck[T], input: T): ValidationNel[ValidationError, T] = {
+    convertResult(input, check(input), check.name)
+  }
 
   def convertResult[T](input: T, result: Result, ruleName: String): ValidationNel[ValidationError, T] = {
     result match {

--- a/validation/src/main/scala/hmda/validation/engine/lar/validity/LarValidityEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/lar/validity/LarValidityEngine.scala
@@ -3,14 +3,9 @@ package hmda.validation.engine.lar.validity
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.api.ValidationApi
 import hmda.validation.engine.lar.LarCommonEngine
-import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.validity._
 
 trait LarValidityEngine extends LarCommonEngine with ValidationApi {
-
-  private def doCheck(check: EditCheck[LoanApplicationRegister], lar: LoanApplicationRegister): LarValidation = {
-    convertResult(lar, check(lar), check.name)
-  }
 
   def validate(lar: LoanApplicationRegister): LarValidation = {
     val checks = List(

--- a/validation/src/main/scala/hmda/validation/engine/lar/validity/LarValidityEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/lar/validity/LarValidityEngine.scala
@@ -3,27 +3,21 @@ package hmda.validation.engine.lar.validity
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.api.ValidationApi
 import hmda.validation.engine.lar.LarCommonEngine
+import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.validity.{ V262, V220, V225 }
 
 trait LarValidityEngine extends LarCommonEngine with ValidationApi {
-  private def v220(lar: LoanApplicationRegister): LarValidation = {
-    convertResult(lar, V220(lar.loan), "V220")
-  }
 
-  private def v225(lar: LoanApplicationRegister): LarValidation = {
-    convertResult(lar, V225(lar), "V225")
-  }
-
-  private def v262(lar: LoanApplicationRegister): LarValidation = {
-    convertResult(lar, V262(lar), "V262")
+  private def doCheck(editCheck: EditCheck[LoanApplicationRegister], lar: LoanApplicationRegister): LarValidation = {
+    convertResult(lar, editCheck(lar), editCheck.name)
   }
 
   def validate(lar: LoanApplicationRegister): LarValidation = {
     val checks = List(
-      v220(lar),
-      v225(lar),
-      v262(lar)
-    )
+      V220,
+      V225,
+      V262
+    ).map(doCheck(_, lar))
 
     validateAll(checks, lar)
   }

--- a/validation/src/main/scala/hmda/validation/engine/lar/validity/LarValidityEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/lar/validity/LarValidityEngine.scala
@@ -14,7 +14,7 @@ trait LarValidityEngine extends LarCommonEngine with ValidationApi {
       V255,
       V262,
       V400
-    ).map(doCheck(_, lar))
+    ).map(check(_, lar))
 
     validateAll(checks, lar)
   }

--- a/validation/src/main/scala/hmda/validation/engine/lar/validity/LarValidityEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/lar/validity/LarValidityEngine.scala
@@ -8,8 +8,8 @@ import hmda.validation.rules.lar.validity.{ V262, V220, V225 }
 
 trait LarValidityEngine extends LarCommonEngine with ValidationApi {
 
-  private def doCheck(editCheck: EditCheck[LoanApplicationRegister], lar: LoanApplicationRegister): LarValidation = {
-    convertResult(lar, editCheck(lar), editCheck.name)
+  private def doCheck(check: EditCheck[LoanApplicationRegister], lar: LoanApplicationRegister): LarValidation = {
+    convertResult(lar, check(lar), check.name)
   }
 
   def validate(lar: LoanApplicationRegister): LarValidation = {

--- a/validation/src/main/scala/hmda/validation/engine/ts/validity/TsValidityEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/ts/validity/TsValidityEngine.scala
@@ -11,8 +11,8 @@ import scalaz._
 
 trait TsValidityEngine extends TsCommonEngine with ValidationApi {
 
-  private def doCheck[T](editCheck: EditCheck[T], input: T): ValidationNel[ValidationError, T] = {
-    convertResult(input, editCheck(input), editCheck.name)
+  private def doCheck[T](check: EditCheck[T], input: T): ValidationNel[ValidationError, T] = {
+    convertResult(input, check(input), check.name)
   }
 
   def validate(ts: TransmittalSheet): TsValidation = {

--- a/validation/src/main/scala/hmda/validation/engine/ts/validity/TsValidityEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/ts/validity/TsValidityEngine.scala
@@ -2,29 +2,25 @@ package hmda.validation.engine.ts.validity
 
 import hmda.model.fi.ts.TransmittalSheet
 import hmda.validation.api.ValidationApi
+import hmda.validation.engine.ValidationError
 import hmda.validation.engine.ts.TsCommonEngine
+import hmda.validation.rules.EditCheck
 import hmda.validation.rules.ts.validity.{ V105, V140, V155 }
+
+import scalaz._
 
 trait TsValidityEngine extends TsCommonEngine with ValidationApi {
 
-  private def v105(t: TransmittalSheet): TsValidation = {
-    convertResult(t, V105(t), "V105")
-  }
-
-  private def v140(t: TransmittalSheet): TsValidation = {
-    convertResult(t, V140(t), "V140")
-  }
-
-  private def v155(t: TransmittalSheet): TsValidation = {
-    convertResult(t, V155(t), "V155")
+  private def doCheck[T](editCheck: EditCheck[T], input: T): ValidationNel[ValidationError, T] = {
+    convertResult(input, editCheck(input), editCheck.name)
   }
 
   def validate(ts: TransmittalSheet): TsValidation = {
-    val checks = List(
-      v105(ts),
-      v140(ts),
-      v155(ts)
-    )
+    val checks: List[TsValidation] = List(
+      V105,
+      V140,
+      V155
+    ).map(doCheck(_, ts))
 
     validateAll(checks, ts)
   }

--- a/validation/src/main/scala/hmda/validation/engine/ts/validity/TsValidityEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/ts/validity/TsValidityEngine.scala
@@ -2,18 +2,10 @@ package hmda.validation.engine.ts.validity
 
 import hmda.model.fi.ts.TransmittalSheet
 import hmda.validation.api.ValidationApi
-import hmda.validation.engine.ValidationError
 import hmda.validation.engine.ts.TsCommonEngine
-import hmda.validation.rules.EditCheck
 import hmda.validation.rules.ts.validity.{ V105, V140, V155 }
 
-import scalaz._
-
 trait TsValidityEngine extends TsCommonEngine with ValidationApi {
-
-  private def doCheck[T](check: EditCheck[T], input: T): ValidationNel[ValidationError, T] = {
-    convertResult(input, check(input), check.name)
-  }
 
   def validate(ts: TransmittalSheet): TsValidation = {
     val checks: List[TsValidation] = List(

--- a/validation/src/main/scala/hmda/validation/engine/ts/validity/TsValidityEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/ts/validity/TsValidityEngine.scala
@@ -12,7 +12,7 @@ trait TsValidityEngine extends TsCommonEngine with ValidationApi {
       V105,
       V140,
       V155
-    ).map(doCheck(_, ts))
+    ).map(check(_, ts))
 
     validateAll(checks, ts)
   }

--- a/validation/src/main/scala/hmda/validation/rules/EditCheck.scala
+++ b/validation/src/main/scala/hmda/validation/rules/EditCheck.scala
@@ -6,5 +6,5 @@ abstract class EditCheck[T] extends CommonDsl {
 
   def name: String
 
-  def apply(lar: T): Result
+  def apply(input: T): Result
 }

--- a/validation/src/main/scala/hmda/validation/rules/EditCheck.scala
+++ b/validation/src/main/scala/hmda/validation/rules/EditCheck.scala
@@ -1,0 +1,10 @@
+package hmda.validation.rules
+
+import hmda.validation.dsl.{ CommonDsl, Result }
+
+abstract class EditCheck[T] extends CommonDsl {
+
+  def name: String
+
+  def apply(lar: T): Result
+}

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V220.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V220.scala
@@ -1,13 +1,18 @@
 package hmda.validation.rules.lar.validity
 
-import hmda.model.fi.lar.Loan
+import hmda.model.fi.lar.{ LoanApplicationRegister, Loan }
 import hmda.validation.dsl.{ CommonDsl, Result }
+import hmda.validation.rules.EditCheck
 
-object V220 extends CommonDsl {
+object V220 extends EditCheck[LoanApplicationRegister] {
 
   val loanTypes = List(1, 2, 3, 4)
 
   def apply(loan: Loan): Result = {
     loan.loanType is containedIn(loanTypes)
   }
+
+  def apply(lar: LoanApplicationRegister) = this.apply(lar.loan)
+
+  def name = "V220"
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V225.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V225.scala
@@ -1,9 +1,10 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
-import hmda.validation.dsl.{ CommonDsl, Result }
+import hmda.validation.dsl.Result
+import hmda.validation.rules.EditCheck
 
-object V225 extends CommonDsl {
+object V225 extends EditCheck[LoanApplicationRegister] {
 
   val loanPurposes = List(1, 2, 3)
 
@@ -11,4 +12,5 @@ object V225 extends CommonDsl {
     lar.loan.purpose is containedIn(loanPurposes)
   }
 
+  def name = "V225"
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V255.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V255.scala
@@ -1,10 +1,13 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
-import hmda.validation.dsl.{ Result, CommonDsl }
+import hmda.validation.dsl.Result
+import hmda.validation.rules.EditCheck
 
-object V255 extends CommonDsl {
+object V255 extends EditCheck[LoanApplicationRegister] {
   def apply(lar: LoanApplicationRegister): Result = {
     lar.actionTakenType is containedIn(1 to 8)
   }
+
+  override def name: String = "V255"
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V262.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V262.scala
@@ -1,7 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
-import hmda.validation.dsl.{ CommonDsl, Result }
+import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 
 object V262 extends EditCheck[LoanApplicationRegister] {

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V262.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V262.scala
@@ -1,9 +1,10 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
-import hmda.validation.dsl.{ CommonDsl, Result, Success }
+import hmda.validation.dsl.{ Result, Success }
+import hmda.validation.rules.EditCheck
 
-object V262 extends CommonDsl {
+object V262 extends EditCheck[LoanApplicationRegister] {
   def apply(lar: LoanApplicationRegister): Result = {
     val applicationDate = lar.loan.applicationDate
     if (applicationDate == "NA") {
@@ -12,4 +13,6 @@ object V262 extends CommonDsl {
       Success()
     }
   }
+
+  def name = "V262"
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V340.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V340.scala
@@ -1,11 +1,14 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
-import hmda.validation.dsl.{ CommonDsl, Result }
+import hmda.validation.dsl.Result
+import hmda.validation.rules.EditCheck
 
-object V340 extends CommonDsl {
+object V340 extends EditCheck[LoanApplicationRegister] {
 
   def apply(lar: LoanApplicationRegister): Result = {
     lar.purchaserType is containedIn(0 to 9)
   }
+
+  def name = "V340"
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V375.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V375.scala
@@ -1,13 +1,16 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
-import hmda.validation.dsl.{ CommonDsl, Result }
+import hmda.validation.dsl.Result
+import hmda.validation.rules.EditCheck
 
-object V375 extends CommonDsl {
+object V375 extends EditCheck[LoanApplicationRegister] {
 
   val okLoanTypes = List(2, 3, 4)
 
   def apply(lar: LoanApplicationRegister): Result = {
     when(lar.purchaserType is equalTo(2)) { lar.loan.loanType is containedIn(okLoanTypes) }
   }
+
+  override def name: String = "V375"
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V400.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V400.scala
@@ -1,9 +1,10 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
-import hmda.validation.dsl.{ CommonDsl, Result }
+import hmda.validation.dsl.Result
+import hmda.validation.rules.EditCheck
 
-object V400 extends CommonDsl {
+object V400 extends EditCheck[LoanApplicationRegister] {
 
   val propertyTypes = List(1, 2, 3)
 
@@ -11,4 +12,5 @@ object V400 extends CommonDsl {
     lar.loan.propertyType is containedIn(propertyTypes)
   }
 
+  override def name: String = "V400"
 }

--- a/validation/src/main/scala/hmda/validation/rules/ts/validity/V105.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/validity/V105.scala
@@ -1,12 +1,13 @@
 package hmda.validation.rules.ts.validity
 
-import hmda.model.fi.ts.{ Respondent, TransmittalSheet }
-import hmda.validation.dsl.{ CommonDsl, Result }
+import hmda.model.fi.ts.TransmittalSheet
+import hmda.validation.dsl.Result
+import hmda.validation.rules.EditCheck
 
 /*
  Respondent name, address, city, state, and zip code must not = blank
  */
-object V105 extends CommonDsl {
+object V105 extends EditCheck[TransmittalSheet] {
   def apply(ts: TransmittalSheet): Result = {
     val respondent = ts.respondent
     val respName = respondent.name
@@ -22,4 +23,5 @@ object V105 extends CommonDsl {
       (respZipCode not empty)
   }
 
+  override def name: String = "V105"
 }

--- a/validation/src/main/scala/hmda/validation/rules/ts/validity/V140.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/validity/V140.scala
@@ -1,13 +1,16 @@
 package hmda.validation.rules.ts.validity
 
-import hmda.validation.dsl.{ CommonDsl, Result }
 import hmda.model.census.Census._
-import hmda.model.fi.ts.{ Respondent, TransmittalSheet }
+import hmda.model.fi.ts.TransmittalSheet
+import hmda.validation.dsl.Result
+import hmda.validation.rules.EditCheck
 
-object V140 extends CommonDsl {
+object V140 extends EditCheck[TransmittalSheet] {
   def apply(ts: TransmittalSheet): Result = {
     val resp = ts.respondent
     val stateCodes = states.keys.toList
     resp.state is containedIn(stateCodes)
   }
+
+  override def name: String = "V140"
 }

--- a/validation/src/main/scala/hmda/validation/rules/ts/validity/V155.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/validity/V155.scala
@@ -1,12 +1,15 @@
 package hmda.validation.rules.ts.validity
 
-import hmda.model.fi.ts.{ Contact, TransmittalSheet }
-import hmda.validation.dsl.{ CommonDsl, RegexDsl, Result }
+import hmda.model.fi.ts.TransmittalSheet
+import hmda.validation.dsl.{ RegexDsl, Result }
+import hmda.validation.rules.EditCheck
 
-object V155 extends CommonDsl with RegexDsl {
+object V155 extends EditCheck[TransmittalSheet] with RegexDsl {
   def apply(ts: TransmittalSheet): Result = {
     val contact = ts.contact
     val email = contact.email
     email is validEmail
   }
+
+  override def name: String = "V155"
 }


### PR DESCRIPTION
The goal here is to get rid of the duplication that causes us to add 4 lines each time we add a validation to `LarValidityEngine` (and others, but that's the current pain point).

It won't solve all the merge conflicts, but it'll at least mean we're adding just one new line for each new edit check.

There's more work to do here, including some really obvious parts, but I'd like to get something merged soonish, so we can stop doing extra work for each validation rule, and also make merges slightly easier.  (That said: it may be a good idea to merge the existing PRs first, then fix this one, and then merge this one -- ideally quickly, before others happen.)

Then, once the immediate `LarValidityEngine` pressure is off, we can finish up the refactoring.  (Assuming, that is, that people like it in the first place!)