### PR TITLE
Get rid of type erasure compiler warning

### DIFF
--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/BadValueUtils.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/BadValueUtils.scala
@@ -14,7 +14,7 @@ trait BadValueUtils extends LarGenerators {
 
   def intOtherThan(x: Any): Gen[Int] = x match {
     case x: Int => Gen.choose(Int.MinValue, Int.MaxValue).filter(_ != x)
-    case x: Seq[Int] => Gen.choose(Int.MinValue, Int.MaxValue).filter(!x.contains(_))
+    case x: Seq[_] => Gen.choose(Int.MinValue, Int.MaxValue).filter(!x.contains(_))
   }
 
   val badPurchaserTypeGen: Gen[Int] = intOutsideRange(1, 9)


### PR DESCRIPTION
`BadValueUtils` has a compiler warning due to type erasure