### PR TITLE
refactor: extract method to generate int outside range

### DIFF
--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/BadValueUtils.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/BadValueUtils.scala
@@ -4,8 +4,15 @@ import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.parser.fi.lar.LarGenerators
 import org.scalacheck.Gen
 
-trait PurchaserTypeUtils extends LarGenerators {
-  val badPurchaserTypeGen: Gen[Int] = Gen.oneOf(Gen.negNum[Int], Gen.choose(10, Integer.MAX_VALUE))
+trait BadValueUtils extends LarGenerators {
+
+  def intOutsideRange(lower: Int, upper: Int): Gen[Int] = {
+    val belowRange = Gen.choose(Integer.MIN_VALUE, lower - 1)
+    val aboveRange = Gen.choose(upper + 1, Integer.MAX_VALUE)
+    Gen.oneOf(belowRange, aboveRange)
+  }
+
+  val badPurchaserTypeGen: Gen[Int] = intOutsideRange(1, 9)
 
   val badPurchaserTypeLarGen: Gen[LoanApplicationRegister] = {
     for {

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V220Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V220Spec.scala
@@ -5,7 +5,7 @@ import hmda.validation.dsl.{ Failure, Success }
 import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
 
-class V220Spec extends LarEditCheckSpec {
+class V220Spec extends LarEditCheckSpec with BadValueUtils {
   property("Loan Type must = 1,2,3, or 4") {
     forAll(larGen) { lar =>
       whenever(lar.id == 2) {
@@ -14,11 +14,7 @@ class V220Spec extends LarEditCheckSpec {
     }
   }
 
-  val badLoanTypeGen: Gen[Int] = {
-    val belowRange = Gen.choose(Integer.MIN_VALUE, 0)
-    val aboveRange = Gen.choose(5, Integer.MAX_VALUE)
-    Gen.oneOf(belowRange, aboveRange)
-  }
+  val badLoanTypeGen: Gen[Int] = intOutsideRange(1, 4)
 
   property("Loan Type other than 1,2,3,4 is invalid") {
     forAll(larGen, badLoanTypeGen) { (lar: LoanApplicationRegister, x: Int) =>

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V225Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V225Spec.scala
@@ -5,18 +5,14 @@ import hmda.validation.dsl.{ Failure, Success }
 import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
 
-class V225Spec extends LarEditCheckSpec {
+class V225Spec extends LarEditCheckSpec with BadValueUtils {
   property("Loan Purpose must = 1, 2, or 3") {
     forAll(larGen) { lar =>
       V225(lar) mustBe Success()
     }
   }
 
-  val badLoanPurposeGen: Gen[Int] = {
-    val belowRange = Gen.choose(Integer.MIN_VALUE, 0)
-    val aboveRange = Gen.choose(4, Integer.MAX_VALUE)
-    Gen.oneOf(belowRange, aboveRange)
-  }
+  val badLoanPurposeGen: Gen[Int] = intOutsideRange(1, 3)
 
   property("Loan Purpose other than 1,2,3 is invalid") {
     forAll(larGen, badLoanPurposeGen) { (lar: LoanApplicationRegister, x: Int) =>

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V255Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V255Spec.scala
@@ -4,7 +4,7 @@ import hmda.validation.dsl.{ Failure, Success }
 import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
 
-class V255Spec extends LarEditCheckSpec {
+class V255Spec extends LarEditCheckSpec with BadValueUtils {
   property("Succeeds when Action Taken Type = 1, 2, 3, 4, 5, 6, 7, or 8") {
     forAll(larGen) { lar =>
       V255(lar) mustBe Success()
@@ -12,7 +12,7 @@ class V255Spec extends LarEditCheckSpec {
   }
 
   property("Fails when Action Taken Type is not valid") {
-    forAll(larGen, Gen.oneOf(Gen.negNum[Int], Gen.choose(9, Integer.MAX_VALUE))) { (lar, action) =>
+    forAll(larGen, intOutsideRange(1, 8)) { (lar, action) =>
       val invalidLAR = lar.copy(actionTakenType = action)
       V255(invalidLAR) mustBe a[Failure]
     }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V310Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V310Spec.scala
@@ -4,7 +4,7 @@ import hmda.validation.dsl.{ Failure, Success }
 import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
 
-class V310Spec extends LarEditCheckSpec {
+class V310Spec extends LarEditCheckSpec with BadValueUtils {
 
   property("Succeeds when Applicant Race1 is 1,2,3,4,5,6,7") {
     forAll(larGen) { lar =>
@@ -13,9 +13,7 @@ class V310Spec extends LarEditCheckSpec {
   }
 
   val badApplicantRaceGen: Gen[Int] = {
-    val belowRange = Gen.choose(Integer.MIN_VALUE, 0)
-    val aboveRange = Gen.choose(8, Integer.MAX_VALUE)
-    Gen.oneOf(belowRange, aboveRange)
+    intOutsideRange(1, 7)
   }
 
   property("Fails when Applicant Race1 is < 1 or > 7") {

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V315Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V315Spec.scala
@@ -4,7 +4,7 @@ import hmda.validation.dsl.{ Failure, Success }
 import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
 
-class V315Spec extends LarEditCheckSpec {
+class V315Spec extends LarEditCheckSpec with BadValueUtils {
 
   property("Succeeds when Applicant CoRace1 is 1,2,3,4,5,6,7,8") {
     forAll(larGen) { lar =>
@@ -12,11 +12,7 @@ class V315Spec extends LarEditCheckSpec {
     }
   }
 
-  val badApplicantRaceGen: Gen[Int] = {
-    val belowRange = Gen.choose(Integer.MIN_VALUE, 0)
-    val aboveRange = Gen.choose(9, Integer.MAX_VALUE)
-    Gen.oneOf(belowRange, aboveRange)
-  }
+  val badApplicantRaceGen: Gen[Int] = intOutsideRange(1, 8)
 
   property("Fails when Co-Applicant Race1 (applicant coRace1) is < 1 or > 8") {
     forAll(larGen, badApplicantRaceGen) { (lar, cr1) =>

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V340Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V340Spec.scala
@@ -3,7 +3,7 @@ package hmda.validation.rules.lar.validity
 import hmda.validation.dsl.{ Failure, Success }
 import hmda.validation.rules.lar.LarEditCheckSpec
 
-class V340Spec extends LarEditCheckSpec with PurchaserTypeUtils {
+class V340Spec extends LarEditCheckSpec with BadValueUtils {
 
   property("Succeeds when Type of Purchaser = 0, 1, 2, 3, 4, 5, 6, 7, 8, or 9.") {
     forAll(larGen) { lar =>

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V347Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V347Spec.scala
@@ -6,7 +6,7 @@ import org.scalacheck.Gen
 import org.scalatest.{ MustMatchers, PropSpec }
 import org.scalatest.prop.PropertyChecks
 
-class V347Spec extends PropSpec with PropertyChecks with MustMatchers with LarGenerators with PurchaserTypeUtils {
+class V347Spec extends PropSpec with PropertyChecks with MustMatchers with LarGenerators with BadValueUtils {
 
   property("Succeeds when there is a relevant purchaser type (1-9) and loan was originated or purchased (1 or 6)") {
     forAll(larGen, Gen.choose(1, 9), Gen.oneOf(1, 6)) { (lar, pt, action) =>

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V400Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V400Spec.scala
@@ -5,18 +5,14 @@ import hmda.validation.dsl.{ Failure, Success }
 import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
 
-class V400Spec extends LarEditCheckSpec {
+class V400Spec extends LarEditCheckSpec with BadValueUtils {
   property("Property Type must = 1,2, or 3") {
     forAll(larGen) { lar =>
       V400(lar) mustBe Success()
     }
   }
 
-  val badPropertyTypeGen: Gen[Int] = {
-    val belowRange = Gen.choose(Integer.MIN_VALUE, 0)
-    val aboveRange = Gen.choose(4, Integer.MAX_VALUE)
-    Gen.oneOf(belowRange, aboveRange)
-  }
+  val badPropertyTypeGen: Gen[Int] = intOutsideRange(1, 3)
 
   property("Property Type other than 1,2,3 is invalid") {
     forAll(larGen, badPropertyTypeGen) { (lar: LoanApplicationRegister, x: Int) =>

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V450Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V450Spec.scala
@@ -4,18 +4,14 @@ import hmda.validation.dsl.{ Failure, Success }
 import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
 
-class V450Spec extends LarEditCheckSpec {
+class V450Spec extends LarEditCheckSpec with BadValueUtils {
   property("Applicant ethnicity must = 1,2,3, or 4") {
     forAll(larGen) { lar =>
       V450(lar) mustBe Success()
     }
   }
 
-  val badEthnicityGen: Gen[Int] = {
-    val belowRange = Gen.choose(Integer.MIN_VALUE, 0)
-    val aboveRange = Gen.choose(5, Integer.MAX_VALUE)
-    Gen.oneOf(belowRange, aboveRange)
-  }
+  val badEthnicityGen: Gen[Int] = intOutsideRange(1, 4)
 
   property("Applicant ethnicity other than 1,2,3,4 is invalid") {
     forAll(larGen, badEthnicityGen) { (lar, x) =>

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V460Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V460Spec.scala
@@ -4,18 +4,14 @@ import hmda.validation.dsl.{ Failure, Success }
 import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
 
-class V460Spec extends LarEditCheckSpec {
+class V460Spec extends LarEditCheckSpec with BadValueUtils {
   property("CoApplicant ethnicity must = 1,2,3,4 or 5") {
     forAll(larGen) { lar =>
       V460(lar) mustBe Success()
     }
   }
 
-  val badCoEthnicityGen: Gen[Int] = {
-    val belowRange = Gen.choose(Integer.MIN_VALUE, 0)
-    val aboveRange = Gen.choose(6, Integer.MAX_VALUE)
-    Gen.oneOf(belowRange, aboveRange)
-  }
+  val badCoEthnicityGen: Gen[Int] = intOutsideRange(1, 5)
 
   property("Applicant ethnicity other than 1,2,3,4,5 is invalid") {
     forAll(larGen, badCoEthnicityGen) { (lar, x) =>


### PR DESCRIPTION
Extract duplicated logic into a single handy method.
Rename a Utils class to something more general, and put method there.
If it grows too large in the future, we can re-evaluate.

This change was inspired by PR #307 (issues #138 and #139) but has a scope beyond those rules.