### PR TITLE
Stripped down standard error response

### DIFF
--- a/api/src/main/scala/hmda/api/http/InstitutionsHttpApi.scala
+++ b/api/src/main/scala/hmda/api/http/InstitutionsHttpApi.scala
@@ -135,7 +135,7 @@ trait InstitutionsHttpApi extends InstitutionProtocol with ApiErrorProtocol {
                   complete(ToResponseMarshallable(StatusCodes.InternalServerError -> errorResponse))
               }
             } else {
-              val errorResponse = ErrorResponse(404, s"No $period filing found for institution $institutionId", path)
+              val errorResponse = ErrorResponse(404, s"$period filing not found for institution $institutionId", path)
               complete(ToResponseMarshallable(StatusCodes.NotFound -> errorResponse))
             }
           case Failure(error) =>
@@ -170,13 +170,13 @@ trait InstitutionsHttpApi extends InstitutionProtocol with ApiErrorProtocol {
             case Failure(error) =>
               processingActor ! Shutdown
               log.error(error.getLocalizedMessage)
-              val errorResponse = ErrorResponse(422, "Invalid File Format", path)
+              val errorResponse = ErrorResponse(400, "Invalid File Format", path)
               complete(ToResponseMarshallable(StatusCodes.BadRequest -> errorResponse))
           }
 
         case _ =>
           processingActor ! Shutdown
-          val errorResponse = ErrorResponse(422, "Invalid File Format", path)
+          val errorResponse = ErrorResponse(400, "Invalid File Format", path)
           complete(ToResponseMarshallable(StatusCodes.BadRequest -> errorResponse))
       }
 

--- a/api/src/main/scala/hmda/api/http/InstitutionsHttpApi.scala
+++ b/api/src/main/scala/hmda/api/http/InstitutionsHttpApi.scala
@@ -1,6 +1,7 @@
 package hmda.api.http
 
 import java.time.Instant
+
 import akka.actor.{ ActorRef, ActorSelection, ActorSystem }
 import akka.event.LoggingAdapter
 import akka.stream.ActorMaterializer
@@ -15,16 +16,17 @@ import hmda.api.model._
 import hmda.persistence.institutions.FilingPersistence.GetFilingByPeriod
 import hmda.persistence.institutions.InstitutionPersistence.GetInstitutionById
 import hmda.persistence.institutions.SubmissionPersistence.{ CreateSubmission, GetLatestSubmission }
-import hmda.api.protocol.processing.InstitutionProtocol
+import hmda.api.protocol.processing.{ ApiErrorProtocol, InstitutionProtocol }
 import hmda.model.fi.{ Filing, Institution, Submission }
 import hmda.persistence.CommonMessages._
 import hmda.persistence.institutions.{ FilingPersistence, SubmissionPersistence }
 import hmda.persistence.processing.HmdaFileUpload._
+
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.{ Failure, Success }
 import spray.json._
 
-trait InstitutionsHttpApi extends InstitutionProtocol {
+trait InstitutionsHttpApi extends InstitutionProtocol with ApiErrorProtocol {
 
   implicit val system: ActorSystem
   implicit val materializer: ActorMaterializer

--- a/api/src/main/scala/hmda/api/model/ErrorResponse.scala
+++ b/api/src/main/scala/hmda/api/model/ErrorResponse.scala
@@ -3,5 +3,5 @@ package hmda.api.model
 case class ErrorResponse(
   httpStatus: Int,
   message: String,
-  parth: String
+  path: String
 )

--- a/api/src/main/scala/hmda/api/model/ErrorResponse.scala
+++ b/api/src/main/scala/hmda/api/model/ErrorResponse.scala
@@ -1,0 +1,7 @@
+package hmda.api.model
+
+case class ErrorResponse(
+  httpStatus: Int,
+  message: String,
+  parth: String
+)

--- a/api/src/main/scala/hmda/api/protocol/processing/ApiErrorProtocol.scala
+++ b/api/src/main/scala/hmda/api/protocol/processing/ApiErrorProtocol.scala
@@ -1,0 +1,10 @@
+package hmda.api.protocol.processing
+
+import hmda.api.model.ErrorResponse
+import spray.json.DefaultJsonProtocol
+
+trait ApiErrorProtocol extends DefaultJsonProtocol {
+
+  implicit val apiErrorFormat = jsonFormat3(ErrorResponse.apply)
+
+}

--- a/api/src/test/scala/hmda/api/http/InstitutionsHttpApiSpec.scala
+++ b/api/src/test/scala/hmda/api/http/InstitutionsHttpApiSpec.scala
@@ -53,6 +53,7 @@ class InstitutionsHttpApiSpec extends WordSpec with MustMatchers with ScalatestR
       }
       Get("/institutions/xxxx") ~> institutionsRoutes ~> check {
         status mustBe StatusCodes.NotFound
+        responseAs[ErrorResponse] mustBe ErrorResponse(404, "Institution xxxx not found", "institutions/xxxx")
       }
     }
 
@@ -73,9 +74,11 @@ class InstitutionsHttpApiSpec extends WordSpec with MustMatchers with ScalatestR
       }
       Get("/institutions/12345/filings/xxxx") ~> institutionsRoutes ~> check {
         status mustBe StatusCodes.NotFound
+        responseAs[ErrorResponse] mustBe ErrorResponse(404, "xxxx filing not found for institution 12345", "institutions/12345/filings/xxxx")
       }
       Get("/institutions/xxxxx/filings/2017") ~> institutionsRoutes ~> check {
         status mustBe StatusCodes.NotFound
+        responseAs[ErrorResponse] mustBe ErrorResponse(404, "2017 filing not found for institution xxxxx", "institutions/xxxxx/filings/2017")
       }
     }
 
@@ -89,12 +92,14 @@ class InstitutionsHttpApiSpec extends WordSpec with MustMatchers with ScalatestR
     "fail creating a new submission for a non existent institution" in {
       Post("/institutions/xxxxx/filings/2017/submissions") ~> institutionsRoutes ~> check {
         status mustBe StatusCodes.NotFound
+        responseAs[ErrorResponse] mustBe ErrorResponse(404, "2017 filing not found for institution xxxxx", "institutions/xxxxx/filings/2017/submissions")
       }
     }
 
     "fail creating a new submission for a non existent filing period" in {
       Post("/institutions/12345/filings/2001/submissions") ~> institutionsRoutes ~> check {
         status mustBe StatusCodes.NotFound
+        responseAs[ErrorResponse] mustBe ErrorResponse(404, "2001 filing not found for institution 12345", "institutions/12345/filings/2001/submissions")
       }
     }
 
@@ -117,6 +122,7 @@ class InstitutionsHttpApiSpec extends WordSpec with MustMatchers with ScalatestR
       val file = multiPartFile(badContent, "sample.dat")
       Post("/institutions/12345/filings/2017/submissions/1", file) ~> institutionsRoutes ~> check {
         status mustBe StatusCodes.BadRequest
+        responseAs[ErrorResponse] mustBe ErrorResponse(400, "Invalid File Format", "institutions/12345/filings/2017/submissions/1")
       }
     }
 


### PR DESCRIPTION
Create an error response object and protocol to convert it into json and use that in place of only return status codes.

Closes #433 