### PR TITLE
homogenized the syntax in tests

### DIFF
--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V220.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V220.scala
@@ -10,11 +10,9 @@ object V220 extends EditCheck[LoanApplicationRegister] {
 
   val loanTypes = List(1, 2, 3, 4)
 
-  def apply(loan: Loan): Result = {
-    loan.loanType is containedIn(loanTypes)
+  def apply(lar: LoanApplicationRegister): Result = {
+    lar.loan.loanType is containedIn(loanTypes)
   }
-
-  override def apply(lar: LoanApplicationRegister) = this.apply(lar.loan)
 
   override def name = "V220"
 }

--- a/validation/src/main/scala/hmda/validation/rules/ts/syntactical/S013.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/syntactical/S013.scala
@@ -6,7 +6,7 @@ import scala.concurrent.{ ExecutionContext, Future }
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 
-object S013 extends {
+object S013 {
 
   def apply(ts: TransmittalSheet, timestamp: Long): Result = {
     val t = ts.timestamp

--- a/validation/src/test/scala/hmda/validation/rules/lar/MultipleLarEditCheckSpec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/MultipleLarEditCheckSpec.scala
@@ -2,6 +2,7 @@ package hmda.validation.rules.lar
 
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.parser.fi.lar.LarGenerators
+import hmda.validation.dsl.{ Failure, Success }
 import hmda.validation.rules.EditCheck
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{ MustMatchers, PropSpec }
@@ -9,4 +10,11 @@ import org.scalatest.{ MustMatchers, PropSpec }
 abstract class MultipleLarEditCheckSpec extends PropSpec with PropertyChecks with MustMatchers with LarGenerators {
   implicit val generatorDriverConfig =
     PropertyCheckConfig(minSuccessful = 100, maxDiscarded = 500)
+
+  def check: EditCheck[Iterable[LoanApplicationRegister]]
+
+  implicit class LarsChecker(lars: Iterable[LoanApplicationRegister]) {
+    def mustFail = check(lars) mustBe a[Failure]
+    def mustPass = check(lars) mustBe a[Success]
+  }
 }

--- a/validation/src/test/scala/hmda/validation/rules/lar/syntactical/S010Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/syntactical/S010Spec.scala
@@ -10,7 +10,7 @@ class S010Spec extends LarEditCheckSpec {
   property("Record identifier must be 2") {
     forAll(larGen) { lar =>
       whenever(lar.id == 2) {
-        S010(lar) mustBe Success()
+        lar.mustPass
       }
     }
   }

--- a/validation/src/test/scala/hmda/validation/rules/lar/syntactical/S011Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/syntactical/S011Spec.scala
@@ -1,12 +1,15 @@
 package hmda.validation.rules.lar.syntactical
 
-import hmda.validation.dsl.Success
+import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.MultipleLarEditCheckSpec
 
 class S011Spec extends MultipleLarEditCheckSpec {
   property("LAR list must not be empty") {
     forAll(larListGen) { lars =>
-      S011(lars) mustBe Success()
+      lars.mustPass
     }
   }
+
+  override def check: EditCheck[Iterable[LoanApplicationRegister]] = S011
 }

--- a/validation/src/test/scala/hmda/validation/rules/lar/syntactical/S020Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/syntactical/S020Spec.scala
@@ -9,7 +9,7 @@ class S020Spec extends LarEditCheckSpec {
   property("Loan Application Register Agency Code must = 1,2,3,5,7,9") {
     forAll(larGen) { lar =>
       whenever(lar.id == 2) {
-        S020(lar) mustBe Success()
+        lar.mustPass
       }
     }
   }

--- a/validation/src/test/scala/hmda/validation/rules/lar/syntactical/S040Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/syntactical/S040Spec.scala
@@ -1,18 +1,21 @@
 package hmda.validation.rules.lar.syntactical
 
-import hmda.validation.dsl.{ Failure, Success }
+import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.MultipleLarEditCheckSpec
 
 class S040Spec extends MultipleLarEditCheckSpec {
 
   property("Loan/Application number must be unique") {
     forAll(larListGen) { lars =>
-      S040(lars) mustBe Success()
+      lars.mustPass
       whenever(lars.nonEmpty) {
         val duplicateLars = lars.head :: lars
-        S040(duplicateLars) mustBe Failure("Submission contains duplicates")
+        duplicateLars.mustFail
       }
     }
   }
+
+  override def check: EditCheck[Iterable[LoanApplicationRegister]] = S040
 
 }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V220Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V220Spec.scala
@@ -1,7 +1,6 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.{ Loan, LoanApplicationRegister }
-import hmda.validation.dsl.{ Failure, Success }
 import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
@@ -10,7 +9,7 @@ class V220Spec extends LarEditCheckSpec with BadValueUtils {
   property("Loan Type must = 1,2,3, or 4") {
     forAll(larGen) { lar =>
       whenever(lar.id == 2) {
-        V220(lar.loan) mustBe Success()
+        lar.mustPass
       }
     }
   }
@@ -20,7 +19,8 @@ class V220Spec extends LarEditCheckSpec with BadValueUtils {
   property("Loan Type other than 1,2,3,4 is invalid") {
     forAll(larGen, badLoanTypeGen) { (lar: LoanApplicationRegister, x: Int) =>
       val invalidLoan: Loan = lar.loan.copy(loanType = x)
-      V220(invalidLoan) mustBe Failure("is not contained in valid values domain")
+      val invalidLar = lar.copy(loan = invalidLoan)
+      invalidLar.mustFail
     }
   }
 

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V225Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V225Spec.scala
@@ -1,7 +1,6 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.{ Loan, LoanApplicationRegister }
-import hmda.validation.dsl.{ Failure, Success }
 import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
@@ -9,7 +8,7 @@ import org.scalacheck.Gen
 class V225Spec extends LarEditCheckSpec with BadValueUtils {
   property("Loan Purpose must = 1, 2, or 3") {
     forAll(larGen) { lar =>
-      V225(lar) mustBe Success()
+      lar.mustPass
     }
   }
 
@@ -19,7 +18,7 @@ class V225Spec extends LarEditCheckSpec with BadValueUtils {
     forAll(larGen, badLoanPurposeGen) { (lar: LoanApplicationRegister, x: Int) =>
       val invalidLoan: Loan = lar.loan.copy(purpose = x)
       val invalidLar: LoanApplicationRegister = lar.copy(loan = invalidLoan)
-      V225(invalidLar) mustBe Failure("is not contained in valid values domain")
+      invalidLar.mustFail
     }
   }
 

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V255Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V255Spec.scala
@@ -1,22 +1,20 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
-import hmda.validation.dsl.{ Failure, Success }
 import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
-import org.scalacheck.Gen
 
 class V255Spec extends LarEditCheckSpec with BadValueUtils {
   property("Succeeds when Action Taken Type = 1, 2, 3, 4, 5, 6, 7, or 8") {
     forAll(larGen) { lar =>
-      V255(lar) mustBe Success()
+      lar.mustPass
     }
   }
 
   property("Fails when Action Taken Type is not valid") {
     forAll(larGen, intOutsideRange(1, 8)) { (lar, action) =>
       val invalidLAR = lar.copy(actionTakenType = action)
-      V255(invalidLAR) mustBe a[Failure]
+      invalidLAR.mustFail
     }
   }
 

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V262Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V262Spec.scala
@@ -1,7 +1,6 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
-import hmda.validation.dsl.{ Failure, Success }
 import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 
@@ -11,7 +10,7 @@ class V262Spec extends LarEditCheckSpec {
       whenever(lar.id == 2) {
         val naLoan = lar.loan.copy(applicationDate = "NA")
         val v262Lar = lar.copy(loan = naLoan, actionTakenType = 6)
-        V262(v262Lar) mustBe Success()
+        v262Lar.mustPass
       }
     }
   }
@@ -21,7 +20,7 @@ class V262Spec extends LarEditCheckSpec {
       whenever(lar.actionTakenType != 6) {
         val naLoan = lar.loan.copy(applicationDate = "NA")
         val v262Lar = lar.copy(loan = naLoan)
-        V262(v262Lar) mustBe a[Failure]
+        v262Lar.mustFail
       }
     }
   }
@@ -30,7 +29,7 @@ class V262Spec extends LarEditCheckSpec {
     forAll(larGen, dateGen) { (lar, altDate) =>
       val datedLoan = lar.loan.copy(applicationDate = altDate.toString)
       val datedLar = lar.copy(loan = datedLoan)
-      V262(datedLar) mustBe Success()
+      datedLar.mustPass
     }
   }
 

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V280Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V280Spec.scala
@@ -1,7 +1,6 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
-import hmda.validation.dsl.{ Failure, Success }
 import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 
@@ -11,7 +10,7 @@ class V280Spec extends LarEditCheckSpec {
     forAll(larGen) { lar =>
       val validGeography = lar.geography.copy(msa = "17020")
       val validLar = lar.copy(geography = validGeography)
-      V280(validLar) mustBe a[Success]
+      validLar.mustPass
     }
   }
 
@@ -19,7 +18,7 @@ class V280Spec extends LarEditCheckSpec {
     forAll(larGen) { lar =>
       val validGeography = lar.geography.copy(msa = "48424")
       val validLar = lar.copy(geography = validGeography)
-      V280(validLar) mustBe a[Success]
+      validLar.mustPass
     }
   }
 
@@ -27,7 +26,7 @@ class V280Spec extends LarEditCheckSpec {
     forAll(larGen) { lar =>
       val validGeography = lar.geography.copy(msa = "NA")
       val validLar = lar.copy(geography = validGeography)
-      V280(validLar) mustBe a[Success]
+      validLar.mustPass
     }
   }
 
@@ -35,7 +34,7 @@ class V280Spec extends LarEditCheckSpec {
     forAll(larGen) { lar =>
       val inValidGeography = lar.geography.copy(msa = "010201")
       val inValidLar = lar.copy(geography = inValidGeography)
-      V280(inValidLar) mustBe a[Failure]
+      inValidLar.mustFail
     }
   }
 

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V285Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V285Spec.scala
@@ -1,7 +1,6 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
-import hmda.validation.dsl.{ Failure, Success }
 import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
@@ -11,7 +10,7 @@ class V285Spec extends LarEditCheckSpec {
   property("Succeeds when state is valid FIPS code") {
     forAll(larGen) { lar =>
       whenever(lar.geography.state != "NA") {
-        V285(lar) mustBe a[Success]
+        lar.mustPass
       }
     }
   }
@@ -21,7 +20,7 @@ class V285Spec extends LarEditCheckSpec {
       whenever(lar.geography.state != "NA") {
         val invalidGeography = lar.geography.copy(state = state)
         val invalidLar = lar.copy(geography = invalidGeography)
-        V285(invalidLar) mustBe a[Failure]
+        invalidLar.mustFail
       }
     }
   }
@@ -30,7 +29,7 @@ class V285Spec extends LarEditCheckSpec {
     forAll(larGen) { lar =>
       val validGeography = lar.geography.copy(state = "NA", msa = "NA")
       val validLar = lar.copy(geography = validGeography)
-      V285(validLar) mustBe a[Success]
+      validLar.mustPass
     }
   }
 
@@ -39,7 +38,7 @@ class V285Spec extends LarEditCheckSpec {
       whenever(lar.geography.msa != "NA") {
         val invalidGeography = lar.geography.copy(state = "NA")
         val invalidLar = lar.copy(geography = invalidGeography)
-        V285(invalidLar) mustBe a[Failure]
+        invalidLar.mustFail
       }
     }
   }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V290Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V290Spec.scala
@@ -1,7 +1,6 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
-import hmda.validation.dsl.{ Failure, Success }
 import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 
@@ -11,7 +10,7 @@ class V290Spec extends LarEditCheckSpec {
     forAll(larGen) { lar =>
       val validGeography = lar.geography.copy(msa = "NA")
       val validLar = lar.copy(geography = validGeography)
-      V290(validLar) mustBe a[Success]
+      validLar.mustPass
     }
   }
 
@@ -19,7 +18,7 @@ class V290Spec extends LarEditCheckSpec {
     forAll(larGen) { lar =>
       val validGeography = lar.geography.copy(msa = "17020", county = "007", state = "06")
       val validLar = lar.copy(geography = validGeography)
-      V290(validLar) mustBe a[Success]
+      validLar.mustPass
     }
   }
 
@@ -27,7 +26,7 @@ class V290Spec extends LarEditCheckSpec {
     forAll(larGen) { lar =>
       val invalidGeography = lar.geography.copy(msa = "17020", county = "001", state = "05")
       val invalidLar = lar.copy(geography = invalidGeography)
-      V290(invalidLar) mustBe a[Failure]
+      invalidLar.mustFail
     }
   }
 
@@ -35,7 +34,7 @@ class V290Spec extends LarEditCheckSpec {
     forAll(larGen) { lar =>
       val validGeography = lar.geography.copy(msa = "48424", state = "12", county = "099")
       val validLar = lar.copy(geography = validGeography)
-      V290(validLar) mustBe a[Success]
+      validLar.mustPass
     }
   }
 
@@ -43,7 +42,7 @@ class V290Spec extends LarEditCheckSpec {
     forAll(larGen) { lar =>
       val validGeography = lar.geography.copy(msa = "48424", state = "12", county = "086")
       val validLar = lar.copy(geography = validGeography)
-      V290(validLar) mustBe a[Failure]
+      validLar.mustFail
     }
   }
 

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V295Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V295Spec.scala
@@ -1,7 +1,6 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
-import hmda.validation.dsl.{ Failure, Success }
 import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 
@@ -12,7 +11,7 @@ class V295Spec extends LarEditCheckSpec {
       whenever(lar.geography.msa != "NA") {
         val validGeography = lar.geography.copy(state = "06", county = "007")
         val validLar = lar.copy(geography = validGeography)
-        V295(validLar) mustBe a[Success]
+        validLar.mustPass
       }
     }
   }
@@ -22,7 +21,7 @@ class V295Spec extends LarEditCheckSpec {
       whenever(lar.geography.msa != "NA") {
         val invalidGeography = lar.geography.copy(state = "11", county = "555")
         val invalidLar = lar.copy(geography = invalidGeography)
-        V295(invalidLar) mustBe a[Failure]
+        invalidLar.mustFail
       }
     }
   }
@@ -31,7 +30,7 @@ class V295Spec extends LarEditCheckSpec {
     forAll(larGen) { lar =>
       val validGeography = lar.geography.copy(msa = "NA", county = "NA")
       val validLar = lar.copy(geography = validGeography)
-      V295(validLar) mustBe a[Success]
+      validLar.mustPass
     }
   }
 
@@ -40,7 +39,7 @@ class V295Spec extends LarEditCheckSpec {
       whenever(lar.geography.msa != "NA") {
         val invalidGeography = lar.geography.copy(county = "NA")
         val invalidLar = lar.copy(geography = invalidGeography)
-        V295(invalidLar) mustBe a[Failure]
+        invalidLar.mustFail
       }
     }
   }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V310Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V310Spec.scala
@@ -1,7 +1,6 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
-import hmda.validation.dsl.{ Failure, Success }
 import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
@@ -10,7 +9,7 @@ class V310Spec extends LarEditCheckSpec with BadValueUtils {
 
   property("Succeeds when Applicant Race1 is 1,2,3,4,5,6,7") {
     forAll(larGen) { lar =>
-      V310(lar) mustBe Success()
+      lar.mustPass
     }
   }
 
@@ -22,7 +21,7 @@ class V310Spec extends LarEditCheckSpec with BadValueUtils {
     forAll(larGen, badApplicantRaceGen) { (lar, r1) =>
       val invalidApplicant = lar.applicant.copy(race1 = r1)
       val invalidLar = lar.copy(applicant = invalidApplicant)
-      V310(invalidLar) mustBe a[Failure]
+      invalidLar.mustFail
     }
   }
 

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V315Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V315Spec.scala
@@ -1,7 +1,6 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
-import hmda.validation.dsl.{ Failure, Success }
 import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
@@ -10,7 +9,7 @@ class V315Spec extends LarEditCheckSpec with BadValueUtils {
 
   property("Succeeds when Applicant CoRace1 is 1,2,3,4,5,6,7,8") {
     forAll(larGen) { lar =>
-      V315(lar) mustBe Success()
+      lar.mustPass
     }
   }
 
@@ -20,7 +19,7 @@ class V315Spec extends LarEditCheckSpec with BadValueUtils {
     forAll(larGen, badApplicantRaceGen) { (lar, cr1) =>
       val invalidApplicant = lar.applicant.copy(coRace1 = cr1)
       val invalidLar = lar.copy(applicant = invalidApplicant)
-      V315(invalidLar) mustBe a[Failure]
+      invalidLar.mustFail
     }
   }
 

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V320Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V320Spec.scala
@@ -1,7 +1,6 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
-import hmda.validation.dsl.{ Failure, Success }
 import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
@@ -9,7 +8,7 @@ import org.scalacheck.Gen
 class V320Spec extends LarEditCheckSpec with BadValueUtils {
   property("Applicant sex must = 1,2,3, or 4") {
     forAll(larGen) { lar =>
-      V320(lar) mustBe Success()
+      lar.mustPass
     }
   }
 
@@ -19,7 +18,7 @@ class V320Spec extends LarEditCheckSpec with BadValueUtils {
     forAll(larGen, badApplicantSexGen) { (lar, sex) =>
       val invalidApplicant = lar.applicant.copy(sex = sex)
       val invalidLar = lar.copy(applicant = invalidApplicant)
-      V320(invalidLar) mustBe a[Failure]
+      invalidLar.mustFail
     }
   }
 

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V325Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V325Spec.scala
@@ -1,7 +1,6 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
-import hmda.validation.dsl.{ Failure, Success }
 import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
@@ -10,7 +9,7 @@ class V325Spec extends LarEditCheckSpec with BadValueUtils {
 
   property("CoApplicant sex must = 1,2,3,4, or 5") {
     forAll(larGen) { lar =>
-      V325(lar) mustBe Success()
+      lar.mustPass
     }
   }
 
@@ -20,7 +19,7 @@ class V325Spec extends LarEditCheckSpec with BadValueUtils {
     forAll(larGen, badApplicantCoSexGen) { (lar, sex) =>
       val invalidApplicant = lar.applicant.copy(coSex = sex)
       val invalidLar = lar.copy(applicant = invalidApplicant)
-      V325(invalidLar) mustBe a[Failure]
+      invalidLar.mustFail
     }
   }
 

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V330Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V330Spec.scala
@@ -1,7 +1,6 @@
 package hmda.validation.rules.lar.validity
 
-import hmda.model.fi.lar.{ Loan, LoanApplicationRegister }
-import hmda.validation.dsl.{ Failure, Success }
+import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
@@ -9,7 +8,7 @@ import org.scalacheck.Gen
 class V330Spec extends LarEditCheckSpec {
   property("Income must be greater than 0 or 'NA'") {
     forAll(larGen) { lar =>
-      V330(lar) mustBe Success()
+      lar.mustPass
     }
   }
 
@@ -19,7 +18,7 @@ class V330Spec extends LarEditCheckSpec {
     forAll(larGen, badIncomeNumberGen) { (lar: LoanApplicationRegister, x: Int) =>
       val invalidApplicant = lar.applicant.copy(income = x.toString)
       val invalidLar = lar.copy(applicant = invalidApplicant)
-      V330(invalidLar) mustBe a[Failure]
+      invalidLar.mustFail
     }
   }
 
@@ -29,7 +28,7 @@ class V330Spec extends LarEditCheckSpec {
     forAll(larGen, badIncomeStringGen) { (lar: LoanApplicationRegister, x: String) =>
       val invalidApplicant = lar.applicant.copy(income = x)
       val invalidLar = lar.copy(applicant = invalidApplicant)
-      V330(invalidLar) mustBe a[Failure]
+      invalidLar.mustFail
     }
   }
 

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V340Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V340Spec.scala
@@ -1,7 +1,6 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
-import hmda.validation.dsl.{ Failure, Success }
 import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 
@@ -9,14 +8,14 @@ class V340Spec extends LarEditCheckSpec with BadValueUtils {
 
   property("Succeeds when Type of Purchaser = 0, 1, 2, 3, 4, 5, 6, 7, 8, or 9.") {
     forAll(larGen) { lar =>
-      V340(lar) mustBe Success()
+      lar.mustPass
     }
   }
 
   property("Fails when purchaser type is not valid") {
     forAll(larGen, badPurchaserTypeGen) { (lar, pt) =>
       val invalidLAR = lar.copy(purchaserType = pt)
-      V340(invalidLAR) mustBe Failure("is not contained in valid values domain")
+      invalidLAR.mustFail
     }
   }
 

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V347Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V347Spec.scala
@@ -1,17 +1,16 @@
 package hmda.validation.rules.lar.validity
 
-import hmda.parser.fi.lar.LarGenerators
-import hmda.validation.dsl.{ Failure, Success }
+import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.validation.rules.EditCheck
+import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
-import org.scalatest.{ MustMatchers, PropSpec }
-import org.scalatest.prop.PropertyChecks
 
-class V347Spec extends PropSpec with PropertyChecks with MustMatchers with LarGenerators with BadValueUtils {
+class V347Spec extends LarEditCheckSpec with BadValueUtils {
 
   property("Succeeds when there is a relevant purchaser type (1-9) and loan was originated or purchased (1 or 6)") {
     forAll(larGen, Gen.choose(1, 9), Gen.oneOf(1, 6)) { (lar, pt, action) =>
       val newLar = lar.copy(purchaserType = pt, actionTakenType = action)
-      V347(newLar) mustBe Success()
+      newLar.mustPass
     }
   }
 
@@ -19,20 +18,22 @@ class V347Spec extends PropSpec with PropertyChecks with MustMatchers with LarGe
     forAll(larGen, Gen.choose(1, 9)) { (lar, pt) =>
       whenever(!List(1, 6).contains(lar.actionTakenType)) {
         val newLar = lar.copy(purchaserType = pt)
-        V347(newLar) mustBe a[Failure]
+        newLar.mustFail
       }
     }
   }
 
   property("Succeeds when Type of Purchaser = 0") {
     forAll(larGen) { lar =>
-      V347(lar.copy(purchaserType = 0)) mustBe Success()
+      lar.copy(purchaserType = 0).mustPass
     }
   }
 
   property("Succeeds when Type of Purchaser is invalid") {
     forAll(badPurchaserTypeLarGen) { lar =>
-      V347(lar) mustBe Success()
+      lar.mustPass
     }
   }
+
+  override def check: EditCheck[LoanApplicationRegister] = V347
 }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V375Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V375Spec.scala
@@ -1,7 +1,6 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
-import hmda.validation.dsl.{ Failure, Success }
 import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 
@@ -11,7 +10,7 @@ class V375Spec extends LarEditCheckSpec {
     forAll(larGen) { lar =>
       val newLar = lar.copy(purchaserType = 2)
       whenever(List(2, 3, 4).contains(newLar.loan.loanType)) {
-        V375(newLar) mustBe Success()
+        newLar.mustPass
       }
     }
   }
@@ -20,14 +19,14 @@ class V375Spec extends LarEditCheckSpec {
     forAll(larGen) { lar =>
       val newLoan = lar.loan.copy(loanType = 1)
       val newLar = lar.copy(purchaserType = 2, loan = newLoan)
-      V375(newLar) mustBe a[Failure]
+      newLar.mustFail
     }
   }
 
   property("if purchaser type is not 2, then any loan type succeeds") {
     forAll(larGen) { lar =>
       whenever(lar.purchaserType != 2) {
-        V375(lar) mustBe Success()
+        lar.mustPass
       }
     }
   }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V400Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V400Spec.scala
@@ -1,7 +1,6 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.{ Loan, LoanApplicationRegister }
-import hmda.validation.dsl.{ Failure, Success }
 import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
@@ -9,7 +8,7 @@ import org.scalacheck.Gen
 class V400Spec extends LarEditCheckSpec with BadValueUtils {
   property("Property Type must = 1,2, or 3") {
     forAll(larGen) { lar =>
-      V400(lar) mustBe Success()
+      lar.mustPass
     }
   }
 
@@ -19,7 +18,7 @@ class V400Spec extends LarEditCheckSpec with BadValueUtils {
     forAll(larGen, badPropertyTypeGen) { (lar: LoanApplicationRegister, x: Int) =>
       val invalidLoan: Loan = lar.loan.copy(propertyType = x)
       val invalidLar: LoanApplicationRegister = lar.copy(loan = invalidLoan)
-      V400(invalidLar) mustBe a[Failure]
+      invalidLar.mustFail
     }
   }
 

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V410Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V410Spec.scala
@@ -1,7 +1,6 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
-import hmda.validation.dsl.{ Failure, Success }
 import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
@@ -13,7 +12,7 @@ class V410Spec extends LarEditCheckSpec {
   property("succeeds when lien status is not 3") {
     forAll(larGen) { lar =>
       whenever(lar.lienStatus != 3) {
-        V410(lar) mustBe a[Success]
+        lar.mustPass
       }
     }
   }
@@ -22,7 +21,7 @@ class V410Spec extends LarEditCheckSpec {
     forAll(larGen) { lar =>
       val loan = lar.loan.copy(purpose = 2)
       val validLar = lar.copy(lienStatus = 3, loan = loan)
-      V410(validLar) mustBe a[Success]
+      validLar.mustPass
     }
   }
 
@@ -31,7 +30,7 @@ class V410Spec extends LarEditCheckSpec {
       whenever(x != 2) {
         val loan = lar.loan.copy(purpose = x)
         val invalidLar = lar.copy(lienStatus = 3, loan = loan)
-        V410(invalidLar) mustBe a[Failure]
+        invalidLar.mustFail
       }
     }
   }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V450Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V450Spec.scala
@@ -1,7 +1,6 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
-import hmda.validation.dsl.{ Failure, Success }
 import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
@@ -9,7 +8,7 @@ import org.scalacheck.Gen
 class V450Spec extends LarEditCheckSpec with BadValueUtils {
   property("Applicant ethnicity must = 1,2,3, or 4") {
     forAll(larGen) { lar =>
-      V450(lar) mustBe Success()
+      lar.mustPass
     }
   }
 
@@ -19,7 +18,7 @@ class V450Spec extends LarEditCheckSpec with BadValueUtils {
     forAll(larGen, badEthnicityGen) { (lar, x) =>
       val invalidApplicant = lar.applicant.copy(ethnicity = x)
       val invalidLar = lar.copy(applicant = invalidApplicant)
-      V450(invalidLar) mustBe a[Failure]
+      invalidLar.mustFail
     }
   }
 

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V455Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V455Spec.scala
@@ -1,7 +1,6 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
-import hmda.validation.dsl.{ Failure, Success }
 import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
@@ -14,7 +13,7 @@ class V455Spec extends LarEditCheckSpec {
       whenever(ethn > 3) {
         val applicant = lar.applicant.copy(ethnicity = ethn)
         val newLar = lar.copy(applicant = applicant)
-        V455(newLar) mustBe a[Success]
+        newLar.mustPass
       }
     }
   }
@@ -23,7 +22,7 @@ class V455Spec extends LarEditCheckSpec {
       whenever(race != 7) {
         val applicant = lar.applicant.copy(race1 = race)
         val newLar = lar.copy(applicant = applicant)
-        V455(newLar) mustBe a[Success]
+        newLar.mustPass
       }
     }
   }
@@ -33,7 +32,7 @@ class V455Spec extends LarEditCheckSpec {
       whenever(List(1, 2, 3).contains(lar.applicant.ethnicity)) {
         val applicant = lar.applicant.copy(race1 = 7)
         val newLar = lar.copy(applicant = applicant)
-        V455(newLar) mustBe a[Failure]
+        newLar.mustFail
       }
     }
   }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V460Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V460Spec.scala
@@ -1,7 +1,6 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
-import hmda.validation.dsl.{ Failure, Success }
 import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
@@ -9,7 +8,7 @@ import org.scalacheck.Gen
 class V460Spec extends LarEditCheckSpec with BadValueUtils {
   property("CoApplicant ethnicity must = 1,2,3,4 or 5") {
     forAll(larGen) { lar =>
-      V460(lar) mustBe Success()
+      lar.mustPass
     }
   }
 
@@ -19,7 +18,7 @@ class V460Spec extends LarEditCheckSpec with BadValueUtils {
     forAll(larGen, badCoEthnicityGen) { (lar, x) =>
       val invalidApplicant = lar.applicant.copy(coEthnicity = x)
       val invalidLar = lar.copy(applicant = invalidApplicant)
-      V460(invalidLar) mustBe a[Failure]
+      invalidLar.mustFail
     }
   }
 

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V465Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V465Spec.scala
@@ -1,7 +1,6 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
-import hmda.validation.dsl.{ Failure, Success }
 import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
@@ -14,7 +13,7 @@ class V465Spec extends LarEditCheckSpec {
       whenever(coEthn > 3) {
         val applicant = lar.applicant.copy(coEthnicity = coEthn)
         val newLar = lar.copy(applicant = applicant)
-        V465(newLar) mustBe a[Success]
+        newLar.mustPass
       }
     }
   }
@@ -23,7 +22,7 @@ class V465Spec extends LarEditCheckSpec {
       whenever(cr1 != 7 && cr1 != 8) {
         val applicant = lar.applicant.copy(coRace1 = cr1)
         val newLar = lar.copy(applicant = applicant)
-        V465(newLar) mustBe a[Success]
+        newLar.mustPass
       }
     }
   }
@@ -33,7 +32,7 @@ class V465Spec extends LarEditCheckSpec {
       whenever(List(1, 2, 3).contains(lar.applicant.coEthnicity)) {
         val applicant = lar.applicant.copy(coRace1 = cr1)
         val newLar = lar.copy(applicant = applicant)
-        V465(newLar) mustBe a[Failure]
+        newLar.mustFail
       }
     }
   }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V470Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V470Spec.scala
@@ -1,7 +1,6 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
-import hmda.validation.dsl.{ Failure, Success }
 import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
@@ -14,7 +13,7 @@ class V470Spec extends LarEditCheckSpec {
       whenever(race > 5) {
         val applicant = lar.applicant.copy(race1 = race)
         val newLar = lar.copy(applicant = applicant)
-        V470(newLar) mustBe a[Success]
+        newLar.mustPass
       }
     }
   }
@@ -28,7 +27,7 @@ class V470Spec extends LarEditCheckSpec {
       (lar: LoanApplicationRegister, raceVals) =>
         val applicant = lar.applicant.copy(race2 = raceVals(0), race3 = raceVals(1), race4 = raceVals(2), race5 = raceVals(3))
         val newLar = lar.copy(applicant = applicant)
-        V470(newLar) mustBe a[Success]
+        newLar.mustPass
     }
   }
 
@@ -37,7 +36,7 @@ class V470Spec extends LarEditCheckSpec {
       whenever(race2 > 5) {
         val applicant = lar.applicant.copy(race1 = race1, race2 = race2.toString)
         val newLar = lar.copy(applicant = applicant)
-        V470(newLar) mustBe a[Failure]
+        newLar.mustFail
       }
     }
   }
@@ -47,7 +46,7 @@ class V470Spec extends LarEditCheckSpec {
       whenever(race3 > 5) {
         val applicant = lar.applicant.copy(race1 = race1, race3 = race3.toString)
         val newLar = lar.copy(applicant = applicant)
-        V470(newLar) mustBe a[Failure]
+        newLar.mustFail
       }
     }
   }
@@ -57,7 +56,7 @@ class V470Spec extends LarEditCheckSpec {
       whenever(race4 > 5) {
         val applicant = lar.applicant.copy(race1 = race1, race4 = race4.toString)
         val newLar = lar.copy(applicant = applicant)
-        V470(newLar) mustBe a[Failure]
+        newLar.mustFail
       }
     }
   }
@@ -67,7 +66,7 @@ class V470Spec extends LarEditCheckSpec {
       whenever(race5 > 5) {
         val applicant = lar.applicant.copy(race1 = race1, race5 = race5.toString)
         val newLar = lar.copy(applicant = applicant)
-        V470(newLar) mustBe a[Failure]
+        newLar.mustFail
       }
     }
   }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V485Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V485Spec.scala
@@ -1,7 +1,6 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.{ Applicant, LoanApplicationRegister }
-import hmda.validation.dsl.{ Failure, Success }
 import hmda.validation.rules.EditCheck
 import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
@@ -14,7 +13,7 @@ class V485Spec extends LarEditCheckSpec {
       whenever(coRace > 5) {
         val applicant = lar.applicant.copy(coRace1 = coRace)
         val newLar = lar.copy(applicant = applicant)
-        V485(newLar) mustBe a[Success]
+        newLar.mustPass
       }
     }
   }
@@ -27,7 +26,7 @@ class V485Spec extends LarEditCheckSpec {
     forAll(larGen, coRace1Gen, Gen.listOfN(4, otherCoRaceGen)) { (lar, cr1, crVals) =>
       val applicant = lar.applicant.copy(coRace1 = cr1, coRace2 = crVals.head, coRace3 = crVals(1), coRace4 = crVals(2), coRace5 = crVals(3))
       val newLar = lar.copy(applicant = applicant)
-      V485(newLar) mustBe a[Success]
+      newLar.mustPass
     }
   }
 
@@ -38,7 +37,7 @@ class V485Spec extends LarEditCheckSpec {
           val validApplicant = withValidCoRace2To5(lar.applicant)
           val invalidApplicant = validApplicant.copy(coRace1 = cr1, coRace2 = cr2.toString)
           val newLar = lar.copy(applicant = invalidApplicant)
-          V485(newLar) mustBe a[Failure]
+          newLar.mustFail
         }
     }
   }
@@ -49,7 +48,7 @@ class V485Spec extends LarEditCheckSpec {
         val validApplicant = withValidCoRace2To5(lar.applicant)
         val invalidApplicant = validApplicant.copy(coRace1 = cr1, coRace3 = cr3.toString)
         val newLar = lar.copy(applicant = invalidApplicant)
-        V485(newLar) mustBe a[Failure]
+        newLar.mustFail
       }
     }
   }
@@ -60,7 +59,7 @@ class V485Spec extends LarEditCheckSpec {
         val validApplicant = withValidCoRace2To5(lar.applicant)
         val invalidApplicant = validApplicant.copy(coRace1 = cr1, coRace4 = cr4.toString)
         val newLar = lar.copy(applicant = invalidApplicant)
-        V485(newLar) mustBe a[Failure]
+        newLar.mustFail
       }
     }
   }
@@ -71,7 +70,7 @@ class V485Spec extends LarEditCheckSpec {
         val validApplicant = withValidCoRace2To5(lar.applicant)
         val invalidApplicant = validApplicant.copy(coRace1 = cr1, coRace5 = cr5.toString)
         val newLar = lar.copy(applicant = invalidApplicant)
-        V485(newLar) mustBe a[Failure]
+        newLar.mustFail
       }
     }
   }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V490Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V490Spec.scala
@@ -1,9 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
-import hmda.validation.dsl.{ Failure, Success }
 import hmda.validation.rules.EditCheck
-import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
 
 class V490Spec extends RaceEditCheckSpec {
@@ -14,7 +12,7 @@ class V490Spec extends RaceEditCheckSpec {
       whenever(!(6 to 8).contains(cr1)) {
         val applicant = lar.applicant.copy(coRace1 = cr1)
         val newLar = lar.copy(applicant = applicant)
-        V490(newLar) mustBe a[Success]
+        newLar.mustPass
       }
     }
   }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V520Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V520Spec.scala
@@ -19,7 +19,7 @@ class V520Spec extends RateSpreadEditCheckSpec {
   property("succeeds in any case if lien status != 3") {
     forAll(larGen) { lar =>
       whenever(lar.lienStatus != 3) {
-        check(lar) mustBe Success()
+        lar.mustPass
       }
     }
   }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V570Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V570Spec.scala
@@ -1,7 +1,5 @@
 package hmda.validation.rules.lar.validity
 
-import hmda.validation.dsl.Success
-
 class V570Spec extends RateSpreadEditCheckSpec {
 
   override val check = V570
@@ -45,7 +43,7 @@ class V570Spec extends RateSpreadEditCheckSpec {
   property("succeeds in any case when lien status is not 1") {
     forAll(larGen) { lar =>
       whenever(lar.lienStatus != 1) {
-        check(lar) mustBe Success()
+        lar.mustPass
       }
     }
   }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V575Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V575Spec.scala
@@ -1,7 +1,5 @@
 package hmda.validation.rules.lar.validity
 
-import hmda.validation.dsl.Success
-
 class V575Spec extends RateSpreadEditCheckSpec {
 
   override val check = V575
@@ -51,7 +49,7 @@ class V575Spec extends RateSpreadEditCheckSpec {
   property("succeeds in any case when lien status is not 2") {
     forAll(larGen) { lar =>
       whenever(lar.lienStatus != 2) {
-        check(lar) mustBe Success()
+        lar.mustPass
       }
     }
   }

--- a/validation/src/test/scala/hmda/validation/rules/ts/TsEditCheckSpec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/ts/TsEditCheckSpec.scala
@@ -4,8 +4,8 @@ import hmda.model.fi.ts.TransmittalSheet
 import hmda.parser.fi.ts.TsGenerators
 import hmda.validation.dsl.{ Failure, Success }
 import hmda.validation.rules.EditCheck
-import org.scalatest.{ MustMatchers, PropSpec }
 import org.scalatest.prop.PropertyChecks
+import org.scalatest.{ MustMatchers, PropSpec }
 
 abstract class TsEditCheckSpec extends PropSpec with PropertyChecks with MustMatchers with TsGenerators {
   implicit val generatorDriverConfig =

--- a/validation/src/test/scala/hmda/validation/rules/ts/syntactical/S010Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/ts/syntactical/S010Spec.scala
@@ -1,18 +1,18 @@
 package hmda.validation.rules.ts.syntactical
 
-import hmda.parser.fi.ts.TsGenerators
-import hmda.validation.dsl.Success
-import org.scalatest.prop.PropertyChecks
-import org.scalatest.{ MustMatchers, PropSpec }
+import hmda.model.fi.ts.TransmittalSheet
+import hmda.validation.rules.EditCheck
+import hmda.validation.rules.ts.TsEditCheckSpec
 
-class S010Spec extends PropSpec with MustMatchers with PropertyChecks with TsGenerators {
+class S010Spec extends TsEditCheckSpec {
 
   property("Record identifier must be 1") {
     forAll(tsGen) { ts =>
       whenever(ts.id == 1) {
-        S010(ts) mustBe Success()
+        ts.mustPass
       }
     }
   }
 
+  override def check: EditCheck[TransmittalSheet] = S010
 }

--- a/validation/src/test/scala/hmda/validation/rules/ts/syntactical/S020Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/ts/syntactical/S020Spec.scala
@@ -1,18 +1,19 @@
 package hmda.validation.rules.ts.syntactical
 
-import hmda.parser.fi.ts.TsGenerators
-import hmda.validation.dsl.Success
-import org.scalatest.prop.PropertyChecks
-import org.scalatest.{ MustMatchers, PropSpec }
+import hmda.model.fi.ts.TransmittalSheet
+import hmda.validation.rules.EditCheck
+import hmda.validation.rules.ts.TsEditCheckSpec
 
-class S020Spec extends PropSpec with PropertyChecks with MustMatchers with TsGenerators {
+class S020Spec extends TsEditCheckSpec {
 
   property("Transmittal Sheet Agency Code must = 1,2,3,5,7,9") {
     forAll(tsGen) { ts =>
       whenever(ts.id == 1) {
-        S020(ts) mustBe Success()
+        ts.mustPass
       }
     }
   }
+
+  override def check: EditCheck[TransmittalSheet] = S020
 
 }

--- a/validation/src/test/scala/hmda/validation/rules/ts/syntactical/S028Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/ts/syntactical/S028Spec.scala
@@ -1,17 +1,18 @@
 package hmda.validation.rules.ts.syntactical
 
-import hmda.parser.fi.ts.TsGenerators
-import hmda.validation.dsl.Success
-import org.scalatest.prop.PropertyChecks
-import org.scalatest.{ MustMatchers, PropSpec }
+import hmda.model.fi.ts.TransmittalSheet
+import hmda.validation.rules.EditCheck
+import hmda.validation.rules.ts.TsEditCheckSpec
 
-class S028Spec extends PropSpec with PropertyChecks with MustMatchers with TsGenerators {
+class S028Spec extends TsEditCheckSpec {
 
   property("Transmittal Sheet timestamp must be numeric and in ccyymmddhhmm format") {
     forAll(tsGen) { ts =>
       whenever(ts.id == 1) {
-        S028(ts) mustBe Success()
+        ts.mustPass
       }
     }
   }
+
+  override def check: EditCheck[TransmittalSheet] = S028
 }


### PR DESCRIPTION
This applies the `.mustPass` and `.mustFail` formula in `LarEditCheckSpec` and `TsEditCheckSpec` to all specs and updates `MultipleLarEditCheckSpec` to contain said formula