### PR TITLE
Fix FileNotFoundException in LAR API

### DIFF
--- a/model/src/main/scala/hmda/model/ResourceUtils.scala
+++ b/model/src/main/scala/hmda/model/ResourceUtils.scala
@@ -1,0 +1,16 @@
+package hmda.model
+
+import scala.io.{ BufferedSource, Source }
+
+trait ResourceUtils {
+  // For opening and reading files in this project's /resources directory.
+
+  def resource(filename: String): BufferedSource = {
+    val file = getClass.getResourceAsStream(filename)
+    Source.fromInputStream(file)
+  }
+
+  def resourceLines(filename: String): Iterator[String] = {
+    resource(filename).getLines()
+  }
+}

--- a/model/src/main/scala/hmda/model/census/CBSAMetroMicroLookup.scala
+++ b/model/src/main/scala/hmda/model/census/CBSAMetroMicroLookup.scala
@@ -1,13 +1,10 @@
 package hmda.model.census
 
-import java.io.File
+import hmda.model.ResourceUtils
 
-import scala.io.Source
-
-object CBSAMetroMicroLookup {
+object CBSAMetroMicroLookup extends ResourceUtils {
   val values: Seq[CBSAMetroMicro] = {
-    val cbsaResource = getClass.getResourceAsStream("/tl_2013_us_cbsa.csv")
-    val lines = Source.fromInputStream(cbsaResource).getLines()
+    val lines = resourceLines("/tl_2013_us_cbsa.csv")
 
     lines.map { line =>
       val values = line.split('|').map(_.trim)

--- a/model/src/main/scala/hmda/model/census/CBSAMetroMicroLookup.scala
+++ b/model/src/main/scala/hmda/model/census/CBSAMetroMicroLookup.scala
@@ -6,7 +6,9 @@ import scala.io.Source
 
 object CBSAMetroMicroLookup {
   val values: Seq[CBSAMetroMicro] = {
-    val lines = Source.fromFile(new File("model/src/main/resources/tl_2013_us_cbsa.csv")).getLines
+    val cbsaResource = getClass.getResourceAsStream("/tl_2013_us_cbsa.csv")
+    val lines = Source.fromInputStream(cbsaResource).getLines()
+
     lines.map { line =>
       val values = line.split('|').map(_.trim)
       val combinedCode = values(0)

--- a/model/src/main/scala/hmda/model/census/CBSATractLookup.scala
+++ b/model/src/main/scala/hmda/model/census/CBSATractLookup.scala
@@ -6,7 +6,9 @@ import scala.io.Source
 
 object CBSATractLookup {
   val values: Seq[CBSATract] = {
-    val lines = Source.fromFile(new File("model/src/main/resources/tract_to_cbsa_2013.csv")).getLines
+    val cbsaResource = getClass.getResourceAsStream("/tract_to_cbsa_2013.csv")
+    val lines = Source.fromInputStream(cbsaResource).getLines()
+
     lines.map { line =>
       val values = line.split('|').map(_.trim)
       val name = values(0)

--- a/model/src/main/scala/hmda/model/census/CBSATractLookup.scala
+++ b/model/src/main/scala/hmda/model/census/CBSATractLookup.scala
@@ -1,13 +1,10 @@
 package hmda.model.census
 
-import java.io.File
+import hmda.model.ResourceUtils
 
-import scala.io.Source
-
-object CBSATractLookup {
+object CBSATractLookup extends ResourceUtils {
   val values: Seq[CBSATract] = {
-    val cbsaResource = getClass.getResourceAsStream("/tract_to_cbsa_2013.csv")
-    val lines = Source.fromInputStream(cbsaResource).getLines()
+    val lines = resourceLines("/tract_to_cbsa_2013.csv")
 
     lines.map { line =>
       val values = line.split('|').map(_.trim)


### PR DESCRIPTION
Fixes #426 (I believe)

I tested this manually by running the project locally (`sbt`, then `reStart`), then using Postman to hit the validation endpoint (`localhost:8080/lar/validate`). The endpoint now returns the result of the validations, instead of throwing a `FileNotFoundException` and failing to return.

Should I test the fix in more places before we consider it done?