### PR TITLE
whitespace cleanup

### DIFF
--- a/api/src/main/scala/hmda/api/processing/HmdaFileUpload.scala
+++ b/api/src/main/scala/hmda/api/processing/HmdaFileUpload.scala
@@ -1,7 +1,7 @@
 package hmda.api.processing
 
-import akka.actor.{ActorLogging, ActorRef, ActorSystem, Props}
-import akka.persistence.{PersistentActor, SnapshotOffer}
+import akka.actor.{ ActorLogging, ActorRef, ActorSystem, Props }
+import akka.persistence.{ PersistentActor, SnapshotOffer }
 
 object HmdaFileUpload {
   def props(id: String): Props = Props(new HmdaFileUpload(id))

--- a/api/src/test/scala/hmda/api/processing/HmdaFileUploadSpec.scala
+++ b/api/src/test/scala/hmda/api/processing/HmdaFileUploadSpec.scala
@@ -2,7 +2,7 @@ package hmda.api.processing
 
 import java.time.Instant
 import akka.testkit.TestProbe
-import hmda.api.processing.HmdaFileUpload.{AddLine, GetState, HmdaFileUploadState}
+import hmda.api.processing.HmdaFileUpload.{ AddLine, GetState, HmdaFileUploadState }
 import hmda.api.processing.HmdaFileUpload._
 
 class HmdaFileUploadSpec extends ActorSpec {


### PR DESCRIPTION
When I run sbt, it changes the whitespace to look like what you see in this commit.  Perhaps the same is not true on other people's machines (and in particular on @jmarin's as of #315), in which case, let's find the discrepancy rather than getting into a commit war.

But if it's true on other people's machines too, then please merge.