### PR TITLE
Friendly docker dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,14 @@ To find your docker machine endpoint:
 docker-machine ip dev
 ```
 
+Also, for convenience when doing development on the UI, the `docker-compose` file uses a `volumes` which mount the local directory into the `hmda-platform-ui` container. This means you can make UI changes and refresh the browser to view them.
+
+``` shell
+# while still in the hmda-platform directory
+cd ../hmda-platform-ui
+npm run watch
+```
+
 ## Contributing
 
 CFPB is developing the HMDA Platform in the open to maximize transparency and encourage third party contributions. If you want to contribute, please read and abide by the terms of the [License](LICENSE) for this project.

--- a/README.md
+++ b/README.md
@@ -8,14 +8,7 @@ Information contained in this repository should be considered provisional and a 
 
 ## Introduction
 
-The Home Mortgage Disclosure Act (HMDA) requires many financial institutions to maintain, report, and publicly disclose information about mortgages. HMDA was originally enacted by Congress in 1975 and is implemented by [Regulation C](https://www.gpo.gov/fdsys/pkg/CFR-2012-title12-vol8/xml/CFR-2012-title12-vol8-part1003.xml). The Dodd-Frank Act transferred HMDA rulemaking authority from the Federal Reserve Board to the Consumer Financial Protection Bureau (CFPB) on July 21, 2011.
-
-This regulation provides the public loan data that can be used to assist:
-* in determining whether financial institutions are serving the housing needs of their communities;
-* public officials in distributing public-sector investments so as to attract private investment to areas where it is needed;
-* and in identifying possible discriminatory lending patterns.
-
-This regulation applies to certain financial institutions, including banks, savings associations, credit unions, and other mortgage lending institutions.
+For more information on HMDA, checkout the [About HMDA page](http://www.consumerfinance.gov/data-research/hmda/learn-more) on the CFPB website.
 
 ## The HMDA Platform
 
@@ -169,4 +162,3 @@ We use GitHub issues in this repository to track features, bugs, and enhancement
 1. [TERMS](TERMS.md)
 2. [LICENSE](LICENSE)
 3. [CFPB Source Code Policy](https://github.com/cfpb/source-code-policy/)
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,5 @@ services:
       - "80:80"
     depends_on:
       - api
+    volumes:
+      - ../hmda-platform-ui/dist:/usr/src/app/dist


### PR DESCRIPTION
- adds the local volume for the UI
- updates to README with instructions to use docker and `npm run watch` and to point to /hmda for more information about HMDA

### For testing 

In the browser, the expected result is to see the "Home" link with the FFIEC logo just below. Also, if you open up dev tools, you should see the API request and the correct response returned (even though its not rendered).