### PR TITLE
simplify phoneGen and avoid compiler warning

### DIFF
--- a/parser/src/test/scala/hmda/parser/fi/ts/TsGenerators.scala
+++ b/parser/src/test/scala/hmda/parser/fi/ts/TsGenerators.scala
@@ -100,17 +100,11 @@ trait TsGenerators extends FIGenerators {
 
   implicit def phoneGen: Gen[String] = {
     for {
-      p1 <- Gen.choose(0, 999)
-      p2 <- Gen.choose(0, 999)
-      p3 <- Gen.choose(0, 9999)
+      p1 <- Gen.listOfN(3, Gen.numChar)
+      p2 <- Gen.listOfN(3, Gen.numChar)
+      p3 <- Gen.listOfN(4, Gen.numChar)
       sep = "-"
-    } yield List(
-      p1.toString.reverse.padTo(3, "0").reverse.mkString,
-      sep,
-      p2.toString.reverse.padTo(3, "0").reverse.mkString,
-      sep,
-      p3.toString.reverse.padTo(4, "0").reverse.mkString
-    ).mkString
+    } yield List(p1, p2, p3).map(_.mkString).mkString(sep)
   }
 
   implicit def emailGen: Gen[String] = {


### PR DESCRIPTION
addresses #110 
addresses #111 

I'd mentioned compiler warnings. Fixed one of them while in transit, by simplifying the code.  Came from PR #344 so I'm mentioning the same issues.