### PR TITLE
V317, V326, V463

### DIFF
--- a/api/src/test/scala/hmda/api/http/LarHttpApiSpec.scala
+++ b/api/src/test/scala/hmda/api/http/LarHttpApiSpec.scala
@@ -23,7 +23,7 @@ class LarHttpApiSpec extends WordSpec with MustMatchers with ScalatestRouteTest 
   //Start up API Actors
   val larValidation = system.actorOf(SingleLarValidation.props, "larValidation")
 
-  val larCsv = "2|0123456789|9|ABCDEFGHIJKLMNOPQRSTUVWXY|20130117|4|3|2|1|10000|1|6|20130119|12540|06|029|001.01|4|5|5|4|3|2|1|6|||||1|2|NA|0|9|8|7|01.05|2|4"
+  val larCsv = "2|0123456789|9|ABCDEFGHIJKLMNOPQRSTUVWXY|20130117|4|3|2|1|10000|1|6|20130119|12540|06|029|001.01|4|3|5|4|3|2|1|6|||||1|2|NA|0|9|8|7|01.05|2|4"
   val lar = LarCsvParser(larCsv)
   val larJson = lar.toJson
 

--- a/validation/src/main/scala/hmda/validation/engine/lar/validity/LarValidityEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/lar/validity/LarValidityEngine.scala
@@ -20,6 +20,7 @@ trait LarValidityEngine extends LarCommonEngine with ValidationApi {
       V295,
       V310,
       V315,
+      V317,
       V320,
       V325,
       V326,

--- a/validation/src/main/scala/hmda/validation/engine/lar/validity/LarValidityEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/lar/validity/LarValidityEngine.scala
@@ -34,6 +34,7 @@ trait LarValidityEngine extends LarCommonEngine with ValidationApi {
       V450,
       V455,
       V460,
+      V463,
       V465,
       V470,
       V475,

--- a/validation/src/main/scala/hmda/validation/engine/lar/validity/LarValidityEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/lar/validity/LarValidityEngine.scala
@@ -22,6 +22,7 @@ trait LarValidityEngine extends LarCommonEngine with ValidationApi {
       V315,
       V320,
       V325,
+      V326,
       V330,
       V335,
       V340,

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V317.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V317.scala
@@ -1,0 +1,16 @@
+package hmda.validation.rules.lar.validity
+
+import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.validation.dsl.Result
+import hmda.validation.rules.EditCheck
+
+object V317 extends EditCheck[LoanApplicationRegister] {
+  override def name: String = "V317"
+
+  override def apply(lar: LoanApplicationRegister): Result = {
+    when(lar.applicant.coRace1 is equalTo(8)) {
+      (lar.applicant.coSex is equalTo(5)) and
+        (lar.applicant.coEthnicity is equalTo(5))
+    }
+  }
+}

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V317.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V317.scala
@@ -3,6 +3,8 @@ package hmda.validation.rules.lar.validity
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
+import hmda.validation.dsl.PredicateCommon._
+import hmda.validation.dsl.PredicateSyntax._
 
 object V317 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "V317"

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V326.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V326.scala
@@ -3,6 +3,8 @@ package hmda.validation.rules.lar.validity
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
+import hmda.validation.dsl.PredicateCommon._
+import hmda.validation.dsl.PredicateSyntax._
 
 object V326 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "V326"

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V326.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V326.scala
@@ -1,0 +1,16 @@
+package hmda.validation.rules.lar.validity
+
+import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.validation.dsl.Result
+import hmda.validation.rules.EditCheck
+
+object V326 extends EditCheck[LoanApplicationRegister] {
+  override def name: String = "V326"
+
+  override def apply(lar: LoanApplicationRegister): Result = {
+    when(lar.applicant.coSex is equalTo(5)) {
+      (lar.applicant.coRace1 is equalTo(8)) and
+        (lar.applicant.coEthnicity is equalTo(5))
+    }
+  }
+}

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V463.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V463.scala
@@ -3,6 +3,8 @@ package hmda.validation.rules.lar.validity
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
+import hmda.validation.dsl.PredicateCommon._
+import hmda.validation.dsl.PredicateSyntax._
 
 object V463 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "V463"

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V463.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V463.scala
@@ -1,0 +1,16 @@
+package hmda.validation.rules.lar.validity
+
+import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.validation.dsl.Result
+import hmda.validation.rules.EditCheck
+
+object V463 extends EditCheck[LoanApplicationRegister] {
+  override def name: String = "V463"
+
+  override def apply(lar: LoanApplicationRegister): Result = {
+    when(lar.applicant.coEthnicity is equalTo(5)) {
+      (lar.applicant.coRace1 is equalTo(8)) and
+        (lar.applicant.coSex is equalTo(5))
+    }
+  }
+}

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V317Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V317Spec.scala
@@ -1,0 +1,46 @@
+package hmda.validation.rules.lar.validity
+
+import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.validation.rules.EditCheck
+import hmda.validation.rules.lar.LarEditCheckSpec
+
+class V317Spec extends LarEditCheckSpec {
+  property("Succeeds when Co-Applicant race1 is not 8") {
+    forAll(larGen) { lar =>
+      whenever(lar.applicant.coRace1 != 8) {
+        lar.mustPass
+      }
+    }
+  }
+
+  property("Succeeds when Co-Applicant race1=8, sex=5, and ethnicity=5") {
+    forAll(larGen) { lar =>
+      val applicantWithoutCoApp = lar.applicant.copy(coSex = 5, coRace1 = 8, coEthnicity = 5)
+      val larWithoutCoApp = lar.copy(applicant = applicantWithoutCoApp)
+      larWithoutCoApp.mustPass
+    }
+  }
+
+  property("Fails when Co-Applicant race1=8, sex=5, and ethnicity NOT 5") {
+    forAll(larGen) { lar =>
+      whenever(lar.applicant.coEthnicity != 5) {
+        val invalidApplicant = lar.applicant.copy(coSex = 5, coRace1 = 8)
+        val invalidLar = lar.copy(applicant = invalidApplicant)
+        invalidLar.mustFail
+      }
+    }
+  }
+
+  property("Fails whenever Applicant race1=8, ethnicity=5, and sex NOT 5") {
+    forAll(larGen) { lar =>
+      whenever(lar.applicant.coSex != 5) {
+        val invalidApplicant = lar.applicant.copy(coRace1 = 8, coEthnicity = 5)
+        val invalidLar = lar.copy(applicant = invalidApplicant)
+        invalidLar.mustFail
+      }
+    }
+  }
+
+  override def check: EditCheck[LoanApplicationRegister] = V317
+}
+

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V326Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V326Spec.scala
@@ -1,0 +1,45 @@
+package hmda.validation.rules.lar.validity
+
+import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.validation.rules.EditCheck
+import hmda.validation.rules.lar.LarEditCheckSpec
+
+class V326Spec extends LarEditCheckSpec {
+  property("Succeeds when Co-Applicant sex is not 5") {
+    forAll(larGen) { lar =>
+      whenever(lar.applicant.coSex != 5) {
+        lar.mustPass
+      }
+    }
+  }
+
+  property("Succeeds when Co-Applicant sex=5, ethnicity=5, and race1=8") {
+    forAll(larGen) { lar =>
+      val applicantWithoutCoApp = lar.applicant.copy(coSex = 5, coRace1 = 8, coEthnicity = 5)
+      val larWithoutCoApp = lar.copy(applicant = applicantWithoutCoApp)
+      larWithoutCoApp.mustPass
+    }
+  }
+
+  property("Fails when Co-Applicant sex=5, race1=8, and ethnicity NOT 5") {
+    forAll(larGen) { lar =>
+      whenever(lar.applicant.coEthnicity != 5) {
+        val invalidApplicant = lar.applicant.copy(coSex = 5, coRace1 = 8)
+        val invalidLar = lar.copy(applicant = invalidApplicant)
+        invalidLar.mustFail
+      }
+    }
+  }
+
+  property("Fails whenever Applicant coSex=5, coEthnicity=5, and coRace1 NOT 8") {
+    forAll(larGen) { lar =>
+      whenever(lar.applicant.coRace1 != 8) {
+        val invalidApplicant = lar.applicant.copy(coSex = 5, coEthnicity = 5)
+        val invalidLar = lar.copy(applicant = invalidApplicant)
+        invalidLar.mustFail
+      }
+    }
+  }
+
+  override def check: EditCheck[LoanApplicationRegister] = V326
+}

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V463Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V463Spec.scala
@@ -1,0 +1,45 @@
+package hmda.validation.rules.lar.validity
+
+import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.validation.rules.EditCheck
+import hmda.validation.rules.lar.LarEditCheckSpec
+
+class V463Spec extends LarEditCheckSpec {
+  property("Succeeds when Co-Applicant ethnicity is not 5") {
+    forAll(larGen) { lar =>
+      whenever(lar.applicant.coEthnicity != 5) {
+        lar.mustPass
+      }
+    }
+  }
+
+  property("Succeeds when Co-Applicant ethnicity=5, sex=5, and race1=8") {
+    forAll(larGen) { lar =>
+      val applicantWithoutCoApp = lar.applicant.copy(coSex = 5, coRace1 = 8, coEthnicity = 5)
+      val larWithoutCoApp = lar.copy(applicant = applicantWithoutCoApp)
+      larWithoutCoApp.mustPass
+    }
+  }
+
+  property("Fails when Co-Applicant ethnicity=5, race1=8, and sex NOT 5") {
+    forAll(larGen) { lar =>
+      whenever(lar.applicant.coSex != 5) {
+        val invalidApplicant = lar.applicant.copy(coEthnicity = 5, coRace1 = 8)
+        val invalidLar = lar.copy(applicant = invalidApplicant)
+        invalidLar.mustFail
+      }
+    }
+  }
+
+  property("Fails whenever Applicant ethnicity=5, sex=5, and coRace1 NOT 8") {
+    forAll(larGen) { lar =>
+      whenever(lar.applicant.coRace1 != 8) {
+        val invalidApplicant = lar.applicant.copy(coSex = 5, coEthnicity = 5)
+        val invalidLar = lar.copy(applicant = invalidApplicant)
+        invalidLar.mustFail
+      }
+    }
+  }
+
+  override def check: EditCheck[LoanApplicationRegister] = V463
+}


### PR DESCRIPTION
Closes #154 
Closes #141 
Closes #140 

Summary: If one coapplicant field says there is no coapplicant, the other coapplicant fields should corroborate that.