### PR TITLE
Source maps for the UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,20 +140,29 @@ docker-compose up -d --build
 
 This will bring up all the HMDA Platform services. The first run may take several minutes.
 
+To build the front-end and allow "watching" for changes. For convenience when doing development on the UI, the `docker-compose` file uses a `volumes` which mount the local directory into the `hmda-platform-ui` container. This means you can make UI changes and refresh the browser to view them.
+
+``` shell
+# while still in the hmda-platform directory
+cd ../hmda-platform-ui
+npm run watch
+```
+
+If you don't need to "watch" for changes you can run:
+
+``` shell
+# while still in the hmda-platform directory
+cd ../hmda-platform-ui
+npm run build
+```
+
+This will simply build the front-end, still taking advantage of the mounted volume.
 
 View the app by visiting your docker machine's endpoint in the browser.
 To find your docker machine endpoint:
 
 ```shell
 docker-machine ip dev
-```
-
-Also, for convenience when doing development on the UI, the `docker-compose` file uses a `volumes` which mount the local directory into the `hmda-platform-ui` container. This means you can make UI changes and refresh the browser to view them.
-
-``` shell
-# while still in the hmda-platform directory
-cd ../hmda-platform-ui
-npm run watch
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ To build the front-end and allow "watching" for changes. For convenience when do
 ``` shell
 # while still in the hmda-platform directory
 cd ../hmda-platform-ui
+npm install # optional, to make sure you get the dependencies
 npm run watch
 ```
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,9 @@ docker-compose up -d --build
 
 This will bring up all the HMDA Platform services. The first run may take several minutes.
 
-To build the front-end and allow "watching" for changes. For convenience when doing development on the UI, the `docker-compose` file uses a `volumes` which mount the local directory into the `hmda-platform-ui` container. This means you can make UI changes and refresh the browser to view them.
+For convenience when doing development on the UI, the `docker-compose` file uses a `volumes` which mount the local directory into the `hmda-platform-ui` container. This means you can make UI changes and refresh the browser to view them.
+
+To build the front-end and allow "watching" for changes you can run:
 
 ``` shell
 # while still in the hmda-platform directory
@@ -155,7 +157,7 @@ If you don't need to "watch" for changes you can run:
 # while still in the hmda-platform directory
 cd ../hmda-platform-ui
 npm install # optional, to make sure you get the dependencies
-npm run build
+npm run build:docker
 ```
 
 This will simply build the front-end, still taking advantage of the mounted volume.

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ If you don't need to "watch" for changes you can run:
 ``` shell
 # while still in the hmda-platform directory
 cd ../hmda-platform-ui
+npm install # optional, to make sure you get the dependencies
 npm run build
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,10 @@ services:
   api:
     build: .
   ui:
-    build: ../hmda-platform-ui
+    build:
+      context: ../hmda-platform-ui
+      args:
+        dev: build:docker
     ports:
       - "80:80"
     depends_on:


### PR DESCRIPTION
- small update to readme instructions, to run a front-end build first
- passes an argument in on the ui setup to run a different build

To test:
- use the `source-maps` branch for the platform
- use the `source-maps-full` branch for the ui
- the steps to get docker-compose running have __not__ changed
- once running, open the browser and open dev tools
- using dev tools 'select and element' tool, select the "home" link you should see that its css is coming from `cf-base.less` instead of `app.css.min`
  - this is showing the source map working

Also see https://github.com/cfpb/hmda-platform-ui/pull/185