### PR TITLE
remove Predicate boilerplate

### DIFF
--- a/validation/src/main/scala/hmda/validation/dsl/Predicate.scala
+++ b/validation/src/main/scala/hmda/validation/dsl/Predicate.scala
@@ -4,3 +4,9 @@ trait Predicate[T] {
   def validate: T => Boolean
 }
 
+object Predicate {
+  import scala.language.implicitConversions
+  implicit def func2predicate[T](f: T => Boolean): Predicate[T] = new Predicate[T] {
+    override def validate = f
+  }
+}

--- a/validation/src/main/scala/hmda/validation/dsl/PredicateCommon.scala
+++ b/validation/src/main/scala/hmda/validation/dsl/PredicateCommon.scala
@@ -6,33 +6,33 @@ import scala.util.Try
 object PredicateCommon {
   implicit def equalTo[T](that: T): Predicate[T] = (_: T) == that
 
-  implicit def greaterThan[T](that: T)(implicit ord: Ordering[T]): Predicate[T] = ord.gt(_: T, that)
+  def greaterThan[T](that: T)(implicit ord: Ordering[T]): Predicate[T] = ord.gt(_: T, that)
 
-  implicit def greaterThanOrEqual[T](that: T)(implicit ord: Ordering[T]): Predicate[T] = ord.gteq(_: T, that)
+  def greaterThanOrEqual[T](that: T)(implicit ord: Ordering[T]): Predicate[T] = ord.gteq(_: T, that)
 
-  implicit def lessThan[T](that: T)(implicit ord: Ordering[T]): Predicate[T] = ord.lt(_: T, that)
+  def lessThan[T](that: T)(implicit ord: Ordering[T]): Predicate[T] = ord.lt(_: T, that)
 
-  implicit def lessThanOrEqual[T](that: T)(implicit ord: Ordering[T]): Predicate[T] = ord.lteq(_: T, that)
+  def lessThanOrEqual[T](that: T)(implicit ord: Ordering[T]): Predicate[T] = ord.lteq(_: T, that)
 
-  implicit def between[T](lower: T, upper: T)(implicit ord: Ordering[T]): Predicate[T] = { x: T =>
+  def between[T](lower: T, upper: T)(implicit ord: Ordering[T]): Predicate[T] = { x: T =>
     ord.lteq(lower, x) && ord.lteq(x, upper)
   }
 
-  implicit def numericallyBetween(lower: String, upper: String): Predicate[String] = { x: String =>
+  def numericallyBetween(lower: String, upper: String): Predicate[String] = { x: String =>
     Try(between(BigDecimal(lower), BigDecimal(upper)).validate(BigDecimal(x))).getOrElse(false)
   }
 
-  implicit def numericallyLessThan(upper: String): Predicate[String] = { x: String =>
+  def numericallyLessThan(upper: String): Predicate[String] = { x: String =>
     Try(lessThan(BigDecimal(upper)).validate(BigDecimal(x))).getOrElse(false)
   }
 
-  implicit def numericallyLessThanOrEqual(upper: String): Predicate[String] = { x: String =>
+  def numericallyLessThanOrEqual(upper: String): Predicate[String] = { x: String =>
     Try(lessThanOrEqual(BigDecimal(upper)).validate(BigDecimal(x))).getOrElse(false)
   }
 
-  implicit def oneOf[T](domain: T*): Predicate[T] = containedIn(domain)
+  def oneOf[T](domain: T*): Predicate[T] = containedIn(domain)
 
-  implicit def containedIn[T](domain: Seq[T]): Predicate[T] = domain.contains(_: T)
+  def containedIn[T](domain: Seq[T]): Predicate[T] = domain.contains(_: T)
 
   def containedIn[T](domain: Set[T]): Predicate[T] = domain.contains(_: T)
 
@@ -42,7 +42,7 @@ object PredicateCommon {
     case _ => throw new NotImplementedError("'numeric' doesn't handle non-number/string values yet")
   }
 
-  implicit def empty[T]: Predicate[T] = (_: T) match {
+  def empty[T]: Predicate[T] = (_: T) match {
     case s: String => s.isEmpty
     case _ => throw new NotImplementedError("'empty' doesn't handle non-string values yet")
   }

--- a/validation/src/main/scala/hmda/validation/dsl/PredicateCommon.scala
+++ b/validation/src/main/scala/hmda/validation/dsl/PredicateCommon.scala
@@ -47,7 +47,7 @@ object PredicateCommon {
     case _ => throw new NotImplementedError("'empty' doesn't handle non-string values yet")
   }
 
-  implicit def when(condition: Result)(thenTest: => Result): Result = {
+  def when(condition: Result)(thenTest: => Result): Result = {
     condition.implies(thenTest)
   }
 

--- a/validation/src/main/scala/hmda/validation/dsl/PredicateCommon.scala
+++ b/validation/src/main/scala/hmda/validation/dsl/PredicateCommon.scala
@@ -50,8 +50,4 @@ object PredicateCommon {
   def when(condition: Result)(thenTest: => Result): Result = {
     condition.implies(thenTest)
   }
-
-  implicit def func2predicate[T](f: T => Boolean): Predicate[T] = new Predicate[T] {
-    override def validate = f
-  }
 }

--- a/validation/src/main/scala/hmda/validation/dsl/PredicateCommon.scala
+++ b/validation/src/main/scala/hmda/validation/dsl/PredicateCommon.scala
@@ -4,74 +4,54 @@ import scala.language.implicitConversions
 import scala.util.Try
 
 object PredicateCommon {
-  implicit def equalTo[T](that: T): Predicate[T] = new Predicate[T] {
-    override def validate: (T) => Boolean = _ == that
+  implicit def equalTo[T](that: T): Predicate[T] = (_: T) == that
+
+  implicit def greaterThan[T](that: T)(implicit ord: Ordering[T]): Predicate[T] = ord.gt(_: T, that)
+
+  implicit def greaterThanOrEqual[T](that: T)(implicit ord: Ordering[T]): Predicate[T] = ord.gteq(_: T, that)
+
+  implicit def lessThan[T](that: T)(implicit ord: Ordering[T]): Predicate[T] = ord.lt(_: T, that)
+
+  implicit def lessThanOrEqual[T](that: T)(implicit ord: Ordering[T]): Predicate[T] = ord.lteq(_: T, that)
+
+  implicit def between[T](lower: T, upper: T)(implicit ord: Ordering[T]): Predicate[T] = { x: T =>
+    ord.lteq(lower, x) && ord.lteq(x, upper)
   }
 
-  implicit def greaterThan[T](that: T)(implicit ord: Ordering[T]): Predicate[T] = new Predicate[T] {
-    override def validate: (T) => Boolean = ord.gt(_, that)
+  implicit def numericallyBetween(lower: String, upper: String): Predicate[String] = { x: String =>
+    Try(between(BigDecimal(lower), BigDecimal(upper)).validate(BigDecimal(x))).getOrElse(false)
   }
 
-  implicit def greaterThanOrEqual[T](that: T)(implicit ord: Ordering[T]): Predicate[T] = new Predicate[T] {
-    override def validate: (T) => Boolean = ord.gteq(_, that)
+  implicit def numericallyLessThan(upper: String): Predicate[String] = { x: String =>
+    Try(lessThan(BigDecimal(upper)).validate(BigDecimal(x))).getOrElse(false)
   }
 
-  implicit def lessThan[T](that: T)(implicit ord: Ordering[T]): Predicate[T] = new Predicate[T] {
-    override def validate: (T) => Boolean = ord.lt(_, that)
-  }
-
-  implicit def lessThanOrEqual[T](that: T)(implicit ord: Ordering[T]): Predicate[T] = new Predicate[T] {
-    override def validate: (T) => Boolean = ord.lteq(_, that)
-  }
-
-  implicit def between[T](lower: T, upper: T)(implicit ord: Ordering[T]): Predicate[T] = new Predicate[T] {
-    override def validate: (T) => Boolean = { x => ord.lteq(lower, x) && ord.lteq(x, upper) }
-  }
-
-  implicit def numericallyBetween(lower: String, upper: String): Predicate[String] = new Predicate[String] {
-    override def validate: (String) => Boolean = { x =>
-      Try(between(BigDecimal(lower), BigDecimal(upper)).validate(BigDecimal(x))).getOrElse(false)
-    }
-  }
-
-  implicit def numericallyLessThan(upper: String): Predicate[String] = new Predicate[String] {
-    override def validate: (String) => Boolean = { x =>
-      Try(lessThan(BigDecimal(upper)).validate(BigDecimal(x))).getOrElse(false)
-    }
-  }
-
-  implicit def numericallyLessThanOrEqual(upper: String): Predicate[String] = new Predicate[String] {
-    override def validate: (String) => Boolean = { x =>
-      Try(lessThanOrEqual(BigDecimal(upper)).validate(BigDecimal(x))).getOrElse(false)
-    }
+  implicit def numericallyLessThanOrEqual(upper: String): Predicate[String] = { x: String =>
+    Try(lessThanOrEqual(BigDecimal(upper)).validate(BigDecimal(x))).getOrElse(false)
   }
 
   implicit def oneOf[T](domain: T*): Predicate[T] = containedIn(domain)
 
-  implicit def containedIn[T](domain: Seq[T]): Predicate[T] = new Predicate[T] {
-    override def validate: (T) => Boolean = domain.contains(_)
+  implicit def containedIn[T](domain: Seq[T]): Predicate[T] = domain.contains(_: T)
+
+  def containedIn[T](domain: Set[T]): Predicate[T] = domain.contains(_: T)
+
+  def numeric[T]: Predicate[T] = (_: T) match {
+    case n: Number => true
+    case s: String => Try(s.toDouble).isSuccess
+    case _ => throw new NotImplementedError("'numeric' doesn't handle non-number/string values yet")
   }
 
-  def containedIn[T](domain: Set[T]): Predicate[T] = new Predicate[T] {
-    override def validate: (T) => Boolean = domain.contains
-  }
-
-  def numeric[T]: Predicate[T] = new Predicate[T] {
-    override def validate: (T) => Boolean = _.asInstanceOf[AnyRef] match {
-      case n: Number => true
-      case s: String => Try(s.toDouble).isSuccess
-      case _ => throw new NotImplementedError("'numeric' doesn't handle non-number/string values yet")
-    }
-  }
-
-  implicit def empty[T]: Predicate[T] = new Predicate[T] {
-    override def validate: (T) => Boolean = _.asInstanceOf[AnyRef] match {
-      case s: String => s.isEmpty
-      case _ => throw new NotImplementedError("'empty' doesn't handle non-string values yet")
-    }
+  implicit def empty[T]: Predicate[T] = (_: T) match {
+    case s: String => s.isEmpty
+    case _ => throw new NotImplementedError("'empty' doesn't handle non-string values yet")
   }
 
   implicit def when(condition: Result)(thenTest: => Result): Result = {
     condition.implies(thenTest)
+  }
+
+  implicit def func2predicate[T](f: T => Boolean): Predicate[T] = new Predicate[T] {
+    override def validate = f
   }
 }

--- a/validation/src/main/scala/hmda/validation/dsl/PredicateGeo.scala
+++ b/validation/src/main/scala/hmda/validation/dsl/PredicateGeo.scala
@@ -47,36 +47,30 @@ object PredicateGeo {
     .map { cbsa => (cbsa.state, cbsa.county) }
     .toSet
 
-  implicit def smallCounty: Predicate[Geography] = new Predicate[Geography] {
-    override def validate: (Geography) => Boolean = (geo) =>
-      smallCounties.contains((geo.state, geo.county))
+  implicit def smallCounty: Predicate[Geography] = { (geo: Geography) =>
+    smallCounties.contains((geo.state, geo.county))
   }
 
-  implicit def validStateCountyCombination: Predicate[Geography] = new Predicate[Geography] {
-    override def validate: (Geography) => Boolean = (geo) =>
-      validStateCountyCombinationSet.contains((geo.state, geo.county))
+  implicit def validStateCountyCombination: Predicate[Geography] = { (geo: Geography) =>
+    validStateCountyCombinationSet.contains((geo.state, geo.county))
   }
 
-  implicit def validStateCountyTractCombination: Predicate[Geography] = new Predicate[Geography] {
-    override def validate: (Geography) => Boolean = (geo) =>
-      validStateCountyTractCombinationSet.contains((geo.state, geo.county, geo.tract))
+  implicit def validStateCountyTractCombination: Predicate[Geography] = { (geo: Geography) =>
+    validStateCountyTractCombinationSet.contains((geo.state, geo.county, geo.tract))
   }
 
-  implicit def validCompleteCombination: Predicate[Geography] = new Predicate[Geography] {
-    override def validate: (Geography) => Boolean = (geo) =>
-      validMsaCombinationSet.contains((geo.msa, geo.state, geo.county, geo.tract)) ||
-        validMdCombinationSet.contains((geo.msa, geo.state, geo.county, geo.tract))
+  implicit def validCompleteCombination: Predicate[Geography] = { (geo: Geography) =>
+    validMsaCombinationSet.contains((geo.msa, geo.state, geo.county, geo.tract)) ||
+      validMdCombinationSet.contains((geo.msa, geo.state, geo.county, geo.tract))
   }
 
-  implicit def validStateCountyMsaCombination: Predicate[Geography] = new Predicate[Geography] {
-    override def validate: (Geography) => Boolean = (geo) =>
-      validMsaCombinationSetNoTract.contains((geo.msa, geo.state, geo.county)) ||
-        validMdCombinationSetNoTract.contains((geo.msa, geo.state, geo.county))
+  implicit def validStateCountyMsaCombination: Predicate[Geography] = { (geo: Geography) =>
+    validMsaCombinationSetNoTract.contains((geo.msa, geo.state, geo.county)) ||
+      validMdCombinationSetNoTract.contains((geo.msa, geo.state, geo.county))
   }
 
-  implicit def stateCountyCombinationInMsaNotMicro: Predicate[Geography] = new Predicate[Geography] {
-    override def validate: (Geography) => Boolean = (geo) =>
-      hasMsaNotMicroSet.contains((geo.state, geo.county))
+  implicit def stateCountyCombinationInMsaNotMicro: Predicate[Geography] = { (geo: Geography) =>
+    hasMsaNotMicroSet.contains((geo.state, geo.county))
   }
 
 }

--- a/validation/src/main/scala/hmda/validation/dsl/PredicateGeo.scala
+++ b/validation/src/main/scala/hmda/validation/dsl/PredicateGeo.scala
@@ -47,29 +47,29 @@ object PredicateGeo {
     .map { cbsa => (cbsa.state, cbsa.county) }
     .toSet
 
-  implicit def smallCounty: Predicate[Geography] = { (geo: Geography) =>
+  def smallCounty: Predicate[Geography] = { (geo: Geography) =>
     smallCounties.contains((geo.state, geo.county))
   }
 
-  implicit def validStateCountyCombination: Predicate[Geography] = { (geo: Geography) =>
+  def validStateCountyCombination: Predicate[Geography] = { (geo: Geography) =>
     validStateCountyCombinationSet.contains((geo.state, geo.county))
   }
 
-  implicit def validStateCountyTractCombination: Predicate[Geography] = { (geo: Geography) =>
+  def validStateCountyTractCombination: Predicate[Geography] = { (geo: Geography) =>
     validStateCountyTractCombinationSet.contains((geo.state, geo.county, geo.tract))
   }
 
-  implicit def validCompleteCombination: Predicate[Geography] = { (geo: Geography) =>
+  def validCompleteCombination: Predicate[Geography] = { (geo: Geography) =>
     validMsaCombinationSet.contains((geo.msa, geo.state, geo.county, geo.tract)) ||
       validMdCombinationSet.contains((geo.msa, geo.state, geo.county, geo.tract))
   }
 
-  implicit def validStateCountyMsaCombination: Predicate[Geography] = { (geo: Geography) =>
+  def validStateCountyMsaCombination: Predicate[Geography] = { (geo: Geography) =>
     validMsaCombinationSetNoTract.contains((geo.msa, geo.state, geo.county)) ||
       validMdCombinationSetNoTract.contains((geo.msa, geo.state, geo.county))
   }
 
-  implicit def stateCountyCombinationInMsaNotMicro: Predicate[Geography] = { (geo: Geography) =>
+  def stateCountyCombinationInMsaNotMicro: Predicate[Geography] = { (geo: Geography) =>
     hasMsaNotMicroSet.contains((geo.state, geo.county))
   }
 

--- a/validation/src/main/scala/hmda/validation/dsl/PredicateHmda.scala
+++ b/validation/src/main/scala/hmda/validation/dsl/PredicateHmda.scala
@@ -4,13 +4,13 @@ import java.text.SimpleDateFormat
 import scala.language.implicitConversions
 
 object PredicateHmda {
-  implicit def validTimestampFormat[T]: Predicate[T] = (_: T) match {
+  def validTimestampFormat[T]: Predicate[T] = (_: T) match {
     case s: String =>
       checkDateFormat(s)
     case _ => false
   }
 
-  implicit def checkDateFormat[T](s: String): Boolean = {
+  private def checkDateFormat[T](s: String): Boolean = {
     try {
       val format = new SimpleDateFormat("yyyyMMddHHmm")
       format.setLenient(false)

--- a/validation/src/main/scala/hmda/validation/dsl/PredicateHmda.scala
+++ b/validation/src/main/scala/hmda/validation/dsl/PredicateHmda.scala
@@ -4,12 +4,10 @@ import java.text.SimpleDateFormat
 import scala.language.implicitConversions
 
 object PredicateHmda {
-  implicit def validTimestampFormat[T]: Predicate[T] = new Predicate[T] {
-    override def validate: (T) => Boolean = _.asInstanceOf[AnyRef] match {
-      case s: String =>
-        checkDateFormat(s)
-      case _ => false
-    }
+  implicit def validTimestampFormat[T]: Predicate[T] = (_: T) match {
+    case s: String =>
+      checkDateFormat(s)
+    case _ => false
   }
 
   implicit def checkDateFormat[T](s: String): Boolean = {

--- a/validation/src/main/scala/hmda/validation/dsl/PredicateRegEx.scala
+++ b/validation/src/main/scala/hmda/validation/dsl/PredicateRegEx.scala
@@ -4,16 +4,16 @@ import scala.language.implicitConversions
 import scala.util.matching.Regex
 
 object PredicateRegEx {
-  implicit def validCensusTractFormat: Predicate[String] = stringMatching("^\\d{4}\\.\\d{2}$".r)
+  def validCensusTractFormat: Predicate[String] = stringMatching("^\\d{4}\\.\\d{2}$".r)
 
-  implicit def validEmail: Predicate[String] =
+  def validEmail: Predicate[String] =
     stringMatching("^[_A-Za-z0-9-\\+]+(\\.[_A-Za-z0-9-]+)*@[A-Za-z0-9-]+(\\.[A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$".r)
 
-  implicit def validPhoneNumber: Predicate[String] = stringMatching("^\\d{3}-\\d{3}-\\d{4}$".r)
+  def validPhoneNumber: Predicate[String] = stringMatching("^\\d{3}-\\d{3}-\\d{4}$".r)
 
-  implicit def validZipCode: Predicate[String] = stringMatching("^\\d{5}(?:-\\d{4})?$".r)
+  def validZipCode: Predicate[String] = stringMatching("^\\d{5}(?:-\\d{4})?$".r)
 
-  implicit def validTaxId: Predicate[String] = stringMatching("^\\d{2}-\\d{7}$".r)
+  def validTaxId: Predicate[String] = stringMatching("^\\d{2}-\\d{7}$".r)
 
   def numericMatching(pattern: String): Predicate[String] = stringMatching(regExFor(pattern))
 

--- a/validation/src/main/scala/hmda/validation/dsl/PredicateRegEx.scala
+++ b/validation/src/main/scala/hmda/validation/dsl/PredicateRegEx.scala
@@ -25,12 +25,10 @@ object PredicateRegEx {
     result.mkString("^", "", "$").r
   }
 
-  private def stringMatching(regEx: Regex): Predicate[String] = new Predicate[String] {
-    override def validate: (String) => Boolean = {
-      regEx.findFirstIn(_) match {
-        case Some(_) => true
-        case None => false
-      }
+  private def stringMatching(regEx: Regex): Predicate[String] = {
+    regEx.findFirstIn(_: String) match {
+      case Some(_) => true
+      case None => false
     }
   }
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V338.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V338.scala
@@ -12,7 +12,7 @@ object V338 extends EditCheck[LoanApplicationRegister] with ApplicantUtils {
 
   override def apply(lar: LoanApplicationRegister): Result = {
     when(notANaturalPerson(lar)) {
-      lar.applicant.income is equalTo("NA")
+      lar.applicant.income is "NA"
     }
   }
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V520.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V520.scala
@@ -11,8 +11,8 @@ object V520 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "V520"
 
   override def apply(lar: LoanApplicationRegister): Result = {
-    when(lar.lienStatus is equalTo(3)) {
-      lar.rateSpread is equalTo("NA")
+    when(lar.lienStatus is 3) {
+      lar.rateSpread is "NA"
     }
   }
 }


### PR DESCRIPTION
addresses #408 

There are two changes here; both of them involve implicits.

The first is that we can implicitly create a `Predicate` from a Function, now that `Predicate` has just the one method. (This is the "bit more cleanup" mentioned in PR #409.)

The second is removing `implicit` from most of the defs in `PredicateCommon`, because they weren't being called implicitly, and generally couldn't be: if you import all of `PredicateCommon` (as it is before this change), then you have several implicit methods in scope, all with the same type signature.  So you can't implicitly treat a String (or generic T) as a `Predicate`, because the compiler wouldn't know which of these methods to choose.

Now only `equalTo` is implicit, which means we can use it in an implicit conversion when/if desired.  I changed it in two places where I think it reads nicely, to illustrate.

If the team likes these changes, we could do similar things in other `Predicate*` objects.