### PR TITLE
LarQualityEngine Test

### DIFF
--- a/validation/src/main/scala/hmda/validation/engine/lar/quality/LarQualityEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/lar/quality/LarQualityEngine.scala
@@ -7,43 +7,44 @@ import hmda.validation.rules.lar.quality._
 
 trait LarQualityEngine extends LarCommonEngine with ValidationApi {
 
+  val qualityEditsList = List(
+    Q001,
+    Q002,
+    Q003,
+    Q004,
+    Q005,
+    Q013,
+    Q014,
+    Q024,
+    Q025,
+    Q027,
+    Q029,
+    Q032,
+    Q035,
+    Q036,
+    Q037,
+    Q038,
+    Q039,
+    Q040,
+    Q044,
+    Q045,
+    Q046,
+    Q049,
+    Q051,
+    Q052,
+    Q059,
+    Q064,
+    Q066,
+    Q067,
+    Q068
+  )
+
   private def q022(lar: LoanApplicationRegister): LarValidation = {
     convertResult(lar, Q022(lar, 2017), "Q022")
   }
 
   def checkQuality(lar: LoanApplicationRegister): LarValidation = {
-    val checks = List(
-      Q001,
-      Q002,
-      Q003,
-      Q004,
-      Q005,
-      Q013,
-      Q014,
-      Q024,
-      Q025,
-      Q027,
-      Q029,
-      Q032,
-      Q035,
-      Q036,
-      Q037,
-      Q038,
-      Q039,
-      Q040,
-      Q044,
-      Q045,
-      Q046,
-      Q049,
-      Q051,
-      Q052,
-      Q049,
-      Q059,
-      Q064,
-      Q066,
-      Q067,
-      Q068
-    ).map(check(_, lar))
+    val checks = qualityEditsList.map(check(_, lar))
 
     checks :+ q022(lar)
 

--- a/validation/src/test/scala/hmda/validation/engine/lar/quality/LarQualityEngineSpec.scala
+++ b/validation/src/test/scala/hmda/validation/engine/lar/quality/LarQualityEngineSpec.scala
@@ -27,7 +27,7 @@ class LarQualityEngineSpec
   }
 
   property("There should be no duplicates in qualityEditsList") {
-    qualityEditsList.toSet.toList.length mustBe qualityEditsList.length
+    qualityEditsList.distinct.length mustBe qualityEditsList.length
   }
 
   property("There should be edits equal to the number of edit files - 1 (for Q022)") {

--- a/validation/src/test/scala/hmda/validation/engine/lar/quality/LarQualityEngineSpec.scala
+++ b/validation/src/test/scala/hmda/validation/engine/lar/quality/LarQualityEngineSpec.scala
@@ -25,4 +25,17 @@ class LarQualityEngineSpec
       }
     }
   }
+
+  property("There should be no duplicates in qualityEditsList") {
+    qualityEditsList.toSet.toList.length mustBe qualityEditsList.length
+  }
+
+  property("There should be edits equal to the number of edit files - 1 (for Q022)") {
+    val pathOrig = getClass.getResource("").getPath
+    val pathSplit = pathOrig.split("/").dropRight(8).mkString("/")
+    val pathFinal = pathSplit + "/src/main/scala/hmda/validation/rules/lar/quality"
+    val editFiles = Option((new File(pathFinal).list).length).getOrElse(0)
+    editFiles - 1 mustBe qualityEditsList.length
+  }
+
 }


### PR DESCRIPTION
This is another idea for how we might test the various rule engines.

This test is meant solely to test whether all of the edits, and no extras, are being run by QualityEngine.

Instead of checking for edits failing it checks that the list of edits in the engine appears to be correct. It first checks that there are no duplicates in the list. It then checks that the list is the correct size. To check what the size of the list should be the edit counts the number of files in `validation/src/main/scala/hmda/validation/rules/lar/quality` and subtracts 1 because Q022 isn't in the list due to its slightly different behavior.

This pr also removes a duplicate Q049 in the list of edits.