### PR TITLE
Actor refactor

### DIFF
--- a/api/src/main/scala/hmda/api/HmdaApi.scala
+++ b/api/src/main/scala/hmda/api/HmdaApi.scala
@@ -1,12 +1,12 @@
 package hmda.api
 
-import akka.actor.ActorSystem
+import akka.actor.{ActorRef, ActorSystem}
 import akka.event.Logging
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.server.Directives._
 import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
-import hmda.api.http.{ HttpApi, LarHttpApi }
+import hmda.api.http.{HttpApi, LarHttpApi}
 import hmda.api.processing.lar.SingleLarValidation
 
 object HmdaApi extends App with HttpApi with LarHttpApi {
@@ -22,7 +22,11 @@ object HmdaApi extends App with HttpApi with LarHttpApi {
   lazy val port = config.getInt("hmda.http.port")
 
   //Start up API Actors
-  val larValidation = system.actorOf(SingleLarValidation.props, "larValidation")
+  val larValidation = createSingleLarValidator()
+
+  def createSingleLarValidator(): ActorRef = {
+    system.actorOf(SingleLarValidation.props, "larValidation")
+  }
 
   val http = Http().bindAndHandle(
     routes ~ larRoutes,

--- a/api/src/main/scala/hmda/api/HmdaApi.scala
+++ b/api/src/main/scala/hmda/api/HmdaApi.scala
@@ -1,12 +1,12 @@
 package hmda.api
 
-import akka.actor.{ActorRef, ActorSystem}
+import akka.actor.{ ActorRef, ActorSystem }
 import akka.event.Logging
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.server.Directives._
 import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
-import hmda.api.http.{HttpApi, LarHttpApi}
+import hmda.api.http.{ HttpApi, LarHttpApi }
 import hmda.api.processing.lar.SingleLarValidation
 
 object HmdaApi extends App with HttpApi with LarHttpApi {
@@ -22,11 +22,8 @@ object HmdaApi extends App with HttpApi with LarHttpApi {
   lazy val port = config.getInt("hmda.http.port")
 
   //Start up API Actors
-  val larValidation = createSingleLarValidator()
-
-  def createSingleLarValidator(): ActorRef = {
-    system.actorOf(SingleLarValidation.props, "larValidation")
-  }
+  import hmda.api.processing.lar.SingleLarValidation._
+  val larValidation = createSingleLarValidator(system)
 
   val http = Http().bindAndHandle(
     routes ~ larRoutes,

--- a/api/src/main/scala/hmda/api/http/HttpApi.scala
+++ b/api/src/main/scala/hmda/api/http/HttpApi.scala
@@ -47,7 +47,7 @@ trait HttpApi extends HmdaApiProtocol {
       import HmdaFileUpload._
       post {
         val uploadTimestamp = Instant.now.toEpochMilli
-        val processingActor = system.actorOf(HmdaFileUpload.props(id))
+        val processingActor = createHmdaFileUpload(system, id)
         entity(as[Multipart.FormData]) { formData =>
           val uploaded: Future[Done] = formData.parts.mapAsync(1) {
             //TODO: check Content-Type type as well?

--- a/api/src/main/scala/hmda/api/processing/HmdaFileUpload.scala
+++ b/api/src/main/scala/hmda/api/processing/HmdaFileUpload.scala
@@ -1,10 +1,14 @@
 package hmda.api.processing
 
-import akka.actor.{ ActorLogging, Props }
-import akka.persistence.{ PersistentActor, SnapshotOffer }
+import akka.actor.{ActorLogging, ActorRef, ActorSystem, Props}
+import akka.persistence.{PersistentActor, SnapshotOffer}
 
 object HmdaFileUpload {
   def props(id: String): Props = Props(new HmdaFileUpload(id))
+
+  def createHmdaFileUpload(system: ActorSystem, id: String): ActorRef = {
+    system.actorOf(HmdaFileUpload.props(id))
+  }
 
   sealed trait Command
   sealed trait Event

--- a/api/src/main/scala/hmda/api/processing/lar/SingleLarValidation.scala
+++ b/api/src/main/scala/hmda/api/processing/lar/SingleLarValidation.scala
@@ -1,6 +1,6 @@
 package hmda.api.processing.lar
 
-import akka.actor.{ Actor, ActorLogging, Props }
+import akka.actor.{ Actor, ActorLogging, ActorRef, ActorSystem, Props }
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.engine.ValidationError
 import hmda.validation.engine.lar.LarEngine
@@ -11,6 +11,10 @@ object SingleLarValidation {
   case class CheckAll(lar: LoanApplicationRegister)
   case class CheckSyntactical(lar: LoanApplicationRegister)
   case class CheckValidity(lar: LoanApplicationRegister)
+
+  def createSingleLarValidator(system: ActorSystem): ActorRef = {
+    system.actorOf(SingleLarValidation.props, "larValidation")
+  }
 
 }
 

--- a/api/src/test/scala/hmda/api/processing/ActorSpec.scala
+++ b/api/src/test/scala/hmda/api/processing/ActorSpec.scala
@@ -1,20 +1,14 @@
 package hmda.api.processing
 
 import akka.actor.ActorSystem
-import akka.testkit.{ ImplicitSender, TestKit }
-import org.scalatest.{ BeforeAndAfterAll, MustMatchers, WordSpecLike }
+import org.scalatest.{ BeforeAndAfterAll, MustMatchers, WordSpec }
 
-class ActorSpec(_system: ActorSystem)
-    extends TestKit(_system)
-    with WordSpecLike
-    with ImplicitSender
-    with MustMatchers
-    with BeforeAndAfterAll {
+class ActorSpec extends WordSpec with MustMatchers with BeforeAndAfterAll {
 
-  def this() = this(ActorSystem("hmda-test"))
+  implicit lazy val system = ActorSystem()
 
   override def afterAll(): Unit = {
-    TestKit.shutdownActorSystem(system)
+    system.terminate()
   }
 
 }

--- a/api/src/test/scala/hmda/api/processing/HmdaFileUploadSpec.scala
+++ b/api/src/test/scala/hmda/api/processing/HmdaFileUploadSpec.scala
@@ -1,13 +1,17 @@
 package hmda.api.processing
 
 import java.time.Instant
-import hmda.api.processing.HmdaFileUpload.{ AddLine, GetState, HmdaFileUploadState }
+import akka.testkit.TestProbe
+import hmda.api.processing.HmdaFileUpload.{AddLine, GetState, HmdaFileUploadState}
+import hmda.api.processing.HmdaFileUpload._
 
 class HmdaFileUploadSpec extends ActorSpec {
 
   import hmda.parser.util.FITestData._
 
-  val hmdaFileUpload = system.actorOf(HmdaFileUpload.props("1"))
+  val hmdaFileUpload = createHmdaFileUpload(system, "1")
+
+  val probe = TestProbe()
 
   val lines = fiCSV.split("\n")
   val timestamp = Instant.now.toEpochMilli
@@ -15,10 +19,10 @@ class HmdaFileUploadSpec extends ActorSpec {
   "A HMDA File" must {
     "be persisted" in {
       for (line <- lines) {
-        hmdaFileUpload ! AddLine(timestamp, line.toString)
+        probe.send(hmdaFileUpload, AddLine(timestamp, line.toString))
       }
-      hmdaFileUpload ! GetState
-      expectMsg(HmdaFileUploadState(Map(timestamp -> 4)))
+      probe.send(hmdaFileUpload, GetState)
+      probe.expectMsg(HmdaFileUploadState(Map(timestamp -> 4)))
     }
   }
 

--- a/api/src/test/scala/hmda/api/processing/lar/SingleLarValidationSpec.scala
+++ b/api/src/test/scala/hmda/api/processing/lar/SingleLarValidationSpec.scala
@@ -1,14 +1,19 @@
 package hmda.api.processing.lar
 
 import java.io.File
+
+import akka.testkit.TestProbe
 import hmda.api.processing.ActorSpec
 import hmda.api.processing.lar.SingleLarValidation.CheckAll
 import hmda.parser.fi.lar.LarCsvParser
 import scala.io.Source
+import hmda.api.processing.lar.SingleLarValidation._
 
 class SingleLarValidationSpec extends ActorSpec {
 
-  val larValidation = system.actorOf(SingleLarValidation.props, "larValidation")
+  val probe = TestProbe()
+
+  val larValidation = createSingleLarValidator(system)
 
   val lines = Source.fromFile(new File("parser/src/test/resources/txt/FirstTestBankData_clean_407_2017.txt")).getLines()
   val lars = lines.drop(1).map(l => LarCsvParser(l))
@@ -16,8 +21,8 @@ class SingleLarValidationSpec extends ActorSpec {
   "LAR Validation" must {
     "validate all lars in sample files" in {
       lars.foreach { lar =>
-        larValidation ! CheckAll(lar)
-        expectMsg(Nil)
+        probe.send(larValidation, CheckAll(lar))
+        probe.expectMsg(Nil)
       }
     }
   }

--- a/api/src/test/scala/hmda/api/processing/lar/SingleLarValidationSpec.scala
+++ b/api/src/test/scala/hmda/api/processing/lar/SingleLarValidationSpec.scala
@@ -8,6 +8,7 @@ import hmda.api.processing.lar.SingleLarValidation.CheckAll
 import hmda.parser.fi.lar.LarCsvParser
 import scala.io.Source
 import hmda.api.processing.lar.SingleLarValidation._
+import scala.concurrent.duration._
 
 class SingleLarValidationSpec extends ActorSpec {
 
@@ -22,7 +23,7 @@ class SingleLarValidationSpec extends ActorSpec {
     "validate all lars in sample files" in {
       lars.foreach { lar =>
         probe.send(larValidation, CheckAll(lar))
-        probe.expectMsg(Nil)
+        probe.expectMsg(10.seconds, Nil)
       }
     }
   }


### PR DESCRIPTION
This pull request refactors existing actors to:

* Use factory methods for creating actors in order to facilitate testing
* Replace Akka's `TestKit` with `TestProbe` for testing expected messages