### PR TITLE
`Relevant` Keyword

### DIFF
--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V540.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V540.scala
@@ -8,9 +8,9 @@ import hmda.validation.dsl.PredicateSyntax._
 
 object V540 extends EditCheck[LoanApplicationRegister] {
 
-  val actionTakenList = List(2, 3, 4, 5, 7, 8)
+  val relevantActions = List(2, 3, 4, 5, 7, 8)
   override def apply(lar: LoanApplicationRegister): Result = {
-    when(lar.actionTakenType is containedIn(actionTakenList)) {
+    when(lar.actionTakenType is containedIn(relevantActions)) {
       (lar.hoepaStatus is equalTo(2))
     }
   }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V540Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V540Spec.scala
@@ -7,14 +7,14 @@ import org.scalacheck.Gen
 
 class V540Spec extends LarEditCheckSpec with BadValueUtils {
 
-  val relevantActionTakenList = List(2, 3, 4, 5, 7, 8)
+  val relevantActions = List(2, 3, 4, 5, 7, 8)
 
-  val irrelevantActionTakenGen: Gen[Int] =
+  val irrelevantActionGen: Gen[Int] =
     Gen.choose(Int.MinValue, Int.MaxValue)
-      .filter(!relevantActionTakenList.contains(_))
+      .filter(!relevantActions.contains(_))
 
-  property("Valid when Action taken not 2,3,4,5,7 or 8") {
-    forAll(larGen, irrelevantActionTakenGen) { (lar, x) =>
+  property("Valid when Action Taken not 2,3,4,5,7 or 8") {
+    forAll(larGen, irrelevantActionGen) { (lar, x) =>
       val validLar = lar.copy(actionTakenType = x)
       validLar.mustPass
     }
@@ -27,11 +27,11 @@ class V540Spec extends LarEditCheckSpec with BadValueUtils {
     }
   }
 
-  val actionTakenGen: Gen[Int] = Gen.oneOf(relevantActionTakenList)
+  val relevantActionGen: Gen[Int] = Gen.oneOf(relevantActions)
   val badHoepaStatusGen: Gen[Int] = Gen.choose(Int.MinValue, Int.MaxValue).filter(_ != 2)
 
   property("HOEPA status other than 2 is invalid when action taken = 2,3,4,5,7,8") {
-    forAll(larGen, badHoepaStatusGen, actionTakenGen) { (lar: LoanApplicationRegister, hs: Int, at: Int) =>
+    forAll(larGen, badHoepaStatusGen, relevantActionGen) { (lar: LoanApplicationRegister, hs: Int, at: Int) =>
       val invalidLar: LoanApplicationRegister = lar.copy(
         actionTakenType = at,
         hoepaStatus = hs

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V540Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V540Spec.scala
@@ -7,30 +7,31 @@ import org.scalacheck.Gen
 
 class V540Spec extends LarEditCheckSpec with BadValueUtils {
 
-  val badActionTakenList = List(2, 3, 4, 5, 7, 8)
-  val validActionTakenGen: Gen[Int] =
-    Gen.choose(Int.MinValue, Int.MaxValue)
-      .filter(!badActionTakenList.contains(_))
+  val relevantActionTakenList = List(2, 3, 4, 5, 7, 8)
 
-  property("Valid Action taken not 2,3,4,5,7 or 8") {
-    forAll(larGen, validActionTakenGen) { (lar, x) =>
+  val irrelevantActionTakenGen: Gen[Int] =
+    Gen.choose(Int.MinValue, Int.MaxValue)
+      .filter(!relevantActionTakenList.contains(_))
+
+  property("Valid when Action taken not 2,3,4,5,7 or 8") {
+    forAll(larGen, irrelevantActionTakenGen) { (lar, x) =>
       val validLar = lar.copy(actionTakenType = x)
       validLar.mustPass
     }
   }
 
-  property("Valid if HOEPA status is 2") {
+  property("Valid when HOEPA status is 2") {
     forAll(larGen) { lar =>
       val validLar = lar.copy(hoepaStatus = 2)
       validLar.mustPass
     }
   }
 
-  val badActionTakenGen: Gen[Int] = Gen.oneOf(badActionTakenList)
+  val actionTakenGen: Gen[Int] = Gen.oneOf(relevantActionTakenList)
   val badHoepaStatusGen: Gen[Int] = Gen.choose(Int.MinValue, Int.MaxValue).filter(_ != 2)
 
-  property("HOEPA status other than 2 is invalid with certain action types") {
-    forAll(larGen, badHoepaStatusGen, badActionTakenGen) { (lar: LoanApplicationRegister, hs: Int, at: Int) =>
+  property("HOEPA status other than 2 is invalid when action taken = 2,3,4,5,7,8") {
+    forAll(larGen, badHoepaStatusGen, actionTakenGen) { (lar: LoanApplicationRegister, hs: Int, at: Int) =>
       val invalidLar: LoanApplicationRegister = lar.copy(
         actionTakenType = at,
         hoepaStatus = hs


### PR DESCRIPTION
This is an example of how I would use `relevant` in edit checks. 

Per our discussion today, I think it will be useful to designate conditions that must be met for an edit to run.