### PR TITLE
Log invalid messages received by persistence actors

### DIFF
--- a/persistence/src/main/scala/hmda/persistence/institutions/FilingPersistence.scala
+++ b/persistence/src/main/scala/hmda/persistence/institutions/FilingPersistence.scala
@@ -65,6 +65,8 @@ class FilingPersistence(institutionId: String) extends PersistentActor with Acto
           log.debug(s"Persisted: $f")
           updateState(e)
         }
+      } else {
+        log.warning(s"Filing already exists. Could not create $f")
       }
 
     case UpdateFilingStatus(modified) =>

--- a/persistence/src/main/scala/hmda/persistence/institutions/FilingPersistence.scala
+++ b/persistence/src/main/scala/hmda/persistence/institutions/FilingPersistence.scala
@@ -75,6 +75,8 @@ class FilingPersistence(institutionId: String) extends PersistentActor with Acto
           log.debug(s"persisted: $modified")
           updateState(e)
         }
+      } else {
+        log.warning(s"Period does not exist. Could not update $modified")
       }
 
     case GetFilingByPeriod(period) =>

--- a/persistence/src/main/scala/hmda/persistence/institutions/InstitutionPersistence.scala
+++ b/persistence/src/main/scala/hmda/persistence/institutions/InstitutionPersistence.scala
@@ -62,6 +62,8 @@ class InstitutionPersistence extends PersistentActor with ActorLogging {
           log.debug(s"Persisted: $i")
           updateState(e)
         }
+      } else {
+        log.warning(s"Institution already exists. Could not create $i")
       }
 
     case ModifyInstitution(i) =>
@@ -70,6 +72,8 @@ class InstitutionPersistence extends PersistentActor with ActorLogging {
           log.debug(s"Modified: ${i.name}")
           updateState(e)
         }
+      } else {
+        log.warning(s"Institution does not exist. Could not update $i")
       }
 
     case GetInstitutionById(institutionId) =>

--- a/persistence/src/main/scala/hmda/persistence/institutions/SubmissionPersistence.scala
+++ b/persistence/src/main/scala/hmda/persistence/institutions/SubmissionPersistence.scala
@@ -67,6 +67,8 @@ class SubmissionPersistence(fid: String, filingId: String) extends PersistentAct
         persist(SubmissionStatusUpdated(id, status)) { e =>
           updateState(e)
         }
+      } else {
+        log.warning(s"Submission does not exist. Could not update submission with id $id")
       }
 
     case GetSubmissionById(id) =>

--- a/persistence/src/test/resources/application.conf
+++ b/persistence/src/test/resources/application.conf
@@ -6,3 +6,4 @@ akka {
 akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
 akka.persistence.snapshot-store.plugin = "akka.persistence.snapshot-store.local"
 akka.persistence.snapshot-store.local.dir = "target/snapshots"
+akka.loggers = [akka.testkit.TestEventListener]

--- a/persistence/src/test/scala/hmda/persistence/institutions/FilingPersistenceSpec.scala
+++ b/persistence/src/test/scala/hmda/persistence/institutions/FilingPersistenceSpec.scala
@@ -2,10 +2,10 @@ package hmda.persistence.institutions
 
 import akka.testkit.{ EventFilter, TestProbe }
 import hmda.actor.test.ActorSpec
-import hmda.model.fi.{ Cancelled, Completed, Filing }
+import hmda.model.fi._
 import hmda.persistence.CommonMessages.GetState
 import hmda.persistence.demo.DemoData
-import hmda.persistence.institutions.FilingPersistence.{ CreateFiling, GetFilingByPeriod, UpdateFilingStatus, _ }
+import hmda.persistence.institutions.FilingPersistence._
 
 class FilingPersistenceSpec extends ActorSpec {
 
@@ -46,5 +46,14 @@ class FilingPersistenceSpec extends ActorSpec {
         probe.send(filingsActor, CreateFiling(f2))
       }
     }
+
+    "warn when updating status for a nonexistent period" in {
+      val f = Filing("2006", "12345", Cancelled)
+      val msg = s"Period does not exist. Could not update $f"
+      EventFilter.warning(message = msg, occurrences = 1) intercept {
+        probe.send(filingsActor, UpdateFilingStatus(f))
+      }
+    }
   }
+
 }

--- a/persistence/src/test/scala/hmda/persistence/institutions/InstitutionPersistenceSpec.scala
+++ b/persistence/src/test/scala/hmda/persistence/institutions/InstitutionPersistenceSpec.scala
@@ -1,7 +1,8 @@
 package hmda.persistence.institutions
 
-import akka.testkit.TestProbe
+import akka.testkit.{ EventFilter, TestProbe }
 import hmda.actor.test.ActorSpec
+import hmda.model.fi.{ Active, Institution }
 import hmda.persistence.CommonMessages.GetState
 import hmda.persistence.demo.DemoData
 import hmda.persistence.institutions.InstitutionPersistence.{ CreateInstitution, GetInstitutionById, ModifyInstitution, _ }
@@ -28,6 +29,30 @@ class InstitutionPersistenceSpec extends ActorSpec {
       probe.send(institutionsActor, ModifyInstitution(modified))
       probe.send(institutionsActor, GetInstitutionById(modified.id))
       probe.expectMsg(modified)
+    }
+  }
+
+  "Error logging" must {
+
+    "warn when creating an institution that already exists" in {
+      // Setup: Persist an institution
+      val i1 = Institution("12345", "First Bank", Active)
+      probe.send(institutionsActor, CreateInstitution(i1))
+
+      // Attempt to add identical institution; test that warning is logged
+      val i2 = Institution("12345", "First Bank", Active)
+      val msg = s"Institution already exists. Could not create $i2"
+      EventFilter.warning(message = msg, occurrences = 1) intercept {
+        probe.send(institutionsActor, CreateInstitution(i2))
+      }
+    }
+
+    "warn when updating nonexistent institution" in {
+      val i = Institution("BogusId", "Nonsense Bank", Active)
+      val msg = s"Institution does not exist. Could not update $i"
+      EventFilter.warning(message = msg, occurrences = 1) intercept {
+        probe.send(institutionsActor, ModifyInstitution(i))
+      }
     }
   }
 

--- a/persistence/src/test/scala/hmda/persistence/institutions/SubmissionPersistenceSpec.scala
+++ b/persistence/src/test/scala/hmda/persistence/institutions/SubmissionPersistenceSpec.scala
@@ -1,8 +1,8 @@
 package hmda.persistence.institutions
 
-import akka.testkit.TestProbe
+import akka.testkit.{ EventFilter, TestProbe }
 import hmda.actor.test.ActorSpec
-import hmda.model.fi.{ Submission, Uploaded }
+import hmda.model.fi._
 import hmda.persistence.CommonMessages.GetState
 import hmda.persistence.demo.DemoData
 import hmda.persistence.institutions.SubmissionPersistence.{ CreateSubmission, GetSubmissionById, UpdateSubmissionStatus, _ }
@@ -29,6 +29,16 @@ class SubmissionPersistenceSpec extends ActorSpec {
       probe.send(submissionsActor, UpdateSubmissionStatus(1, newStatus))
       probe.send(submissionsActor, GetSubmissionById(1))
       probe.expectMsg(Submission(1, Uploaded))
+    }
+  }
+
+  "Error logging" must {
+    "warn when updating nonexistent submission" in {
+      val id = 777
+      val msg = s"Submission does not exist. Could not update submission with id $id"
+      EventFilter.warning(message = msg, occurrences = 1) intercept {
+        probe.send(submissionsActor, UpdateSubmissionStatus(id, Created))
+      }
     }
   }
 

--- a/validation/src/test/scala/hmda/validation/engine/ts/validity/TsValidityEngineSpec.scala
+++ b/validation/src/test/scala/hmda/validation/engine/ts/validity/TsValidityEngineSpec.scala
@@ -14,7 +14,7 @@ class TsValidityEngineSpec extends PropSpec with PropertyChecks with MustMatcher
 
   property("Transmittal Sheet must be valid") {
     forAll(tsGen) { ts =>
-      whenever(respondentNotEmpty(ts.respondent)) {
+      whenever(respondentNotEmpty(ts.respondent) && (ts.contact.name != ts.respondent.name)) {
         checkValidity(ts).isSuccess mustBe true
       }
     }


### PR DESCRIPTION
Closes #436 

Also fixes rare test failure in `TsValidityEngineSpec`