### PR TITLE
minor cleanup: use states.keySet instead of .keys.toList

### DIFF
--- a/validation/src/main/scala/hmda/validation/rules/ts/validity/V111.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/validity/V111.scala
@@ -14,7 +14,7 @@ object V111 extends EditCheck[TransmittalSheet] {
 
   override def apply(ts: TransmittalSheet): Result = {
     when(ts.parent.state not empty) {
-      ts.parent.state is containedIn(states.keys.toList)
+      ts.parent.state is containedIn(states.keySet)
     }
   }
 

--- a/validation/src/main/scala/hmda/validation/rules/ts/validity/V140.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/validity/V140.scala
@@ -11,7 +11,7 @@ object V140 extends EditCheck[TransmittalSheet] {
 
   override def apply(ts: TransmittalSheet): Result = {
     val resp = ts.respondent
-    val stateCodes = states.keys.toList
+    val stateCodes = states.keySet
     resp.state is containedIn(stateCodes)
   }
 


### PR DESCRIPTION
This change is not motivated by performance concerns (though it may be slightly better on that front). it just seems a bit cleaner.