### PR TITLE
Engine

### DIFF
--- a/validation/src/main/scala/hmda/validation/api/ts/TsValidationApi.scala
+++ b/validation/src/main/scala/hmda/validation/api/ts/TsValidationApi.scala
@@ -1,6 +1,6 @@
 package hmda.validation.api.ts
 
-import scala.concurrent.Future
+import scala.concurrent.{ ExecutionContext, Future }
 
 trait TsValidationApi {
 
@@ -8,18 +8,18 @@ trait TsValidationApi {
   Gets latest timestamp from database (see S013)
    */
   //TODO: this "query" must accept some sort of unique identifier for FI as parameter
-  def findTimestamp: Future[Long]
+  def findTimestamp(implicit ec: ExecutionContext): Future[Long]
 
   /*
   Returns year to be processed (see S100)
    */
   //TODO: confirm this is queried from service. Maybe passed as parameter to validation?
-  def findYearProcessed: Future[Int]
+  def findYearProcessed(implicit ec: ExecutionContext): Future[Int]
 
   /*
   Returns control number (valid respondent id / agency code combination for date processed, see S025)
    */
   //TODO: this "query" must accept some sort of unique identifier for FI as parameter
-  def findControlNumber: Future[String]
+  def findControlNumber(implicit ec: ExecutionContext): Future[String]
 
 }

--- a/validation/src/main/scala/hmda/validation/engine/lar/LarCommonEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/lar/LarCommonEngine.scala
@@ -7,4 +7,5 @@ import scalaz._
 
 trait LarCommonEngine {
   type LarValidation = ValidationNel[ValidationError, LoanApplicationRegister]
+  type LarsValidation = ValidationNel[ValidationError, Iterable[LoanApplicationRegister]]
 }

--- a/validation/src/main/scala/hmda/validation/engine/lar/LarEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/lar/LarEngine.scala
@@ -17,7 +17,7 @@ trait LarEngine extends LarSyntacticalEngine with LarValidityEngine {
   }
 
   def validateLars(lars: Iterable[LoanApplicationRegister]): LarsValidation = {
-    checkSyntacticalIterable(lars)
+    checkSyntacticalCollection(lars)
   }
 
 }

--- a/validation/src/main/scala/hmda/validation/engine/lar/LarEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/lar/LarEngine.scala
@@ -1,0 +1,23 @@
+package hmda.validation.engine.lar
+
+import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.validation.engine.lar.syntactical.LarSyntacticalEngine
+import hmda.validation.engine.lar.validity.LarValidityEngine
+import scalaz._
+import Scalaz._
+
+trait LarEngine extends LarSyntacticalEngine with LarValidityEngine {
+
+  def validateLar(lar: LoanApplicationRegister): LarValidation = {
+    (
+      checkSyntactical(lar) |@|
+      checkValidity(lar)
+    )((_, _) => lar)
+
+  }
+
+  def validateLars(lars: Iterable[LoanApplicationRegister]): LarsValidation = {
+    checkSyntacticalIterable(lars)
+  }
+
+}

--- a/validation/src/main/scala/hmda/validation/engine/lar/syntactical/LarSyntacticalEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/lar/syntactical/LarSyntacticalEngine.scala
@@ -16,7 +16,7 @@ trait LarSyntacticalEngine extends LarCommonEngine with ValidationApi {
     validateAll(checks, lar)
   }
 
-  def checkSyntacticalIterable(lars: Iterable[LoanApplicationRegister]): LarsValidation = {
+  def checkSyntacticalCollection(lars: Iterable[LoanApplicationRegister]): LarsValidation = {
     val checks = List(
       S011,
       S040

--- a/validation/src/main/scala/hmda/validation/engine/lar/syntactical/LarSyntacticalEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/lar/syntactical/LarSyntacticalEngine.scala
@@ -1,0 +1,28 @@
+package hmda.validation.engine.lar.syntactical
+
+import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.validation.api.ValidationApi
+import hmda.validation.engine.lar.LarCommonEngine
+import hmda.validation.rules.lar.syntactical.{ S010, S011, S020, S040 }
+
+trait LarSyntacticalEngine extends LarCommonEngine with ValidationApi {
+
+  def checkSyntactical(lar: LoanApplicationRegister): LarValidation = {
+    val checks = List(
+      S010,
+      S020
+    ).map(check(_, lar))
+
+    validateAll(checks, lar)
+  }
+
+  def checkSyntacticalIterable(lars: Iterable[LoanApplicationRegister]): LarsValidation = {
+    val checks = List(
+      S011,
+      S040
+    ).map(check(_, lars))
+
+    validateAll(checks, lars)
+  }
+
+}

--- a/validation/src/main/scala/hmda/validation/engine/lar/validity/LarValidityEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/lar/validity/LarValidityEngine.scala
@@ -7,7 +7,7 @@ import hmda.validation.rules.lar.validity._
 
 trait LarValidityEngine extends LarCommonEngine with ValidationApi {
 
-  def validate(lar: LoanApplicationRegister): LarValidation = {
+  def checkValidity(lar: LoanApplicationRegister): LarValidation = {
     val checks = List(
       V220,
       V225,

--- a/validation/src/main/scala/hmda/validation/engine/ts/TsEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/ts/TsEngine.scala
@@ -1,0 +1,25 @@
+package hmda.validation.engine.ts
+
+import hmda.model.fi.ts.TransmittalSheet
+import hmda.validation.engine.ts.syntactical.TsSyntacticalEngine
+import hmda.validation.engine.ts.validity.TsValidityEngine
+import scalaz._
+import Scalaz._
+import scala.concurrent.Future
+
+trait TsEngine extends TsSyntacticalEngine with TsValidityEngine {
+
+  def validateTs(ts: TransmittalSheet): Future[TsValidation] = {
+    val fSyntactical = checkSyntactical(ts)
+
+    for {
+      fs <- fSyntactical
+    } yield {
+      (
+        checkValidity(ts)
+        |@| fs
+      )((_, _) => ts)
+    }
+  }
+
+}

--- a/validation/src/main/scala/hmda/validation/engine/ts/syntactical/TsSyntacticalEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/ts/syntactical/TsSyntacticalEngine.scala
@@ -42,7 +42,7 @@ trait TsSyntacticalEngine extends TsCommonEngine with ValidationApi with TsValid
     convertResult(t, S028(t), "S028")
   }
 
-  def validate(ts: TransmittalSheet): Future[TsValidation] = {
+  def checkSyntactical(ts: TransmittalSheet): Future[TsValidation] = {
 
     val checks = List(
       s010(ts),

--- a/validation/src/main/scala/hmda/validation/engine/ts/validity/TsValidityEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/ts/validity/TsValidityEngine.scala
@@ -7,7 +7,7 @@ import hmda.validation.rules.ts.validity.{ V105, V140, V155 }
 
 trait TsValidityEngine extends TsCommonEngine with ValidationApi {
 
-  def validate(ts: TransmittalSheet): TsValidation = {
+  def checkValidity(ts: TransmittalSheet): TsValidation = {
     val checks: List[TsValidation] = List(
       V105,
       V140,

--- a/validation/src/main/scala/hmda/validation/rules/lar/syntactical/S010.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/syntactical/S010.scala
@@ -1,9 +1,10 @@
 package hmda.validation.rules.lar.syntactical
 
 import hmda.model.fi.lar.LoanApplicationRegister
-import hmda.validation.dsl.{ Result, CommonDsl }
+import hmda.validation.dsl.{ CommonDsl, Result }
+import hmda.validation.rules.EditCheck
 
-object S010 extends CommonDsl {
+object S010 extends EditCheck[LoanApplicationRegister] {
 
   //Hardcoded for now
   val larId = 2
@@ -11,4 +12,6 @@ object S010 extends CommonDsl {
   def apply(lar: LoanApplicationRegister): Result = {
     lar.id is equalTo(larId)
   }
+
+  def name = "S010"
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/syntactical/S011.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/syntactical/S011.scala
@@ -2,10 +2,13 @@ package hmda.validation.rules.lar.syntactical
 
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.{ CommonDsl, Result }
+import hmda.validation.rules.EditCheck
 
-object S011 extends CommonDsl {
+object S011 extends EditCheck[Iterable[LoanApplicationRegister]] {
   def apply(lars: Iterable[LoanApplicationRegister]): Result = {
     lars.size is greaterThan(0)
   }
+
+  def name = "S011"
 
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/syntactical/S020.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/syntactical/S020.scala
@@ -2,12 +2,15 @@ package hmda.validation.rules.lar.syntactical
 
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.{ CommonDsl, Result }
+import hmda.validation.rules.EditCheck
 
-object S020 extends CommonDsl {
+object S020 extends EditCheck[LoanApplicationRegister] {
   //Hardcoded for now
   val agencyCodes: List[Int] = List(1, 2, 3, 5, 7, 9)
 
   def apply(lar: LoanApplicationRegister): Result = {
     lar.agencyCode is containedIn(agencyCodes)
   }
+
+  def name = "S020"
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/syntactical/S040.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/syntactical/S040.scala
@@ -2,8 +2,9 @@ package hmda.validation.rules.lar.syntactical
 
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.{ CommonDsl, Failure, Result, Success }
+import hmda.validation.rules.EditCheck
 
-object S040 extends CommonDsl {
+object S040 extends EditCheck[Iterable[LoanApplicationRegister]] {
 
   //TODO: naive implementation, bail out as soon as a duplicate is found
   def apply(lars: Iterable[LoanApplicationRegister]): Result = {
@@ -14,4 +15,6 @@ object S040 extends CommonDsl {
     val uniqueSize = uniqueIds.size
     if (size != uniqueSize) Failure("Submission contains duplicates") else Success()
   }
+
+  def name = "S040"
 }

--- a/validation/src/test/scala/hmda/validation/engine/lar/syntactical/LarSyntacticalEngineSpec.scala
+++ b/validation/src/test/scala/hmda/validation/engine/lar/syntactical/LarSyntacticalEngineSpec.scala
@@ -19,4 +19,10 @@ class LarSyntacticalEngineSpec
     }
   }
 
+  property("Pass syntactical checks on groups of LARs") {
+    forAll(larListGen) { lars =>
+      checkSyntacticalCollection(lars).isSuccess mustBe true
+    }
+  }
+
 }

--- a/validation/src/test/scala/hmda/validation/engine/lar/syntactical/LarSyntacticalEngineSpec.scala
+++ b/validation/src/test/scala/hmda/validation/engine/lar/syntactical/LarSyntacticalEngineSpec.scala
@@ -1,0 +1,22 @@
+package hmda.validation.engine.lar.syntactical
+
+import hmda.parser.fi.lar.LarGenerators
+import org.scalatest.{ MustMatchers, PropSpec }
+import org.scalatest.prop.PropertyChecks
+
+class LarSyntacticalEngineSpec
+    extends PropSpec
+    with PropertyChecks
+    with MustMatchers
+    with LarGenerators
+    with LarSyntacticalEngine {
+
+  property("A LAR must pass syntactical checks") {
+    forAll(larGen) { lar =>
+      whenever(lar.id == 2) {
+        checkSyntactical(lar).isSuccess mustBe true
+      }
+    }
+  }
+
+}

--- a/validation/src/test/scala/hmda/validation/engine/ts/TsEngineSpec.scala
+++ b/validation/src/test/scala/hmda/validation/engine/ts/TsEngineSpec.scala
@@ -1,0 +1,19 @@
+package hmda.validation.engine.ts
+
+import hmda.parser.fi.ts.TsGenerators
+import org.scalatest.{ MustMatchers, PropSpec }
+import hmda.validation.dsl.Success
+import org.scalatest.prop.PropertyChecks
+import scala.concurrent.ExecutionContext
+
+class TsEngineSpec extends PropSpec with PropertyChecks with MustMatchers with TsGenerators with TsEngine with TsValidationApiSpec {
+  override implicit val ec: ExecutionContext = ExecutionContext.Implicits.global
+
+  property("Validates Transmittal Sheet") {
+    forAll(tsGen) { ts =>
+      val fValid = validateTs(ts)
+      fValid.map(v => v mustBe Success())
+    }
+  }
+
+}

--- a/validation/src/test/scala/hmda/validation/engine/ts/TsValidationApiSpec.scala
+++ b/validation/src/test/scala/hmda/validation/engine/ts/TsValidationApiSpec.scala
@@ -1,0 +1,29 @@
+package hmda.validation.engine.ts
+
+import hmda.validation.api.ts.TsValidationApi
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+trait TsValidationApiSpec extends TsValidationApi {
+
+  /*
+   The following methods simulate API calls to get values from remote resources
+  */
+
+  /*
+    Gets latest timestamp from database (see S013)
+   */
+  override def findTimestamp(implicit ec: ExecutionContext): Future[Long] = Future(201301111330L)
+
+  /*
+    Returns year to be processed (see S100)
+   */
+  override def findYearProcessed(implicit ec: ExecutionContext): Future[Int] = Future(2017)
+
+  /*
+  Returns control number (valid respondent id / agency code combination for date processed, see S025)
+  TODO: figure out what this means (???). S025 is not implemented yet
+   */
+  override def findControlNumber(implicit ec: ExecutionContext): Future[String] = Future("")
+
+}

--- a/validation/src/test/scala/hmda/validation/engine/ts/syntactical/TsSyntacticalEngineSpec.scala
+++ b/validation/src/test/scala/hmda/validation/engine/ts/syntactical/TsSyntacticalEngineSpec.scala
@@ -2,6 +2,7 @@ package hmda.validation.engine.ts.syntactical
 
 import hmda.model.fi.ts.TransmittalSheet
 import hmda.parser.fi.ts.TsGenerators
+import hmda.validation.engine.ts.TsValidationApiSpec
 import org.scalacheck.Gen
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
@@ -10,27 +11,7 @@ import org.scalatest.time.{ Millis, Seconds, Span }
 
 import scala.concurrent.{ ExecutionContext, Future }
 
-class TsSyntacticalEngineSpec extends PropSpec with PropertyChecks with MustMatchers with TsGenerators with TsSyntacticalEngine with ScalaFutures {
-
-  /*
-    The following methods simulate API calls to get values from remote resources
-    */
-
-  /*
-    Gets latest timestamp from database (see S013)
-   */
-  override def findTimestamp: Future[Long] = Future(201301111330L)
-
-  /*
-    Returns year to be processed (see S100)
-   */
-  override def findYearProcessed: Future[Int] = Future(2017)
-
-  /*
-  Returns control number (valid respondent id / agency code combination for date processed, see S025)
-  TODO: figure out what this means (???). S025 is not implemented yet
-   */
-  override def findControlNumber: Future[String] = Future("")
+class TsSyntacticalEngineSpec extends PropSpec with PropertyChecks with MustMatchers with TsGenerators with TsSyntacticalEngine with ScalaFutures with TsValidationApiSpec {
 
   override implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
 
@@ -116,7 +97,7 @@ class TsSyntacticalEngineSpec extends PropSpec with PropertyChecks with MustMatc
   protected def failGenTs(badTs: Gen[TransmittalSheet]): Assertion = {
     badTs.sample match {
       case Some(x) => {
-        val fValidated = validate(x)
+        val fValidated = checkSyntactical(x)
         whenReady(fValidated) { validated =>
           validated.isFailure mustBe true
         }
@@ -128,7 +109,7 @@ class TsSyntacticalEngineSpec extends PropSpec with PropertyChecks with MustMatc
   protected def passGenTs(goodTs: Gen[TransmittalSheet]): Assertion = {
     goodTs.sample match {
       case Some(x) => {
-        val fValidated = validate(x)
+        val fValidated = checkSyntactical(x)
         whenReady(fValidated) { validated =>
           validated.isSuccess mustBe true
         }

--- a/validation/src/test/scala/hmda/validation/engine/ts/validity/TsValidityEngineSpec.scala
+++ b/validation/src/test/scala/hmda/validation/engine/ts/validity/TsValidityEngineSpec.scala
@@ -15,7 +15,7 @@ class TsValidityEngineSpec extends PropSpec with PropertyChecks with MustMatcher
   property("Transmittal Sheet must be valid") {
     forAll(tsGen) { ts =>
       whenever(respondentNotEmpty(ts.respondent)) {
-        validate(ts).isSuccess mustBe true
+        checkValidity(ts).isSuccess mustBe true
       }
     }
   }
@@ -24,7 +24,7 @@ class TsValidityEngineSpec extends PropSpec with PropertyChecks with MustMatcher
     forAll(tsGen) { ts =>
       whenever(ts.id == 1) {
         val badTs = ts.copy(respondent = Respondent("", "", "", "", "", ""))
-        validate(badTs).isFailure mustBe true
+        checkValidity(badTs).isFailure mustBe true
       }
     }
   }
@@ -34,8 +34,8 @@ class TsValidityEngineSpec extends PropSpec with PropertyChecks with MustMatcher
       whenever(ts.id == 1) {
         val badTs = ts.copy(respondent = Respondent("", "", "", "", "XXX", ""))
         val badTs2 = ts.copy(respondent = Respondent("", "", "", "", "XX", ""))
-        validate(badTs).isFailure mustBe true
-        validate(badTs2).isFailure mustBe true
+        checkValidity(badTs).isFailure mustBe true
+        checkValidity(badTs2).isFailure mustBe true
       }
     }
   }
@@ -45,8 +45,8 @@ class TsValidityEngineSpec extends PropSpec with PropertyChecks with MustMatcher
       whenever(ts.id == 1) {
         val badTs = ts.copy(contact = Contact("", "", "", "sqwdqw"))
         val badTs2 = ts.copy(contact = Contact("", "", "", ""))
-        validate(badTs).isFailure mustBe true
-        validate(badTs2).isFailure mustBe true
+        checkValidity(badTs).isFailure mustBe true
+        checkValidity(badTs2).isFailure mustBe true
       }
     }
   }


### PR DESCRIPTION
This PR adds a single validation engine for both Transmittal Sheet and Loan Application Register. It does so by combining the existing validation engines (syntactical and validity), refactoring along the way to make this possible. When possible, tests are also added (missing in aggregate LAR validation engine, will be covered once we have test files)