### PR TITLE
Descriptive comments for edit checks overridden by parser

### DIFF
--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V250.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V250.scala
@@ -8,7 +8,9 @@ import hmda.validation.dsl.PredicateSyntax._
 
 object V250 extends EditCheck[LoanApplicationRegister] {
 
-  //the numeric clause is covered by the parser
+  // The parser ensures loan amount is numeric, so the first clause
+  //  of this edit check will never fail. (If it is not numeric,
+  //  file will not parse.)
   override def apply(lar: LoanApplicationRegister): Result = {
     (lar.loan.amount is numeric) and (lar.loan.amount is greaterThan(0))
   }

--- a/validation/src/main/scala/hmda/validation/rules/ts/syntactical/S028.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/syntactical/S028.scala
@@ -12,6 +12,9 @@ import hmda.validation.dsl.PredicateHmda._
  */
 object S028 extends EditCheck[TransmittalSheet] {
 
+  // The parser ensures timestamp is numeric, so the first clause
+  //  of this edit check will never fail. (If timestamp is not numeric,
+  //  file will not parse.)
   override def apply(ts: TransmittalSheet): Result = {
     import scala.language.postfixOps
     val timestamp = ts.timestamp


### PR DESCRIPTION
I could only find two edit checks that can't fail (or partially can't fail) because of the parser: LAR V250 and TS S028.

If you find any more, let me know.