### PR TITLE
use Paths.get for file paths; exit after processing file

### DIFF
--- a/platform-test/src/main/scala/util/Dat2Csv.scala
+++ b/platform-test/src/main/scala/util/Dat2Csv.scala
@@ -17,14 +17,14 @@ Takes a .DAT file and converts to pipe delimited CSV (2017)
  */
 object Dat2Csv {
 
-  implicit val system: ActorSystem = ActorSystem()
-  implicit val materializer: ActorMaterializer = ActorMaterializer()
-  implicit val ec: ExecutionContext = system.dispatcher
-
   def main(args: Array[String]): Unit = {
     if (args.length != 2) {
       throw new Exception("Please provide input .DAT and output .txt files")
     } else {
+      implicit val system: ActorSystem = ActorSystem()
+      implicit val materializer: ActorMaterializer = ActorMaterializer()
+      implicit val ec: ExecutionContext = system.dispatcher
+
       val datFilePath = args(0)
       val txtFilePath = args(1)
 

--- a/platform-test/src/main/scala/util/Dat2Csv.scala
+++ b/platform-test/src/main/scala/util/Dat2Csv.scala
@@ -1,10 +1,10 @@
 package util
 
-import java.io.File
+import java.nio.file.Paths
 
 import akka.NotUsed
 import akka.actor.ActorSystem
-import akka.stream.{ ActorMaterializer, IOResult }
+import akka.stream.ActorMaterializer
 import akka.stream.scaladsl._
 import akka.util.ByteString
 import hmda.parser.fi.lar.LarDatParser
@@ -28,11 +28,8 @@ object Dat2Csv {
       val datFilePath = args(0)
       val txtFilePath = args(1)
 
-      val datFile = new File(datFilePath)
-      val txtFile = new File(txtFilePath)
-
-      val source = FileIO.fromPath(datFile.toPath)
-      val sink = FileIO.toPath(txtFile.toPath)
+      val source = FileIO.fromPath(Paths.get(datFilePath))
+      val sink = FileIO.toPath(Paths.get(txtFilePath))
 
       val framing = Framing.delimiter(ByteString("\n"), 2048, allowTruncation = true)
 

--- a/platform-test/src/main/scala/util/Dat2Csv.scala
+++ b/platform-test/src/main/scala/util/Dat2Csv.scala
@@ -51,6 +51,9 @@ object Dat2Csv {
         .map(s => ByteString(s"$s\n"))
         .runWith(sink)
 
+      convert.andThen {
+        case _ => system.terminate()
+      }
     }
   }
 


### PR DESCRIPTION
The `Paths.get` commit does additional cleanup and closes #434 

The other commit allows the program to exit once its work is done, which makes it a bit easier to use.

I used `sbt "project platformTest" "runMain util.Dat2Csv parser/src/test/resources/dat/ThirdTestBankData_clean_19039_2017.dat whatever.csv"` to run it; there may be other ways.  If you know those ways, feel free to let them inform your review.

I combined these commits into one PR because it seemed faster (and not harmful), but am happy to split them up if needed.