### PR TITLE
Allow requests with an empty Host header

### DIFF
--- a/api/src/main/resources/application.conf
+++ b/api/src/main/resources/application.conf
@@ -3,6 +3,7 @@ akka {
   loglevel = "INFO"
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
   http.parsing.max-content-length = 1G
+  http.server.default-host-header = "cfpb.gov"
 }
 
 hmda {


### PR DESCRIPTION
See [reference documentation](http://doc.akka.io/docs/akka/2.4.6/scala/http/configuration.html) (`default-host-header` setting)