### PR TITLE
Date parsing fix

### DIFF
--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V265.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V265.scala
@@ -13,11 +13,13 @@ import scala.util.Try
 object V265 extends EditCheck[LoanApplicationRegister] {
   override def apply(lar: LoanApplicationRegister): Result = {
     val date = lar.actionTakenDate.toString
+    val dateFormat = "yyyyMMdd"
 
-    val format = new SimpleDateFormat("yyyyMMdd")
+    val format = new SimpleDateFormat(dateFormat)
     format.setLenient(false)
 
-    Try(format.parse(date)).isSuccess is equalTo(true)
+    (Try(format.parse(date)).isSuccess is equalTo(true)) and
+      (date.length is equalTo(dateFormat.length))
   }
 
   override def name = "V265"

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V265Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V265Spec.scala
@@ -42,8 +42,7 @@ class V265Spec extends LarEditCheckSpec with BadValueUtils {
     }
   }
 
-  property("LARs with a valid date of an incorrect length must fail")
-  {
+  property("LARs with a valid date of an incorrect length must fail") {
     forAll(larGen) { lar =>
       val invalidLar = lar.copy(actionTakenDate = 384704001)
       invalidLar.mustFail

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V265Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V265Spec.scala
@@ -16,29 +16,37 @@ class V265Spec extends LarEditCheckSpec with BadValueUtils {
 
   property("LARs with an invalid date must fail") {
     forAll(larGen, invalidDate) { (lar, date) =>
-      val badLar = lar.copy(actionTakenDate = date)
-      badLar.mustFail
+      val invalidLar = lar.copy(actionTakenDate = date)
+      invalidLar.mustFail
     }
   }
 
   property("LARs missing part of the date must fail") {
     forAll(larGen) { lar =>
-      val badLar = lar.copy(actionTakenDate = 200001)
-      badLar.mustFail
+      val invalidLar = lar.copy(actionTakenDate = 200001)
+      invalidLar.mustFail
     }
   }
 
   property("LARs with an invalid month must fail") {
     forAll(larGen) { lar =>
-      val badLar = lar.copy(actionTakenDate = 20001301)
-      badLar.mustFail
+      val invalidLar = lar.copy(actionTakenDate = 20001301)
+      invalidLar.mustFail
     }
   }
 
   property("LARs with an invalid day must fail") {
     forAll(larGen) { lar =>
-      val badLar = lar.copy(actionTakenDate = 20001232)
-      badLar.mustFail
+      val invalidLar = lar.copy(actionTakenDate = 20001232)
+      invalidLar.mustFail
+    }
+  }
+
+  property("LARs with a valid date of an incorrect length must fail")
+  {
+    forAll(larGen) { lar =>
+      val invalidLar = lar.copy(actionTakenDate = 384704001)
+      invalidLar.mustFail
     }
   }
 


### PR DESCRIPTION
The `SimpleDateFormat` class will, when parsing, automatically trim any leading zeroes on the day input.  For example, a date input of `201603026` will correctly be formatted by the parser, but should not be able to pass our validation check.  

Shoutout to @kgudel for discovering this bug.