### PR TITLE
call DSL containedIn without wrapping domain values in a List

### DIFF
--- a/validation/src/main/scala/hmda/validation/dsl/PredicateCommon.scala
+++ b/validation/src/main/scala/hmda/validation/dsl/PredicateCommon.scala
@@ -41,6 +41,8 @@ object PredicateCommon {
     override def failure: String = s"not between $lower and $upper (inclusive)"
   }
 
+  implicit def containedIn[T](first: T, rest: T*): Predicate[T] = containedIn(first +: rest)
+
   implicit def containedIn[T](domain: Seq[T]): Predicate[T] = new Predicate[T] {
     override def validate: (T) => Boolean = domain.contains(_)
     override def failure: String = s"is not contained in valid values domain"

--- a/validation/src/main/scala/hmda/validation/dsl/PredicateCommon.scala
+++ b/validation/src/main/scala/hmda/validation/dsl/PredicateCommon.scala
@@ -41,7 +41,7 @@ object PredicateCommon {
     override def failure: String = s"not between $lower and $upper (inclusive)"
   }
 
-  implicit def containedIn[T](first: T, rest: T*): Predicate[T] = containedIn(first +: rest)
+  implicit def oneOf[T](domain: T*): Predicate[T] = containedIn(domain)
 
   implicit def containedIn[T](domain: Seq[T]): Predicate[T] = new Predicate[T] {
     override def validate: (T) => Boolean = domain.contains(_)

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q005.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q005.scala
@@ -14,8 +14,8 @@ object Q005 extends EditCheck[LoanApplicationRegister] {
     val config = ConfigFactory.load()
     val loanAmount = config.getInt("hmda.validation.quality.Q005.loan.amount")
 
-    when((lar.purchaserType is containedIn(List(1, 2, 3, 4))) and
-      (lar.loan.propertyType is containedIn(List(1, 2)))) {
+    when((lar.purchaserType is containedIn(1, 2, 3, 4)) and
+      (lar.loan.propertyType is containedIn(1, 2))) {
       lar.loan.amount is lessThanOrEqual(loanAmount)
     }
   }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q005.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q005.scala
@@ -14,8 +14,8 @@ object Q005 extends EditCheck[LoanApplicationRegister] {
     val config = ConfigFactory.load()
     val loanAmount = config.getInt("hmda.validation.quality.Q005.loan.amount")
 
-    when((lar.purchaserType is containedIn(1, 2, 3, 4)) and
-      (lar.loan.propertyType is containedIn(1, 2))) {
+    when((lar.purchaserType is oneOf(1, 2, 3, 4)) and
+      (lar.loan.propertyType is oneOf(1, 2))) {
       lar.loan.amount is lessThanOrEqual(loanAmount)
     }
   }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q059.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q059.scala
@@ -8,7 +8,7 @@ import hmda.validation.dsl.PredicateSyntax._
 
 object Q059 extends EditCheck[LoanApplicationRegister] {
   override def apply(lar: LoanApplicationRegister): Result = {
-    when(lar.loan.loanType is containedIn(2, 3, 4)) {
+    when(lar.loan.loanType is oneOf(2, 3, 4)) {
       lar.loan.propertyType not equalTo(3)
     }
   }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q059.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q059.scala
@@ -8,7 +8,7 @@ import hmda.validation.dsl.PredicateSyntax._
 
 object Q059 extends EditCheck[LoanApplicationRegister] {
   override def apply(lar: LoanApplicationRegister): Result = {
-    when(lar.loan.loanType is containedIn(List(2, 3, 4))) {
+    when(lar.loan.loanType is containedIn(2, 3, 4)) {
       lar.loan.propertyType not equalTo(3)
     }
   }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V260.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V260.scala
@@ -14,7 +14,7 @@ object V260 extends EditCheck[LoanApplicationRegister] {
     when((lar.denial.reason1 is containedIn(denialReasons))
       or (lar.denial.reason2 is containedIn(denialReasons))
       or (lar.denial.reason3 is containedIn(denialReasons))) {
-      lar.actionTakenType is containedIn(3, 7)
+      lar.actionTakenType is oneOf(3, 7)
     }
   }
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V260.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V260.scala
@@ -14,7 +14,7 @@ object V260 extends EditCheck[LoanApplicationRegister] {
     when((lar.denial.reason1 is containedIn(denialReasons))
       or (lar.denial.reason2 is containedIn(denialReasons))
       or (lar.denial.reason3 is containedIn(denialReasons))) {
-      (lar.actionTakenType is containedIn(List(3, 7)))
+      lar.actionTakenType is containedIn(3, 7)
     }
   }
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V347.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V347.scala
@@ -12,7 +12,7 @@ object V347 extends EditCheck[LoanApplicationRegister] {
 
   override def apply(lar: LoanApplicationRegister): Result = {
     when(lar.purchaserType is containedIn(1 to 9)) {
-      lar.actionTakenType is containedIn(1, 6)
+      lar.actionTakenType is oneOf(1, 6)
     }
   }
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V347.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V347.scala
@@ -12,7 +12,7 @@ object V347 extends EditCheck[LoanApplicationRegister] {
 
   override def apply(lar: LoanApplicationRegister): Result = {
     when(lar.purchaserType is containedIn(1 to 9)) {
-      lar.actionTakenType is containedIn(List(1, 6))
+      lar.actionTakenType is containedIn(1, 6)
     }
   }
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V430.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V430.scala
@@ -9,8 +9,8 @@ import hmda.validation.dsl.PredicateSyntax._
 object V430 extends EditCheck[LoanApplicationRegister] {
 
   override def apply(lar: LoanApplicationRegister): Result = {
-    when((lar.loan.purpose is containedIn(List(2, 3)))) {
-      (lar.preapprovals is equalTo(3))
+    when(lar.loan.purpose is containedIn(2, 3)) {
+      lar.preapprovals is equalTo(3)
     }
   }
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V430.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V430.scala
@@ -9,7 +9,7 @@ import hmda.validation.dsl.PredicateSyntax._
 object V430 extends EditCheck[LoanApplicationRegister] {
 
   override def apply(lar: LoanApplicationRegister): Result = {
-    when(lar.loan.purpose is containedIn(2, 3)) {
+    when(lar.loan.purpose is oneOf(2, 3)) {
       lar.preapprovals is equalTo(3)
     }
   }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V435.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V435.scala
@@ -9,8 +9,8 @@ import hmda.validation.dsl.PredicateSyntax._
 object V435 extends EditCheck[LoanApplicationRegister] {
 
   override def apply(lar: LoanApplicationRegister): Result = {
-    when(lar.actionTakenType is containedIn(List(7, 8))) {
-      (lar.preapprovals is equalTo(1))
+    when(lar.actionTakenType is containedIn(7, 8)) {
+      lar.preapprovals is equalTo(1)
     }
   }
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V435.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V435.scala
@@ -9,7 +9,7 @@ import hmda.validation.dsl.PredicateSyntax._
 object V435 extends EditCheck[LoanApplicationRegister] {
 
   override def apply(lar: LoanApplicationRegister): Result = {
-    when(lar.actionTakenType is containedIn(7, 8)) {
+    when(lar.actionTakenType is oneOf(7, 8)) {
       lar.preapprovals is equalTo(1)
     }
   }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V455.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V455.scala
@@ -9,7 +9,7 @@ import hmda.validation.dsl.PredicateSyntax._
 object V455 extends EditCheck[LoanApplicationRegister] {
 
   override def apply(lar: LoanApplicationRegister): Result = {
-    when(lar.applicant.ethnicity is containedIn(List(1, 2, 3))) {
+    when(lar.applicant.ethnicity is containedIn(1, 2, 3)) {
       lar.applicant.race1 not equalTo(7)
     }
   }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V455.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V455.scala
@@ -9,7 +9,7 @@ import hmda.validation.dsl.PredicateSyntax._
 object V455 extends EditCheck[LoanApplicationRegister] {
 
   override def apply(lar: LoanApplicationRegister): Result = {
-    when(lar.applicant.ethnicity is containedIn(1, 2, 3)) {
+    when(lar.applicant.ethnicity is oneOf(1, 2, 3)) {
       lar.applicant.race1 not equalTo(7)
     }
   }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V465.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V465.scala
@@ -9,8 +9,8 @@ import hmda.validation.dsl.PredicateSyntax._
 object V465 extends EditCheck[LoanApplicationRegister] {
 
   override def apply(lar: LoanApplicationRegister): Result = {
-    when(lar.applicant.coEthnicity is containedIn(List(1, 2, 3))) {
-      lar.applicant.coRace1 not containedIn(List(7, 8))
+    when(lar.applicant.coEthnicity is containedIn(1, 2, 3)) {
+      lar.applicant.coRace1 not containedIn(7, 8)
     }
   }
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V465.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V465.scala
@@ -9,8 +9,8 @@ import hmda.validation.dsl.PredicateSyntax._
 object V465 extends EditCheck[LoanApplicationRegister] {
 
   override def apply(lar: LoanApplicationRegister): Result = {
-    when(lar.applicant.coEthnicity is containedIn(1, 2, 3)) {
-      lar.applicant.coRace1 not containedIn(7, 8)
+    when(lar.applicant.coEthnicity is oneOf(1, 2, 3)) {
+      lar.applicant.coRace1 not oneOf(7, 8)
     }
   }
 


### PR DESCRIPTION
Basically, I got tired of seeing `List(1, 2, 3)` everywhere; it felt like clutter.  So I added this to the DSL.

Overall I think it's a good idea, but I'm open to discussion of whether it's always good to use.  In particular, please give `V347` a look and decide what you think.  Hard to judge one's own code sometimes!