### PR TITLE
V575 (Rate Spread)

### DIFF
--- a/validation/src/main/scala/hmda/validation/engine/lar/validity/LarValidityEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/lar/validity/LarValidityEngine.scala
@@ -16,7 +16,8 @@ trait LarValidityEngine extends LarCommonEngine with ValidationApi {
       V340,
       V347,
       V375,
-      V400
+      V400,
+      V575
     ).map(check(_, lar))
 
     validateAll(checks, lar)

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V575.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V575.scala
@@ -1,0 +1,25 @@
+package hmda.validation.rules.lar.validity
+
+import java.lang.NumberFormatException
+
+import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.validation.dsl.{ Failure, RegexDsl, Result }
+import hmda.validation.rules.EditCheck
+
+object V575 extends EditCheck[LoanApplicationRegister] with RegexDsl {
+  override def name: String = "V575"
+
+  override def apply(lar: LoanApplicationRegister): Result = {
+    when(lar.lienStatus is equalTo(2)) {
+      lar.rateSpread is equalTo("NA") or {
+        try {
+          val rateSpread = BigDecimal(lar.rateSpread)
+          (rateSpread is greaterThanOrEqual(BigDecimal("3.50"))) and
+            (rateSpread is lessThanOrEqual(BigDecimal("99.99")))
+        } catch {
+          case ex: NumberFormatException => Failure(s"can't parse ${lar.rateSpread} as decimal")
+        }
+      }
+    }
+  }
+}

--- a/validation/src/test/scala/hmda/validation/rules/lar/LarEditCheckSpec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/LarEditCheckSpec.scala
@@ -1,0 +1,9 @@
+package hmda.validation.rules.lar
+
+import hmda.parser.fi.lar.LarGenerators
+import org.scalatest.{ MustMatchers, PropSpec }
+import org.scalatest.prop.PropertyChecks
+
+abstract class LarEditCheckSpec extends PropSpec with PropertyChecks with MustMatchers with LarGenerators {
+
+}

--- a/validation/src/test/scala/hmda/validation/rules/lar/syntactical/S010Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/syntactical/S010Spec.scala
@@ -1,11 +1,9 @@
 package hmda.validation.rules.lar.syntactical
 
-import hmda.parser.fi.lar.LarGenerators
 import hmda.validation.dsl.Success
-import org.scalatest.{ MustMatchers, PropSpec }
-import org.scalatest.prop.PropertyChecks
+import hmda.validation.rules.lar.LarEditCheckSpec
 
-class S010Spec extends PropSpec with PropertyChecks with MustMatchers with LarGenerators {
+class S010Spec extends LarEditCheckSpec {
 
   property("Record identifier must be 2") {
     forAll(larGen) { lar =>

--- a/validation/src/test/scala/hmda/validation/rules/lar/syntactical/S011Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/syntactical/S011Spec.scala
@@ -1,11 +1,9 @@
 package hmda.validation.rules.lar.syntactical
 
-import hmda.parser.fi.lar.LarGenerators
 import hmda.validation.dsl.Success
-import org.scalatest.prop.PropertyChecks
-import org.scalatest.{ MustMatchers, PropSpec }
+import hmda.validation.rules.lar.LarEditCheckSpec
 
-class S011Spec extends PropSpec with PropertyChecks with MustMatchers with LarGenerators {
+class S011Spec extends LarEditCheckSpec {
   property("LAR list must not be empty") {
     forAll(larListGen) { lars =>
       S011(lars) mustBe Success()

--- a/validation/src/test/scala/hmda/validation/rules/lar/syntactical/S020Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/syntactical/S020Spec.scala
@@ -1,11 +1,9 @@
 package hmda.validation.rules.lar.syntactical
 
-import hmda.parser.fi.lar.LarGenerators
 import hmda.validation.dsl.Success
-import org.scalatest.{ MustMatchers, PropSpec }
-import org.scalatest.prop.PropertyChecks
+import hmda.validation.rules.lar.LarEditCheckSpec
 
-class S020Spec extends PropSpec with PropertyChecks with MustMatchers with LarGenerators {
+class S020Spec extends LarEditCheckSpec {
   property("Loan Application Register Agency Code must = 1,2,3,5,7,9") {
     forAll(larGen) { lar =>
       whenever(lar.id == 2) {

--- a/validation/src/test/scala/hmda/validation/rules/lar/syntactical/S040Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/syntactical/S040Spec.scala
@@ -1,11 +1,9 @@
 package hmda.validation.rules.lar.syntactical
 
-import hmda.parser.fi.lar.LarGenerators
 import hmda.validation.dsl.{ Failure, Success }
-import org.scalatest.prop.PropertyChecks
-import org.scalatest.{ MustMatchers, PropSpec }
+import hmda.validation.rules.lar.LarEditCheckSpec
 
-class S040Spec extends PropSpec with PropertyChecks with MustMatchers with LarGenerators {
+class S040Spec extends LarEditCheckSpec {
 
   property("Loan/Application number must be unique") {
     forAll(larListGen) { lars =>

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V220Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V220Spec.scala
@@ -1,13 +1,11 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.{ Loan, LoanApplicationRegister }
-import hmda.parser.fi.lar.LarGenerators
 import hmda.validation.dsl.{ Failure, Success }
+import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
-import org.scalatest.prop.PropertyChecks
-import org.scalatest.{ MustMatchers, PropSpec }
 
-class V220Spec extends PropSpec with PropertyChecks with MustMatchers with LarGenerators {
+class V220Spec extends LarEditCheckSpec {
   property("Loan Type must = 1,2,3, or 4") {
     forAll(larGen) { lar =>
       whenever(lar.id == 2) {

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V225Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V225Spec.scala
@@ -1,13 +1,11 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.{ Loan, LoanApplicationRegister }
-import hmda.parser.fi.lar.LarGenerators
 import hmda.validation.dsl.{ Failure, Success }
+import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
-import org.scalatest.prop.PropertyChecks
-import org.scalatest.{ MustMatchers, PropSpec }
 
-class V225Spec extends PropSpec with PropertyChecks with MustMatchers with LarGenerators {
+class V225Spec extends LarEditCheckSpec {
   property("Loan Purpose must = 1, 2, or 3") {
     forAll(larGen) { lar =>
       V225(lar) mustBe Success()

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V255Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V255Spec.scala
@@ -1,12 +1,10 @@
 package hmda.validation.rules.lar.validity
 
-import hmda.parser.fi.lar.LarGenerators
 import hmda.validation.dsl.{ Failure, Success }
+import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
-import org.scalatest.prop.PropertyChecks
-import org.scalatest.{ MustMatchers, PropSpec }
 
-class V255Spec extends PropSpec with PropertyChecks with MustMatchers with LarGenerators {
+class V255Spec extends LarEditCheckSpec {
   property("Succeeds when Action Taken Type = 1, 2, 3, 4, 5, 6, 7, or 8") {
     forAll(larGen) { lar =>
       V255(lar) mustBe Success()

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V262Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V262Spec.scala
@@ -1,11 +1,9 @@
 package hmda.validation.rules.lar.validity
 
-import hmda.parser.fi.lar.LarGenerators
 import hmda.validation.dsl.{ Failure, Success }
-import org.scalatest.{ MustMatchers, PropSpec }
-import org.scalatest.prop.PropertyChecks
+import hmda.validation.rules.lar.LarEditCheckSpec
 
-class V262Spec extends PropSpec with PropertyChecks with MustMatchers with LarGenerators {
+class V262Spec extends LarEditCheckSpec {
   property("If date application received = NA, then action taken type must = 6") {
     forAll(larGen) { lar =>
       whenever(lar.id == 2) {

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V340Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V340Spec.scala
@@ -1,12 +1,9 @@
 package hmda.validation.rules.lar.validity
 
-import hmda.parser.fi.lar.LarGenerators
 import hmda.validation.dsl.{ Failure, Success }
-import org.scalacheck.Gen
-import org.scalatest.prop.PropertyChecks
-import org.scalatest.{ MustMatchers, PropSpec }
+import hmda.validation.rules.lar.LarEditCheckSpec
 
-class V340Spec extends PropSpec with PropertyChecks with MustMatchers with LarGenerators with PurchaserTypeUtils {
+class V340Spec extends LarEditCheckSpec with PurchaserTypeUtils {
 
   property("Succeeds when Type of Purchaser = 0, 1, 2, 3, 4, 5, 6, 7, 8, or 9.") {
     forAll(larGen) { lar =>

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V375Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V375Spec.scala
@@ -1,11 +1,9 @@
 package hmda.validation.rules.lar.validity
 
-import hmda.parser.fi.lar.LarGenerators
 import hmda.validation.dsl.{ Failure, Success }
-import org.scalatest.prop.PropertyChecks
-import org.scalatest.{ MustMatchers, PropSpec }
+import hmda.validation.rules.lar.LarEditCheckSpec
 
-class V375Spec extends PropSpec with PropertyChecks with MustMatchers with LarGenerators {
+class V375Spec extends LarEditCheckSpec {
 
   property("if purchaser type is 2, then loan type 2, 3, or 4 must succeed") {
     forAll(larGen) { lar =>

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V400Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V400Spec.scala
@@ -1,13 +1,11 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.{ Loan, LoanApplicationRegister }
-import hmda.parser.fi.lar.LarGenerators
 import hmda.validation.dsl.{ Failure, Success }
+import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
-import org.scalatest.prop.PropertyChecks
-import org.scalatest.{ MustMatchers, PropSpec }
 
-class V400Spec extends PropSpec with PropertyChecks with MustMatchers with LarGenerators {
+class V400Spec extends LarEditCheckSpec {
   property("Property Type must = 1,2, or 3") {
     forAll(larGen) { lar =>
       V400(lar) mustBe Success()

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V575Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V575Spec.scala
@@ -1,0 +1,70 @@
+package hmda.validation.rules.lar.validity
+
+import hmda.validation.dsl.{ Failure, Success }
+import hmda.validation.rules.lar.LarEditCheckSpec
+
+class V575Spec extends LarEditCheckSpec {
+
+  property("succeeds if lien status is 2 and rate spread is NA") {
+    succeedsWhen(lienStatus = 2, rateSpread = "NA")
+  }
+
+  property("fails if lien status = 2 and rate spread is < 3.5%") {
+    failsWhen(lienStatus = 2, rateSpread = "03.49")
+    failsWhen(lienStatus = 2, rateSpread = "00.00")
+  }
+
+  property("succeeds if lien status = 2 and rate spread is ≥ 3.5% and ≤ 99.99%") {
+    succeedsWhen(lienStatus = 2, rateSpread = "03.50")
+    succeedsWhen(lienStatus = 2, rateSpread = "03.51")
+    succeedsWhen(lienStatus = 2, rateSpread = "11.11")
+    succeedsWhen(lienStatus = 2, rateSpread = "99.98")
+    succeedsWhen(lienStatus = 2, rateSpread = "99.99")
+  }
+
+  property("works right without leading zeroes, too") {
+    failsWhen(lienStatus = 2, rateSpread = "3.49")
+    failsWhen(lienStatus = 2, rateSpread = "2")
+    failsWhen(lienStatus = 2, rateSpread = ".05")
+
+    succeedsWhen(lienStatus = 2, rateSpread = "3.51")
+    succeedsWhen(lienStatus = 2, rateSpread = "3.5")
+  }
+
+  property("works if lien status = 2 and rate spread is otherwise badly-formatted") {
+    failsWhen(lienStatus = 2, rateSpread = "-23.45")
+    failsWhen(lienStatus = 2, rateSpread = "03.499")
+
+    succeedsWhen(lienStatus = 2, rateSpread = "03.500")
+    succeedsWhen(lienStatus = 2, rateSpread = "03.501")
+
+    failsWhen(lienStatus = 2, rateSpread = "100.01")
+  }
+
+  property("fails if lien status = 2 and rate spread is utterly bogus") {
+    failsWhen(lienStatus = 2, rateSpread = "OOPS")
+    failsWhen(lienStatus = 2, rateSpread = "10.0w")
+  }
+
+  property("succeeds in any case when lien status is not 2") {
+    forAll(larGen) { lar =>
+      whenever(lar.lienStatus != 2) {
+        V575(lar) mustBe Success()
+      }
+    }
+  }
+
+  def failsWhen(lienStatus: Int, rateSpread: String): Any = {
+    forAll(larGen) { lar =>
+      val newLar = lar.copy(lienStatus = lienStatus, rateSpread = rateSpread)
+      V575(newLar) mustBe a[Failure]
+    }
+  }
+
+  def succeedsWhen(lienStatus: Int, rateSpread: String): Any = {
+    forAll(larGen) { lar =>
+      val newLar = lar.copy(lienStatus = lienStatus, rateSpread = rateSpread)
+      V575(newLar) mustBe a[Success]
+    }
+  }
+}


### PR DESCRIPTION
addresses #168 

I will likely refactor a bit when implementing similar/related rules (particularly V570), but this can stand on its own if needed. (And merging it means that we won't keep having to deal with differing commas in `LarValidationEngine` which is a nice bonus.)