### PR TITLE
shorter version of TS validation

### DIFF
--- a/parser/src/main/scala/hmda/parser/fi/ts/TsCsvParser.scala
+++ b/parser/src/main/scala/hmda/parser/fi/ts/TsCsvParser.scala
@@ -39,25 +39,17 @@ object TsCsvParser {
     val parent = Parent(parentName, parentAddress, parentCity, parentState, parentZip)
     val contact = Contact(contactPerson, contactPhone, contactFax, contactEmail)
 
-    val maybeTS = (
+    val maybeTS: ValidationNel[String, TransmittalSheet] = (
       id
       |@| code
       |@| timestamp
       |@| activityYear
+      |@| taxId.success
       |@| totalLines
-    ) {
-        TransmittalSheet(
-          _,
-          _,
-          _,
-          _,
-          taxId,
-          _,
-          respondent,
-          parent,
-          contact
-        )
-      }
+      |@| respondent.success
+      |@| parent.success
+      |@| contact.success
+    ) { TransmittalSheet }
 
     maybeTS.disjunction.toEither.bimap(_.toList, identity(_))
   }

--- a/parser/src/main/scala/hmda/parser/fi/ts/TsCsvParser.scala
+++ b/parser/src/main/scala/hmda/parser/fi/ts/TsCsvParser.scala
@@ -51,7 +51,7 @@ object TsCsvParser {
       |@| contact.success
     ) { TransmittalSheet }
 
-    maybeTS.disjunction.toEither.bimap(_.toList, identity(_))
+    maybeTS.leftMap(_.toList).toEither
   }
 
   def toIntOrFail(value: String, fieldName: String): ValidationNel[String, Int] = {

--- a/parser/src/main/scala/hmda/parser/fi/ts/TsCsvParser.scala
+++ b/parser/src/main/scala/hmda/parser/fi/ts/TsCsvParser.scala
@@ -1,7 +1,7 @@
 package hmda.parser.fi.ts
 
 import hmda.model.fi.ts.{ Contact, Parent, Respondent, TransmittalSheet }
-import scala.collection.immutable.ListMap
+
 import scalaz._
 import scalaz.Scalaz._
 import scala.util.{ Failure, Success, Try }
@@ -9,87 +9,70 @@ import scala.util.{ Failure, Success, Try }
 object TsCsvParser {
   def apply(s: String): Either[List[String], TransmittalSheet] = {
     val values = s.split('|').map(_.trim).toList
-    val parsedInts = checkTs(values)
-    parsedInts match {
-      case scalaz.Success(parsedValues) => {
+    if (values.length != 21) {
+      return Left(List("Incorrect number of fields. found: " + values.length + ", expected: 21"))
+    }
 
-        val id = parsedValues(0).asInstanceOf[Int]
-        val respId = values(1)
-        val code = parsedValues(1).asInstanceOf[Int]
-        val timestamp = parsedValues(4).asInstanceOf[Long]
-        val activityYear = parsedValues(2).asInstanceOf[Int]
-        val taxId = values(5)
-        val totalLines = parsedValues(3).asInstanceOf[Int]
-        val respName = values(7)
-        val respAddress = values(8)
-        val respCity = values(9)
-        val respState = values(10)
-        val respZip = values(11)
-        val parentName = values(12)
-        val parentAddress = values(13)
-        val parentCity = values(14)
-        val parentState = values(15)
-        val parentZip = values(16)
-        val contactPerson = values(17)
-        val contactPhone = values(18)
-        val contactFax = values(19)
-        val contactEmail = values(20)
+    val id = toIntOrFail(values(0), "Record Identifier")
+    val respId = values(1)
+    val code = toIntOrFail(values(2), "Agency Code")
+    val timestamp = toLongOrFail(values(3), "Timestamp")
+    val activityYear = toIntOrFail(values(4), "Activity Year")
+    val taxId = values(5)
+    val totalLines = toIntOrFail(values(6), "Total Lines")
+    val respName = values(7)
+    val respAddress = values(8)
+    val respCity = values(9)
+    val respState = values(10)
+    val respZip = values(11)
+    val parentName = values(12)
+    val parentAddress = values(13)
+    val parentCity = values(14)
+    val parentState = values(15)
+    val parentZip = values(16)
+    val contactPerson = values(17)
+    val contactPhone = values(18)
+    val contactFax = values(19)
+    val contactEmail = values(20)
 
-        val respondent = Respondent(respId, respName, respAddress, respCity, respState, respZip)
-        val parent = Parent(parentName, parentAddress, parentCity, parentState, parentZip)
-        val contact = Contact(contactPerson, contactPhone, contactFax, contactEmail)
-        Right(
-          TransmittalSheet(
-            id,
-            code,
-            timestamp,
-            activityYear,
-            taxId,
-            totalLines,
-            respondent,
-            parent,
-            contact
-          )
+    val respondent = Respondent(respId, respName, respAddress, respCity, respState, respZip)
+    val parent = Parent(parentName, parentAddress, parentCity, parentState, parentZip)
+    val contact = Contact(contactPerson, contactPhone, contactFax, contactEmail)
+
+    val maybeTS = (
+      id
+      |@| code
+      |@| timestamp
+      |@| activityYear
+      |@| totalLines
+    ) {
+        TransmittalSheet(
+          _,
+          _,
+          _,
+          _,
+          taxId,
+          _,
+          respondent,
+          parent,
+          contact
         )
       }
-      case scalaz.Failure(errors) => {
-        Left(
-          errors.list.toList
-        )
-      }
-    }
+
+    maybeTS.disjunction.toEither.bimap(_.toList, identity(_))
   }
 
-  def checkTs(fields: List[String]): ValidationNel[String, List[AnyVal]] = {
-
-    if (fields.length != 21) {
-      ("Incorrect number of fields. found: " + fields.length + ", expected: 21").failure.toValidationNel
-    } else {
-      val numericFields = ListMap(
-        "Record Identifier" -> fields(0),
-        "Agency Code" -> fields(2),
-        "Activity Year" -> fields(4),
-        "Total Lines Entries" -> fields(6)
-      )
-
-      val validationListInt = numericFields.map { case (key, value) => toIntOrFail(value, key) }
-      val validationListLong = toLongOrFail(fields(3), "Timestamp")
-      val validationListIntReduce = validationListInt.reduce(_ +++ _)
-      validationListIntReduce +++ validationListLong
-    }
-  }
-
-  def toIntOrFail(value: String, fieldName: String): ValidationNel[String, List[Int]] = {
+  def toIntOrFail(value: String, fieldName: String): ValidationNel[String, Int] = {
     Try(value.toInt) match {
       case Failure(result) => s"$fieldName is not an Integer".failure.toValidationNel
-      case Success(result) => List(result).success
+      case Success(result) => result.success
     }
   }
 
-  def toLongOrFail(value: String, fieldName: String): ValidationNel[String, List[Long]] = {
+  def toLongOrFail(value: String, fieldName: String): ValidationNel[String, Long] = {
     Try(value.toLong) match {
       case Failure(result) => s"$fieldName is not a Long".failure.toValidationNel
-      case Success(result) => List(result).success
+      case Success(result) => result.success
     }
   }
 

--- a/parser/src/main/scala/hmda/parser/fi/ts/TsCsvParser.scala
+++ b/parser/src/main/scala/hmda/parser/fi/ts/TsCsvParser.scala
@@ -55,15 +55,16 @@ object TsCsvParser {
   }
 
   def toIntOrFail(value: String, fieldName: String): ValidationNel[String, Int] = {
-    Try(value.toInt) match {
-      case Failure(result) => s"$fieldName is not an Integer".failure.toValidationNel
-      case Success(result) => result.success
-    }
+    convert(value.toInt, s"$fieldName is not an Integer")
   }
 
   def toLongOrFail(value: String, fieldName: String): ValidationNel[String, Long] = {
-    Try(value.toLong) match {
-      case Failure(result) => s"$fieldName is not a Long".failure.toValidationNel
+    convert(value.toLong, s"$fieldName is not a Long")
+  }
+
+  private def convert[T](x: => T, message: String): ValidationNel[String, T] = {
+    Try(x) match {
+      case Failure(result) => message.failure.toValidationNel
       case Success(result) => result.success
     }
   }


### PR DESCRIPTION
This PR came from discussion when reviewing #450.  The goal is to illustrate ways to use scalaz validation, both for education as we all learn about scalaz, and potentially for use in the code if preferred.

The first two commits show two different, but similar, ways of constructing the `TransmittalSheet`.  (@kgudel, I showed you a version of this code last week, before leaving for travel; if you've already considered it, no need to re-read.)

The third is a simple refactoring of the two methods for converting strings to numbers, and is conceptually independent.  Happy to re-make it separately if needed.