### PR TITLE
Allow Akka Persistence to write to "target" directory under Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,14 @@ FROM java:8
 
 MAINTAINER Juan Marin Otero <juan.marin.otero@gmail.com>
 
-WORKDIR /
+WORKDIR /opt
+
+RUN mkdir -p target && chmod -R a+w target
 
 USER daemon
 
-ENTRYPOINT ["java", "-jar", "/opt/hmda.jar"]
+ENTRYPOINT ["java", "-jar", "hmda.jar"]
 
 EXPOSE 8080
 
-COPY target/scala-2.11/hmda.jar /opt/hmda.jar
+COPY target/scala-2.11/hmda.jar . 


### PR DESCRIPTION
@schbetsy and I noticed the following errors a couple days ago when trying to work through the initial Docker setup, and I'm also getting it while to hook everything up in [hmda-platform-auth](https://github.com/cfpb/hmda-platform-auth). 

```
api_1      | [2016-07-13 17:51:35,082][ERROR][hmda-akka.actor.default-dispatcher-4] Failed to create snapshot directory [/target/snapshots]
api_1      | akka.actor.ActorInitializationException: akka://hmda/system/akka.persistence.snapshot-store.local: exception during creation
api_1      | 	at akka.actor.ActorInitializationException$.apply(Actor.scala:174) ~[hmda.jar:1.0.0]
api_1      | 	at akka.actor.ActorCell.create(ActorCell.scala:607) ~[hmda.jar:1.0.0]
api_1      | 	at akka.actor.ActorCell.invokeAll$1(ActorCell.scala:461) ~[hmda.jar:1.0.0]
api_1      | 	at akka.actor.ActorCell.systemInvoke(ActorCell.scala:483) ~[hmda.jar:1.0.0]
api_1      | 	at akka.dispatch.Mailbox.processAllSystemMessages(Mailbox.scala:282) ~[hmda.jar:1.0.0]
api_1      | 	at akka.dispatch.Mailbox.run(Mailbox.scala:223) ~[hmda.jar:1.0.0]
api_1      | 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) ~[na:1.8.0_72-internal]
api_1      | 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) ~[na:1.8.0_72-internal]
api_1      | 	at java.lang.Thread.run(Thread.java:745) ~[na:1.8.0_72-internal]
api_1      | Caused by: java.io.IOException: Failed to create snapshot directory [/target/snapshots]
api_1      | 	at akka.persistence.snapshot.local.LocalSnapshotStore.snapshotDir(LocalSnapshotStore.scala:143) ~[hmda.jar:1.0.0]
api_1      | 	at akka.persistence.snapshot.local.LocalSnapshotStore.preStart(LocalSnapshotStore.scala:135) ~[hmda.jar:1.0.0]
api_1      | 	at akka.actor.Actor$class.aroundPreStart(Actor.scala:489) ~[hmda.jar:1.0.0]
api_1      | 	at akka.persistence.snapshot.local.LocalSnapshotStore.aroundPreStart(LocalSnapshotStore.scala:27) ~[hmda.jar:1.0.0]
api_1      | 	at akka.actor.ActorCell.create(ActorCell.scala:590) ~[hmda.jar:1.0.0]
api_1      | 	... 7 common frames omitted
```

...and...

```
api_1      | akka.actor.ActorInitializationException: akka://hmda/system/akka.persistence.journal.leveldb: exception during creation
api_1      | 	at akka.actor.ActorInitializationException$.apply(Actor.scala:174) ~[hmda.jar:1.0.0]
api_1      | 	at akka.actor.ActorCell.create(ActorCell.scala:607) ~[hmda.jar:1.0.0]
api_1      | 	at akka.actor.ActorCell.invokeAll$1(ActorCell.scala:461) ~[hmda.jar:1.0.0]
api_1      | 	at akka.actor.ActorCell.systemInvoke(ActorCell.scala:483) ~[hmda.jar:1.0.0]
api_1      | 	at akka.dispatch.Mailbox.processAllSystemMessages(Mailbox.scala:282) ~[hmda.jar:1.0.0]
api_1      | 	at akka.dispatch.Mailbox.run(Mailbox.scala:223) ~[hmda.jar:1.0.0]
api_1      | 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) ~[na:1.8.0_72-internal]
api_1      | 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) ~[na:1.8.0_72-internal]
api_1      | 	at java.lang.Thread.run(Thread.java:745) ~[na:1.8.0_72-internal]
api_1      | Caused by: java.lang.IllegalArgumentException: Database directory 'target/journal' does not exist and could not be created
api_1      | 	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:148) ~[hmda.jar:1.0.0]
api_1      | 	at org.iq80.leveldb.impl.DbImpl.<init>(DbImpl.java:161) ~[hmda.jar:1.0.0]
api_1      | 	at org.iq80.leveldb.impl.Iq80DBFactory.open(Iq80DBFactory.java:59) ~[hmda.jar:1.0.0]
api_1      | 	at akka.persistence.journal.leveldb.LeveldbStore$class.preStart(LeveldbStore.scala:170) ~[hmda.jar:1.0.0]
api_1      | 	at akka.persistence.journal.leveldb.LeveldbJournal.preStart(LeveldbJournal.scala:22) ~[hmda.jar:1.0.0]
api_1      | 	at akka.actor.Actor$class.aroundPreStart(Actor.scala:489) ~[hmda.jar:1.0.0]
api_1      | 	at akka.persistence.journal.leveldb.LeveldbJournal.aroundPreStart(LeveldbJournal.scala:22) ~[hmda.jar:1.0.0]
api_1      | 	at akka.actor.ActorCell.create(ActorCell.scala:590) ~[hmda.jar:1.0.0]
api_1      | 	... 7 common frames omitted
```

This is all because the `WORKDIR` is set to the filesystem root `/`, and the `daemon` user does not have permissions to write to `/target`.  I've moved the working directory to `/opt`, and created a `/opt/target` directory with appropriate permissions to get around this.