### PR TITLE
Introduce Akka request-timeout config option

### DIFF
--- a/api/src/main/resources/application.conf
+++ b/api/src/main/resources/application.conf
@@ -4,6 +4,7 @@ akka {
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
   http.parsing.max-content-length = 1G
   http.server.default-host-header = "cfpb.gov"
+  http.server.request-timeout = 5 s
 }
 
 hmda {

--- a/api/src/main/scala/hmda/api/http/HttpApi.scala
+++ b/api/src/main/scala/hmda/api/http/HttpApi.scala
@@ -36,20 +36,7 @@ trait HttpApi extends HmdaApiProtocol {
       }
     }
 
-  val timeoutResponse = HttpResponse(
-    StatusCodes.EnhanceYourCalm,
-    entity = "Unable to serve response within time limit, please enhance your calm."
-  )
-
-  val otherName =
-    path("timeout") {
-      get {
-        val response = beSlow("slow")
-        complete(response)
-      }
-    }
-
-  val routes = rootPath ~ otherName
+  val routes = rootPath
 
   def beSlow(echo: String): Future[String] = {
     Future {

--- a/api/src/main/scala/hmda/api/http/HttpApi.scala
+++ b/api/src/main/scala/hmda/api/http/HttpApi.scala
@@ -32,5 +32,4 @@ trait HttpApi extends HmdaApiProtocol {
     }
 
   val routes = rootPath
-
 }

--- a/api/src/main/scala/hmda/api/http/HttpApi.scala
+++ b/api/src/main/scala/hmda/api/http/HttpApi.scala
@@ -2,6 +2,7 @@ package hmda.api.http
 
 import java.net.InetAddress
 import java.time.Instant
+
 import akka.actor.ActorSystem
 import akka.event.LoggingAdapter
 import akka.http.scaladsl.marshalling.ToResponseMarshallable
@@ -9,8 +10,12 @@ import akka.http.scaladsl.server.Directives._
 import akka.stream.ActorMaterializer
 import hmda.api.model.Status
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+import akka.http.scaladsl.model.{ HttpResponse, StatusCodes }
 import hmda.api.protocol.HmdaApiProtocol
 import spray.json._
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.concurrent.duration._
 
 trait HttpApi extends HmdaApiProtocol {
 
@@ -31,5 +36,26 @@ trait HttpApi extends HmdaApiProtocol {
       }
     }
 
-  val routes = rootPath
+  val timeoutResponse = HttpResponse(
+    StatusCodes.EnhanceYourCalm,
+    entity = "Unable to serve response within time limit, please enhance your calm."
+  )
+
+  val otherName =
+    path("timeout") {
+      get {
+        val response = beSlow("slow")
+        complete(response)
+      }
+    }
+
+  val routes = rootPath ~ otherName
+
+  def beSlow(echo: String): Future[String] = {
+    Future {
+      Thread sleep 25000
+      echo
+    }
+  }
+
 }

--- a/api/src/main/scala/hmda/api/http/HttpApi.scala
+++ b/api/src/main/scala/hmda/api/http/HttpApi.scala
@@ -2,7 +2,6 @@ package hmda.api.http
 
 import java.net.InetAddress
 import java.time.Instant
-
 import akka.actor.ActorSystem
 import akka.event.LoggingAdapter
 import akka.http.scaladsl.marshalling.ToResponseMarshallable
@@ -10,12 +9,8 @@ import akka.http.scaladsl.server.Directives._
 import akka.stream.ActorMaterializer
 import hmda.api.model.Status
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
-import akka.http.scaladsl.model.{ HttpResponse, StatusCodes }
 import hmda.api.protocol.HmdaApiProtocol
 import spray.json._
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
-import scala.concurrent.duration._
 
 trait HttpApi extends HmdaApiProtocol {
 
@@ -37,12 +32,5 @@ trait HttpApi extends HmdaApiProtocol {
     }
 
   val routes = rootPath
-
-  def beSlow(echo: String): Future[String] = {
-    Future {
-      Thread sleep 25000
-      echo
-    }
-  }
 
 }


### PR DESCRIPTION
Akka has a global http request timeout config option that I am making explicate here. It's default is 20 seconds, I have set it to the more reasonable 5 seconds. By default if a timeout occurs the route returns:

`The server was not able to produce a timely response to your request.
Please try again in a short while!`

Further I have made sure that this feature is working properly, the code to test it is in the first commit in this pr.

More info on akka http timeouts can be found [here](http://doc.akka.io/docs/akka/2.4/scala/http/common/timeouts.html)

Closes #443 