### PR TITLE
Fix whitespace on sbt compilation

### DIFF
--- a/api/src/test/scala/hmda/api/http/LarHttpApiSpec.scala
+++ b/api/src/test/scala/hmda/api/http/LarHttpApiSpec.scala
@@ -22,7 +22,7 @@ class LarHttpApiSpec extends WordSpec with MustMatchers with ScalatestRouteTest 
 
   //Start up API Actors
   val larValidation = system.actorOf(SingleLarValidation.props, "larValidation")
-  
+
   val larCsv = "2|0123456789|9|ABCDEFGHIJKLMNOPQRSTUVWXY|NA|4|3|2|1|10000|3|6|20130119|12540|06|029|001.01|4|3|5|4|3|2|1|6|||||1|2|NA|0||||NA|2|4"
 
   val lar = LarCsvParser(larCsv)


### PR DESCRIPTION
SBT keeps changing `LarHttpApiSpec.scala` whenever I run it.  If this isn't happening to anyone else, let me know and I can just close the PR.