### PR TITLE
V500 and some test code work

### DIFF
--- a/validation/src/main/scala/hmda/validation/dsl/RegexDsl.scala
+++ b/validation/src/main/scala/hmda/validation/dsl/RegexDsl.scala
@@ -14,10 +14,18 @@ trait RegexDsl {
     override def failure: String = s"is not a valid email"
   }
 
-  def numericMatching: Predicate[String] = new Predicate[String] {
-    val regEx = "^[0-9][0-9]\\.[0-9][0-9]$".r
+  def numericMatching(pattern: String): Predicate[String] = new Predicate[String] {
+    val regEx = regExFor(pattern).r
     override def validate: (String) => Boolean = matches(regEx)
     override def failure: String = s"does not match provided numeric format"
+  }
+
+  private def regExFor(pattern: String): String = {
+    val result = pattern.map {
+      case 'N' => "[0-9]"
+      case '.' => "\\."
+    }
+    "^" + result.reduce(_ + _) + "$"
   }
 
   private def matches(regEx: Regex): (String) => Boolean = {

--- a/validation/src/main/scala/hmda/validation/dsl/RegexDsl.scala
+++ b/validation/src/main/scala/hmda/validation/dsl/RegexDsl.scala
@@ -1,18 +1,29 @@
 package hmda.validation.dsl
 
+import scala.util.matching.Regex
+
 trait RegexDsl {
 
   def validEmail: Predicate[String] = new Predicate[String] {
     override def validate: (String) => Boolean = {
       val emailRegEx = "^[_A-Za-z0-9-\\+]+(\\.[_A-Za-z0-9-]+)*@[A-Za-z0-9-]+(\\.[A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$"
       val Email = emailRegEx.r
-      Email.findFirstIn(_) match {
-        case Some(_) => true
-        case None => false
-      }
+      matches(Email)
     }
 
     override def failure: String = s"is not a valid email"
   }
 
+  def numericMatching: Predicate[String] = new Predicate[String] {
+    val regEx = "^[0-9][0-9]\\.[0-9][0-9]$".r
+    override def validate: (String) => Boolean = matches(regEx)
+    override def failure: String = s"does not match provided numeric format"
+  }
+
+  private def matches(regEx: Regex): (String) => Boolean = {
+    regEx.findFirstIn(_) match {
+      case Some(_) => true
+      case None => false
+    }
+  }
 }

--- a/validation/src/main/scala/hmda/validation/engine/lar/validity/LarValidityEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/lar/validity/LarValidityEngine.scala
@@ -34,6 +34,7 @@ trait LarValidityEngine extends LarCommonEngine with ValidationApi {
       V475,
       V485,
       V490,
+      V500,
       V520,
       V570,
       V575

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V500.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V500.scala
@@ -1,0 +1,13 @@
+package hmda.validation.rules.lar.validity
+
+import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.validation.dsl.{ RegexDsl, Result }
+import hmda.validation.rules.EditCheck
+
+object V500 extends EditCheck[LoanApplicationRegister] with RegexDsl {
+  override def name: String = "V500"
+
+  override def apply(lar: LoanApplicationRegister): Result = {
+    (lar.rateSpread is equalTo("NA")) or (lar.rateSpread is numericMatching)
+  }
+}

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V500.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V500.scala
@@ -8,6 +8,6 @@ object V500 extends EditCheck[LoanApplicationRegister] with RegexDsl {
   override def name: String = "V500"
 
   override def apply(lar: LoanApplicationRegister): Result = {
-    (lar.rateSpread is equalTo("NA")) or (lar.rateSpread is numericMatching)
+    (lar.rateSpread is equalTo("NA")) or (lar.rateSpread is numericMatching("NN.NN"))
   }
 }

--- a/validation/src/test/scala/hmda/validation/rules/lar/LarEditCheckSpec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/LarEditCheckSpec.scala
@@ -1,10 +1,21 @@
 package hmda.validation.rules.lar
 
+import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.parser.fi.lar.LarGenerators
+import hmda.validation.dsl.{ Failure, Success }
+import hmda.validation.rules.EditCheck
 import org.scalatest.{ MustMatchers, PropSpec }
 import org.scalatest.prop.PropertyChecks
 
 abstract class LarEditCheckSpec extends PropSpec with PropertyChecks with MustMatchers with LarGenerators {
   implicit val generatorDriverConfig =
     PropertyCheckConfig(minSuccessful = 100, maxDiscarded = 500)
+
+  def check: EditCheck[LoanApplicationRegister]
+
+  // TODO consider trying Matcher instead of these methods
+  implicit class LarChecker(lar: LoanApplicationRegister) {
+    def mustFail = check(lar) mustBe a[Failure]
+    def mustPass = check(lar) mustBe a[Success]
+  }
 }

--- a/validation/src/test/scala/hmda/validation/rules/lar/MultipleLarEditCheckSpec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/MultipleLarEditCheckSpec.scala
@@ -1,0 +1,12 @@
+package hmda.validation.rules.lar
+
+import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.parser.fi.lar.LarGenerators
+import hmda.validation.rules.EditCheck
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{ MustMatchers, PropSpec }
+
+abstract class MultipleLarEditCheckSpec extends PropSpec with PropertyChecks with MustMatchers with LarGenerators {
+  implicit val generatorDriverConfig =
+    PropertyCheckConfig(minSuccessful = 100, maxDiscarded = 500)
+}

--- a/validation/src/test/scala/hmda/validation/rules/lar/syntactical/S010Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/syntactical/S010Spec.scala
@@ -1,6 +1,8 @@
 package hmda.validation.rules.lar.syntactical
 
+import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.Success
+import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 
 class S010Spec extends LarEditCheckSpec {
@@ -12,4 +14,6 @@ class S010Spec extends LarEditCheckSpec {
       }
     }
   }
+
+  override def check: EditCheck[LoanApplicationRegister] = S010
 }

--- a/validation/src/test/scala/hmda/validation/rules/lar/syntactical/S011Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/syntactical/S011Spec.scala
@@ -1,9 +1,9 @@
 package hmda.validation.rules.lar.syntactical
 
 import hmda.validation.dsl.Success
-import hmda.validation.rules.lar.LarEditCheckSpec
+import hmda.validation.rules.lar.MultipleLarEditCheckSpec
 
-class S011Spec extends LarEditCheckSpec {
+class S011Spec extends MultipleLarEditCheckSpec {
   property("LAR list must not be empty") {
     forAll(larListGen) { lars =>
       S011(lars) mustBe Success()

--- a/validation/src/test/scala/hmda/validation/rules/lar/syntactical/S020Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/syntactical/S020Spec.scala
@@ -1,6 +1,8 @@
 package hmda.validation.rules.lar.syntactical
 
+import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.Success
+import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 
 class S020Spec extends LarEditCheckSpec {
@@ -11,4 +13,6 @@ class S020Spec extends LarEditCheckSpec {
       }
     }
   }
+
+  override def check: EditCheck[LoanApplicationRegister] = S020
 }

--- a/validation/src/test/scala/hmda/validation/rules/lar/syntactical/S040Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/syntactical/S040Spec.scala
@@ -1,9 +1,9 @@
 package hmda.validation.rules.lar.syntactical
 
 import hmda.validation.dsl.{ Failure, Success }
-import hmda.validation.rules.lar.LarEditCheckSpec
+import hmda.validation.rules.lar.MultipleLarEditCheckSpec
 
-class S040Spec extends LarEditCheckSpec {
+class S040Spec extends MultipleLarEditCheckSpec {
 
   property("Loan/Application number must be unique") {
     forAll(larListGen) { lars =>

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/RateSpreadEditCheckSpec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/RateSpreadEditCheckSpec.scala
@@ -16,9 +16,23 @@ abstract class RateSpreadEditCheckSpec extends LarEditCheckSpec {
     }
   }
 
+  def failsWhen(rateSpread: String): Any = {
+    forAll(larGen) { lar =>
+      val newLar = lar.copy(rateSpread = rateSpread)
+      check(newLar) mustBe a[Failure]
+    }
+  }
+
   def succeedsWhen(lienStatus: Int, rateSpread: String): Any = {
     forAll(larGen) { lar =>
       val newLar = lar.copy(lienStatus = lienStatus, rateSpread = rateSpread)
+      check(newLar) mustBe a[Success]
+    }
+  }
+
+  def succeedsWhen(rateSpread: String): Any = {
+    forAll(larGen) { lar =>
+      val newLar = lar.copy(rateSpread = rateSpread)
       check(newLar) mustBe a[Success]
     }
   }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/RateSpreadEditCheckSpec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/RateSpreadEditCheckSpec.scala
@@ -2,38 +2,36 @@ package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.{ Failure, Success }
-import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 
 // this may become a trait, but for now it's in the hierarchy
 abstract class RateSpreadEditCheckSpec extends LarEditCheckSpec {
-  def check: EditCheck[LoanApplicationRegister]
 
   def failsWhen(lienStatus: Int, rateSpread: String): Any = {
     forAll(larGen) { lar =>
       val newLar = lar.copy(lienStatus = lienStatus, rateSpread = rateSpread)
-      check(newLar) mustBe a[Failure]
+      newLar.mustFail
     }
   }
 
   def failsWhen(rateSpread: String): Any = {
     forAll(larGen) { lar =>
       val newLar = lar.copy(rateSpread = rateSpread)
-      check(newLar) mustBe a[Failure]
+      newLar.mustFail
     }
   }
 
   def succeedsWhen(lienStatus: Int, rateSpread: String): Any = {
     forAll(larGen) { lar =>
       val newLar = lar.copy(lienStatus = lienStatus, rateSpread = rateSpread)
-      check(newLar) mustBe a[Success]
+      newLar.mustPass
     }
   }
 
   def succeedsWhen(rateSpread: String): Any = {
     forAll(larGen) { lar =>
       val newLar = lar.copy(rateSpread = rateSpread)
-      check(newLar) mustBe a[Success]
+      newLar.mustPass
     }
   }
 }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V220Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V220Spec.scala
@@ -2,6 +2,7 @@ package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.{ Loan, LoanApplicationRegister }
 import hmda.validation.dsl.{ Failure, Success }
+import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
 
@@ -23,4 +24,5 @@ class V220Spec extends LarEditCheckSpec with BadValueUtils {
     }
   }
 
+  override def check: EditCheck[LoanApplicationRegister] = V220
 }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V225Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V225Spec.scala
@@ -2,6 +2,7 @@ package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.{ Loan, LoanApplicationRegister }
 import hmda.validation.dsl.{ Failure, Success }
+import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
 
@@ -22,4 +23,5 @@ class V225Spec extends LarEditCheckSpec with BadValueUtils {
     }
   }
 
+  override def check: EditCheck[LoanApplicationRegister] = V225
 }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V255Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V255Spec.scala
@@ -1,6 +1,8 @@
 package hmda.validation.rules.lar.validity
 
+import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.{ Failure, Success }
+import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
 
@@ -18,4 +20,5 @@ class V255Spec extends LarEditCheckSpec with BadValueUtils {
     }
   }
 
+  override def check: EditCheck[LoanApplicationRegister] = V255
 }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V262Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V262Spec.scala
@@ -1,6 +1,8 @@
 package hmda.validation.rules.lar.validity
 
+import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.{ Failure, Success }
+import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 
 class V262Spec extends LarEditCheckSpec {
@@ -31,4 +33,6 @@ class V262Spec extends LarEditCheckSpec {
       V262(datedLar) mustBe Success()
     }
   }
+
+  override def check: EditCheck[LoanApplicationRegister] = V262
 }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V280Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V280Spec.scala
@@ -1,6 +1,8 @@
 package hmda.validation.rules.lar.validity
 
+import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.{ Failure, Success }
+import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 
 class V280Spec extends LarEditCheckSpec {
@@ -37,4 +39,5 @@ class V280Spec extends LarEditCheckSpec {
     }
   }
 
+  override def check: EditCheck[LoanApplicationRegister] = V280
 }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V285Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V285Spec.scala
@@ -1,6 +1,8 @@
 package hmda.validation.rules.lar.validity
 
+import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.{ Failure, Success }
+import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
 
@@ -44,4 +46,5 @@ class V285Spec extends LarEditCheckSpec {
 
   private def badStateGen: Gen[String] = Gen.choose(73, 99).toString
 
+  override def check: EditCheck[LoanApplicationRegister] = V285
 }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V290Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V290Spec.scala
@@ -1,6 +1,8 @@
 package hmda.validation.rules.lar.validity
 
+import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.{ Failure, Success }
+import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 
 class V290Spec extends LarEditCheckSpec {
@@ -45,4 +47,5 @@ class V290Spec extends LarEditCheckSpec {
     }
   }
 
+  override def check: EditCheck[LoanApplicationRegister] = V290
 }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V295Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V295Spec.scala
@@ -1,6 +1,8 @@
 package hmda.validation.rules.lar.validity
 
+import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.{ Failure, Success }
+import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 
 class V295Spec extends LarEditCheckSpec {
@@ -43,4 +45,5 @@ class V295Spec extends LarEditCheckSpec {
     }
   }
 
+  override def check: EditCheck[LoanApplicationRegister] = V295
 }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V310Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V310Spec.scala
@@ -1,6 +1,8 @@
 package hmda.validation.rules.lar.validity
 
+import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.{ Failure, Success }
+import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
 
@@ -24,4 +26,5 @@ class V310Spec extends LarEditCheckSpec with BadValueUtils {
     }
   }
 
+  override def check: EditCheck[LoanApplicationRegister] = V310
 }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V315Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V315Spec.scala
@@ -1,6 +1,8 @@
 package hmda.validation.rules.lar.validity
 
+import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.{ Failure, Success }
+import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
 
@@ -22,4 +24,5 @@ class V315Spec extends LarEditCheckSpec with BadValueUtils {
     }
   }
 
+  override def check: EditCheck[LoanApplicationRegister] = V315
 }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V320Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V320Spec.scala
@@ -1,6 +1,8 @@
 package hmda.validation.rules.lar.validity
 
+import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.{ Failure, Success }
+import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
 
@@ -21,4 +23,5 @@ class V320Spec extends LarEditCheckSpec with BadValueUtils {
     }
   }
 
+  override def check: EditCheck[LoanApplicationRegister] = V320
 }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V325Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V325Spec.scala
@@ -1,6 +1,8 @@
 package hmda.validation.rules.lar.validity
 
+import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.{ Failure, Success }
+import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
 
@@ -22,4 +24,5 @@ class V325Spec extends LarEditCheckSpec with BadValueUtils {
     }
   }
 
+  override def check: EditCheck[LoanApplicationRegister] = V325
 }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V340Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V340Spec.scala
@@ -1,6 +1,8 @@
 package hmda.validation.rules.lar.validity
 
+import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.{ Failure, Success }
+import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 
 class V340Spec extends LarEditCheckSpec with BadValueUtils {
@@ -18,4 +20,5 @@ class V340Spec extends LarEditCheckSpec with BadValueUtils {
     }
   }
 
+  override def check: EditCheck[LoanApplicationRegister] = V340
 }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V375Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V375Spec.scala
@@ -1,6 +1,8 @@
 package hmda.validation.rules.lar.validity
 
+import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.{ Failure, Success }
+import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 
 class V375Spec extends LarEditCheckSpec {
@@ -30,4 +32,5 @@ class V375Spec extends LarEditCheckSpec {
     }
   }
 
+  override def check: EditCheck[LoanApplicationRegister] = V375
 }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V400Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V400Spec.scala
@@ -2,6 +2,7 @@ package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.{ Loan, LoanApplicationRegister }
 import hmda.validation.dsl.{ Failure, Success }
+import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
 
@@ -22,4 +23,5 @@ class V400Spec extends LarEditCheckSpec with BadValueUtils {
     }
   }
 
+  override def check: EditCheck[LoanApplicationRegister] = V400
 }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V410Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V410Spec.scala
@@ -2,6 +2,7 @@ package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.{ Failure, Success }
+import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
 
@@ -35,4 +36,5 @@ class V410Spec extends LarEditCheckSpec {
     }
   }
 
+  override def check: EditCheck[LoanApplicationRegister] = V410
 }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V450Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V450Spec.scala
@@ -1,6 +1,8 @@
 package hmda.validation.rules.lar.validity
 
+import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.{ Failure, Success }
+import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
 
@@ -21,4 +23,5 @@ class V450Spec extends LarEditCheckSpec with BadValueUtils {
     }
   }
 
+  override def check: EditCheck[LoanApplicationRegister] = V450
 }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V455Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V455Spec.scala
@@ -1,6 +1,8 @@
 package hmda.validation.rules.lar.validity
 
+import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.{ Failure, Success }
+import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
 
@@ -36,4 +38,5 @@ class V455Spec extends LarEditCheckSpec {
     }
   }
 
+  override def check: EditCheck[LoanApplicationRegister] = V455
 }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V460Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V460Spec.scala
@@ -1,6 +1,8 @@
 package hmda.validation.rules.lar.validity
 
+import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.{ Failure, Success }
+import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
 
@@ -20,4 +22,6 @@ class V460Spec extends LarEditCheckSpec with BadValueUtils {
       V460(invalidLar) mustBe a[Failure]
     }
   }
+
+  override def check: EditCheck[LoanApplicationRegister] = V460
 }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V465Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V465Spec.scala
@@ -1,6 +1,8 @@
 package hmda.validation.rules.lar.validity
 
+import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.{ Failure, Success }
+import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
 
@@ -36,4 +38,5 @@ class V465Spec extends LarEditCheckSpec {
     }
   }
 
+  override def check: EditCheck[LoanApplicationRegister] = V465
 }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V470Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V470Spec.scala
@@ -2,6 +2,7 @@ package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.{ Failure, Success }
+import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
 
@@ -71,4 +72,5 @@ class V470Spec extends LarEditCheckSpec {
     }
   }
 
+  override def check: EditCheck[LoanApplicationRegister] = V470
 }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V475Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V475Spec.scala
@@ -1,6 +1,8 @@
 package hmda.validation.rules.lar.validity
 
+import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.{ Failure, Success }
+import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
 
@@ -59,4 +61,5 @@ class V475Spec extends LarEditCheckSpec {
     }
   }
 
+  override def check: EditCheck[LoanApplicationRegister] = V475
 }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V485Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V485Spec.scala
@@ -1,7 +1,8 @@
 package hmda.validation.rules.lar.validity
 
-import hmda.model.fi.lar.Applicant
+import hmda.model.fi.lar.{ Applicant, LoanApplicationRegister }
 import hmda.validation.dsl.{ Failure, Success }
+import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
 
@@ -80,4 +81,5 @@ class V485Spec extends LarEditCheckSpec {
     applicant.copy(coRace2 = vals(0), coRace3 = vals(1), coRace4 = vals(2), coRace5 = vals(3))
   }
 
+  override def check: EditCheck[LoanApplicationRegister] = V485
 }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V490Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V490Spec.scala
@@ -1,6 +1,8 @@
 package hmda.validation.rules.lar.validity
 
+import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.{ Failure, Success }
+import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
 
@@ -59,4 +61,5 @@ class V490Spec extends LarEditCheckSpec {
     }
   }
 
+  override def check: EditCheck[LoanApplicationRegister] = V490
 }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V500Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V500Spec.scala
@@ -1,0 +1,32 @@
+package hmda.validation.rules.lar.validity
+
+class V500Spec extends RateSpreadEditCheckSpec {
+  override def check = V500
+
+  property("succeeds if rate spread is NA") {
+    succeedsWhen(rateSpread = "NA")
+  }
+
+  property("fails if rate spread is blank") {
+    failsWhen(rateSpread = "")
+  }
+
+  property("succeeds if rate spread has NN.NN format") {
+    succeedsWhen(rateSpread = "00.00")
+    succeedsWhen(rateSpread = "03.50")
+    succeedsWhen(rateSpread = "99.99")
+  }
+
+  property("fails if rate spread has other numeric format") {
+    failsWhen(rateSpread = "00.000")
+    failsWhen(rateSpread = "0.000")
+    failsWhen(rateSpread = "000.0")
+    failsWhen(rateSpread = "1.50")
+    failsWhen(rateSpread = ".22")
+    failsWhen(rateSpread = "01.")
+  }
+
+  property("fails if rate spread is not numeric") {
+    failsWhen(rateSpread = "other")
+  }
+}


### PR DESCRIPTION
Closes #165 

Also includes some changes to test code, with the goal of removing some boilerplate without reducing readability.  Right now it just introduces methods to say that a given LAR passes or fails with the relevant edit; there may be more we can do in the future, but I wanted to go ahead and get the PR in, since this week has other stuff going on.

Also, there may be nicer ways to write it with Matchers, but I was away from the network when writing this code, so couldn't look into best practices for that.  (I'd definitely like to investigate it in the future.)