### PR TITLE
use Set to speed up containedIn for large domains

### DIFF
--- a/validation/src/main/scala/hmda/validation/dsl/CommonDsl.scala
+++ b/validation/src/main/scala/hmda/validation/dsl/CommonDsl.scala
@@ -70,6 +70,11 @@ trait CommonDsl {
     override def failure: String = s"is not contained in valid values domain"
   }
 
+  def containedIn[T](domain: Set[T]): Predicate[T] = new Predicate[T] {
+    override def validate: (T) => Boolean = domain.contains
+    override def failure: String = s"is not contained in valid values domain"
+  }
+
   def numeric[T]: Predicate[T] = new Predicate[T] {
     override def validate: (T) => Boolean = _.asInstanceOf[AnyRef] match {
       case n: Number => true

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V280.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V280.scala
@@ -9,9 +9,9 @@ object V280 extends EditCheck[LoanApplicationRegister] {
 
   val cbsaTracts = CBSATractLookup.values
 
-  val validMSAs = cbsaTracts.map(cbsa => cbsa.geoIdMsa)
+  val validMSAs = cbsaTracts.map(cbsa => cbsa.geoIdMsa).toSet
 
-  val validMDs = cbsaTracts.map(cbsa => cbsa.metDivFp)
+  val validMDs = cbsaTracts.map(cbsa => cbsa.metDivFp).toSet
 
   override def name: String = "V280"
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V285.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V285.scala
@@ -9,7 +9,7 @@ object V285 extends EditCheck[LoanApplicationRegister] {
 
   val cbsaTracts = CBSATractLookup.values
 
-  val stateCodes = cbsaTracts.map(c => c.state).distinct
+  val stateCodes = cbsaTracts.map(c => c.state).toSet
 
   override def name: String = "V285"
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V290.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V290.scala
@@ -11,11 +11,11 @@ object V290 extends EditCheck[LoanApplicationRegister] {
 
   val validCombinations = cbsaTracts.map { cbsa =>
     (cbsa.state, cbsa.county, cbsa.geoIdMsa)
-  }
+  }.toSet
 
   val validMdCombinations = cbsaTracts.map { cbsa =>
     (cbsa.state, cbsa.county, cbsa.metDivFp)
-  }
+  }.toSet
 
   override def name: String = "V290"
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V295.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V295.scala
@@ -11,7 +11,7 @@ object V295 extends EditCheck[LoanApplicationRegister] {
 
   val validCombination = cbsaTracts.map { cbsa =>
     (cbsa.state, cbsa.county)
-  }
+  }.toSet
 
   override def name: String = "V295"
 


### PR DESCRIPTION
Makes the tests a few seconds faster on my machine.
Originally suggested in [this comment](https://github.com/cfpb/hmda-platform/pull/300/files#r61916213) on PR #300 .

Does not address the question of whether to centralize the various uses of the `cbsaTracts` data in the code.