### PR TITLE
fill out Institution Types needed for edits

### DIFF
--- a/model/src/main/scala/hmda/model/fi/ts/NameAndAddress.scala
+++ b/model/src/main/scala/hmda/model/fi/ts/NameAndAddress.scala
@@ -1,0 +1,9 @@
+package hmda.model.fi.ts
+
+trait NameAndAddress {
+  def name: String
+  def address: String
+  def city: String
+  def state: String
+  def zipCode: String
+}

--- a/model/src/main/scala/hmda/model/fi/ts/Parent.scala
+++ b/model/src/main/scala/hmda/model/fi/ts/Parent.scala
@@ -6,5 +6,5 @@ case class Parent(
   city: String,
   state: String,
   zipCode: String
-)
+) extends NameAndAddress
 

--- a/model/src/main/scala/hmda/model/fi/ts/Respondent.scala
+++ b/model/src/main/scala/hmda/model/fi/ts/Respondent.scala
@@ -7,5 +7,5 @@ case class Respondent(
   city: String,
   state: String,
   zipCode: String
-)
+) extends NameAndAddress
 

--- a/model/src/main/scala/hmda/model/institution/Institution.scala
+++ b/model/src/main/scala/hmda/model/institution/Institution.scala
@@ -9,10 +9,10 @@ case class Institution(
     externalIds: Set[ExternalId],
     agency: Agency,
     institutionType: InstitutionType,
-    status: InstitutionStatus
+    status: InstitutionStatus = InstitutionStatus.Active
 ) {
 
-  val extIdsByType: Map[ExternalIdType, ExternalId] = externalIds.map(extId => (extId.idType, extId)).toMap
+  private val extIdsByType: Map[ExternalIdType, ExternalId] = externalIds.map(extId => (extId.idType, extId)).toMap
 
   /**
    * Derives the respondentId for a given Institution based on [[hmda.model.institution.Agency]] and [[hmda.model.institution.InstitutionType]],

--- a/model/src/main/scala/hmda/model/institution/Institution.scala
+++ b/model/src/main/scala/hmda/model/institution/Institution.scala
@@ -9,6 +9,7 @@ case class Institution(
     externalIds: Set[ExternalId],
     agency: Agency,
     institutionType: InstitutionType,
+    hasParent: Boolean,
     status: InstitutionStatus = InstitutionStatus.Active
 ) {
 

--- a/model/src/main/scala/hmda/model/institution/InstitutionType.scala
+++ b/model/src/main/scala/hmda/model/institution/InstitutionType.scala
@@ -31,12 +31,10 @@ object InstitutionType extends Enum[InstitutionType] {
   case object CreditUnion extends InstitutionType("credit-union", Some(Depository))
   case object SavingsAndLoan extends InstitutionType("savings-and-loan", Some(Depository))
 
-  // may or may not have a parent (of which to be independent). is this name better, or IndependentMBS? or other?
   case object IndependentMortgageCompany extends InstitutionType("independent-mortgage-company", Some(NonDepository))
 
-  // must an FI with either of these two types always have a parent?
-  // also: please advise on names; there may be more appropriate industry terms to use.
-  case object DependentMortgageCompany extends InstitutionType("dependent-mortgage-company", Some(NonDepository))
+  // an FI with either of these two types will generally have a parent, but the code does not enforce that constraint.
+  case object MBS extends InstitutionType("mortgage-banking-subsidiary", Some(NonDepository))
   case object Affiliate extends InstitutionType("affiliate", Some(NonDepository))
 
   // FIXME: These are temporary InstitutionType(s) used for testing.  They will be replaced

--- a/model/src/main/scala/hmda/model/institution/InstitutionType.scala
+++ b/model/src/main/scala/hmda/model/institution/InstitutionType.scala
@@ -31,6 +31,14 @@ object InstitutionType extends Enum[InstitutionType] {
   case object CreditUnion extends InstitutionType("credit-union", Some(Depository))
   case object SavingsAndLoan extends InstitutionType("savings-and-loan", Some(Depository))
 
+  // may or may not have a parent (of which to be independent). is this name better, or IndependentMBS? or other?
+  case object IndependentMortgageCompany extends InstitutionType("independent-mortgage-company", Some(NonDepository))
+
+  // must an FI with either of these two types always have a parent?
+  // also: please advise on names; there may be more appropriate industry terms to use.
+  case object DependentMortgageCompany extends InstitutionType("dependent-mortgage-company", Some(NonDepository))
+  case object Affiliate extends InstitutionType("affiliate", Some(NonDepository))
+
   // FIXME: These are temporary InstitutionType(s) used for testing.  They will be replaced
   //        by real ones once we know what they are. :)
   case object NonDepositInstType extends InstitutionType("test-non-depository", Some(NonDepository))

--- a/model/src/test/scala/hmda/model/institution/InMemoryInstitutionRepositorySpec.scala
+++ b/model/src/test/scala/hmda/model/institution/InMemoryInstitutionRepositorySpec.scala
@@ -9,9 +9,9 @@ import org.scalatest.{ MustMatchers, WordSpec }
 class InMemoryInstitutionRepositorySpec extends WordSpec with MustMatchers {
 
   val institutionRepository = new InMemoryInstitutionRepository(Set(
-    Institution(1, "Test Bank 1", Set(ExternalId("99-1234567", FederalTaxId), ExternalId("123456", RssdId)), CFPB, Bank, Active),
-    Institution(2, "Test Bank 2", Set(ExternalId("98-1234567", FederalTaxId), ExternalId("9898989", FdicCertNo)), FDIC, Bank, Inactive),
-    Institution(3, "Test Bank 3", Set(ExternalId("97-1234567", FederalTaxId), ExternalId("64646464", OccCharterId)), OCC, SavingsAndLoan, Active)
+    Institution(1, "Test Bank 1", Set(ExternalId("99-1234567", FederalTaxId), ExternalId("123456", RssdId)), CFPB, Bank, hasParent = true, Active),
+    Institution(2, "Test Bank 2", Set(ExternalId("98-1234567", FederalTaxId), ExternalId("9898989", FdicCertNo)), FDIC, Bank, hasParent = true, Inactive),
+    Institution(3, "Test Bank 3", Set(ExternalId("97-1234567", FederalTaxId), ExternalId("64646464", OccCharterId)), OCC, SavingsAndLoan, hasParent = false, Active)
   ))
 
   "InMemoryInstitutionRepository" must {
@@ -22,7 +22,7 @@ class InMemoryInstitutionRepositorySpec extends WordSpec with MustMatchers {
 
     "return the correct institution when retrieved by ID" in {
       institutionRepository.get(1) mustBe Some(
-        Institution(1, "Test Bank 1", Set(ExternalId("99-1234567", FederalTaxId), ExternalId("123456", RssdId)), CFPB, Bank, Active)
+        Institution(1, "Test Bank 1", Set(ExternalId("99-1234567", FederalTaxId), ExternalId("123456", RssdId)), CFPB, Bank, hasParent = true, Active)
       )
     }
 

--- a/model/src/test/scala/hmda/model/institution/InstitutionSpec.scala
+++ b/model/src/test/scala/hmda/model/institution/InstitutionSpec.scala
@@ -121,7 +121,7 @@ class InstitutionSpec extends WordSpec with MustMatchers {
     }
 
     def createInstitution(externalIds: Set[ExternalId], agency: Agency, instType: InstitutionType): Institution = {
-      Institution(1, "Test Bank", externalIds, agency, instType, Active)
+      Institution(1, "Test Bank", externalIds, agency, instType, hasParent = true, Active)
     }
   }
 

--- a/model/src/test/scala/hmda/model/institution/InstitutionSpec.scala
+++ b/model/src/test/scala/hmda/model/institution/InstitutionSpec.scala
@@ -20,7 +20,7 @@ class InstitutionSpec extends WordSpec with MustMatchers {
     )
 
     "fail to resolve respondentId when institution type does not have a depository type" in {
-      val inst = Institution(1, "Test Bank", externalIds, CFPB, NoDepositTypeInstType, Active)
+      val inst = createInstitution(externalIds, CFPB, NoDepositTypeInstType)
       val expectedId = inst.respondentId
 
       expectedId mustBe Left(NoDepositoryTypeForInstitutionType(1, NoDepositTypeInstType))
@@ -28,7 +28,7 @@ class InstitutionSpec extends WordSpec with MustMatchers {
     }
 
     "fail to resolve respondentId when a required externalId is not present" in {
-      val inst = Institution(1, "Test Bank", Set(ExternalId("666666", FederalTaxId)), CFPB, Bank, Active)
+      val inst = createInstitution(Set(ExternalId("666666", FederalTaxId)), CFPB, Bank)
       val expectedId = inst.respondentId
 
       expectedId mustBe Left(RequiredExternalIdNotPresent(1, RssdId))
@@ -36,49 +36,49 @@ class InstitutionSpec extends WordSpec with MustMatchers {
     }
 
     "resolve respondentId to RSSD ID when agency is CFPB and depository type is depository" in {
-      val inst = Institution(1, "Test Bank", externalIds, CFPB, Bank, Active)
+      val inst = createInstitution(externalIds, CFPB, Bank)
       val expectedId = inst.respondentId
 
       expectedId mustBe Right(ExternalId("555555", RssdId))
     }
 
     "resolve respondentId to Federal Tax ID when agency is CFPB and is a non-depository institution" in {
-      val inst = Institution(1, "Test Bank", externalIds, CFPB, NonDepositInstType, Active)
+      val inst = createInstitution(externalIds, CFPB, NonDepositInstType)
       val expectedId = inst.respondentId
 
       expectedId mustBe Right(ExternalId("222222", FederalTaxId))
     }
 
     "resolve respondentId to FDIC Certificate Number when Agency is FDIC and is a depository institution" in {
-      val inst = Institution(1, "Test Bank", externalIds, FDIC, Bank, Active)
+      val inst = createInstitution(externalIds, FDIC, Bank)
       val expectedId = inst.respondentId
 
       expectedId mustBe Right(ExternalId("111111", FdicCertNo))
     }
 
     "resolve respondentId to Federal Tax ID when Agency is FDIC and is a non-depository institution" in {
-      val inst = Institution(1, "Test Bank", externalIds, FDIC, NonDepositInstType, Active)
+      val inst = createInstitution(externalIds, FDIC, NonDepositInstType)
       val expectedId = inst.respondentId
 
       expectedId mustBe Right(ExternalId("222222", FederalTaxId))
     }
 
     "resolve respondentId to RSSD ID when Agency is FRS and is a depository institution" in {
-      val inst = Institution(1, "Test Bank", externalIds, FRS, Bank, Active)
+      val inst = createInstitution(externalIds, FRS, Bank)
       val expectedId = inst.respondentId
 
       expectedId mustBe Right(ExternalId("555555", RssdId))
     }
 
     "resolve respondentId to RSSD ID when Agency is FRS and is a non-depository institution" in {
-      val inst = Institution(1, "Test Bank", externalIds, FRS, NonDepositInstType, Active)
+      val inst = createInstitution(externalIds, FRS, NonDepositInstType)
       val expectedId = inst.respondentId
 
       expectedId mustBe Right(ExternalId("555555", RssdId))
     }
 
     "fail to resolve respondentId when Agency is HUD and is a depository institution" in {
-      val inst = Institution(1, "Test Bank", externalIds, HUD, Bank, Active)
+      val inst = createInstitution(externalIds, HUD, Bank)
       val expectedId = inst.respondentId
 
       expectedId mustBe Left(UnsupportedDepositoryTypeByAgency(1, HUD, Depository))
@@ -86,38 +86,42 @@ class InstitutionSpec extends WordSpec with MustMatchers {
     }
 
     "resolve respondentId to Federal Tax ID when Agency is HUD and is a non-depository institution" in {
-      val inst = Institution(1, "Test Bank", externalIds, HUD, NonDepositInstType, Active)
+      val inst = createInstitution(externalIds, HUD, NonDepositInstType)
       val expectedId = inst.respondentId
 
       expectedId mustBe Right(ExternalId("222222", FederalTaxId))
     }
 
     "resolve respondentId to NCUA Charter ID when Agency is NCUA and is a depository institution" in {
-      val inst = Institution(1, "Test Bank", externalIds, NCUA, Bank, Active)
+      val inst = createInstitution(externalIds, NCUA, Bank)
       val expectedId = inst.respondentId
 
       expectedId mustBe Right(ExternalId("333333", NcuaCharterId))
     }
 
     "resolve respondentId to Federal Tax ID when Agency is NCUA and is a non-depository institution" in {
-      val inst = Institution(1, "Test Bank", externalIds, NCUA, NonDepositInstType, Active)
+      val inst = createInstitution(externalIds, NCUA, NonDepositInstType)
       val expectedId = inst.respondentId
 
       expectedId mustBe Right(ExternalId("222222", FederalTaxId))
     }
 
     "resolve respondentId to OCC Charter ID when Agency is OCC and is a depository institution" in {
-      val inst = Institution(1, "Test Bank", externalIds, OCC, Bank, Active)
+      val inst = createInstitution(externalIds, OCC, Bank)
       val expectedId = inst.respondentId
 
       expectedId mustBe Right(ExternalId("444444", OccCharterId))
     }
 
     "resolve respondentId to Federal Tax ID when Agency is OCC and is a non-depository institution" in {
-      val inst = Institution(1, "Test Bank", externalIds, OCC, NonDepositInstType, Active)
+      val inst = createInstitution(externalIds, OCC, NonDepositInstType)
       val expectedId = inst.respondentId
 
       expectedId mustBe Right(ExternalId("222222", FederalTaxId))
+    }
+
+    def createInstitution(externalIds: Set[ExternalId], agency: Agency, instType: InstitutionType): Institution = {
+      Institution(1, "Test Bank", externalIds, agency, instType, Active)
     }
   }
 

--- a/parser/src/test/scala/hmda/parser/fi/FIGenerators.scala
+++ b/parser/src/test/scala/hmda/parser/fi/FIGenerators.scala
@@ -3,16 +3,18 @@ package hmda.parser.fi
 import java.text.SimpleDateFormat
 import java.util.Date
 
+import hmda.model.institution.Agency
+
 import org.scalacheck.Gen
 
 trait FIGenerators {
 
   implicit def agencyCodeGen: Gen[Int] = {
-    Gen.oneOf(1, 2, 3, 5, 7, 9)
+    Gen.oneOf(Agency.values).map(_.value)
   }
 
   implicit def respIdGen: Gen[String] = {
-    stringOfUpToN(10, Gen.alphaChar)
+    stringOfOneToN(10, Gen.alphaChar)
   }
 
   // utility functions
@@ -22,6 +24,11 @@ trait FIGenerators {
   }
 
   def stringOfUpToN(n: Int, genOne: Gen[Char]): Gen[String] = {
+    val stringGen = Gen.listOf(genOne).map(_.mkString)
+    Gen.resize(n, stringGen)
+  }
+
+  def stringOfOneToN(n: Int, genOne: Gen[Char]): Gen[String] = {
     val stringGen = Gen.nonEmptyListOf(genOne).map(_.mkString)
     Gen.resize(n, stringGen)
   }

--- a/parser/src/test/scala/hmda/parser/fi/lar/LarGenerators.scala
+++ b/parser/src/test/scala/hmda/parser/fi/lar/LarGenerators.scala
@@ -45,7 +45,7 @@ trait LarGenerators extends FIGenerators {
 
   implicit def loanGen: Gen[Loan] = {
     for {
-      id <- stringOfUpToN(25, Gen.alphaChar)
+      id <- stringOfOneToN(25, Gen.alphaChar)
       applicationDate <- optional(dateGen, "NA")
       loanType <- Gen.oneOf(1, 2, 3, 4)
       propertyType <- Gen.oneOf(1, 2, 3)

--- a/validation/src/main/scala/hmda/validation/dsl/PredicateHmda.scala
+++ b/validation/src/main/scala/hmda/validation/dsl/PredicateHmda.scala
@@ -1,6 +1,9 @@
 package hmda.validation.dsl
 
 import java.text.SimpleDateFormat
+
+import hmda.model.fi.ts.NameAndAddress
+
 import scala.language.implicitConversions
 
 object PredicateHmda {
@@ -20,4 +23,8 @@ object PredicateHmda {
       case e: Exception => false
     }
   }
+
+  def completeNameAndAddress[T <: NameAndAddress]: Predicate[T] = (info: T) =>
+    List(info.name, info.address, info.city, info.state, info.zipCode).forall(!_.isEmpty)
+
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V110.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V110.scala
@@ -4,6 +4,7 @@ import hmda.model.fi.ts.TransmittalSheet
 import hmda.model.institution.Institution
 import hmda.model.institution.InstitutionType._
 import hmda.validation.dsl.PredicateCommon._
+import hmda.validation.dsl.PredicateHmda._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
@@ -12,14 +13,8 @@ class V110(institution: Institution) extends EditCheck[TransmittalSheet] {
   override def name: String = "V110"
 
   override def apply(ts: TransmittalSheet): Result = {
-    val parent = ts.parent
-
     when(institution.institutionType is oneOf(DependentMortgageCompany, Affiliate)) {
-      (parent.name not empty) and
-        (parent.address not empty) and
-        (parent.city not empty) and
-        (parent.state not empty) and
-        (parent.zipCode not empty)
+      ts.parent is completeNameAndAddress
     }
   }
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V110.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V110.scala
@@ -1,0 +1,25 @@
+package hmda.validation.rules.lar.validity
+
+import hmda.model.fi.ts.TransmittalSheet
+import hmda.model.institution.Institution
+import hmda.model.institution.InstitutionType._
+import hmda.validation.dsl.PredicateCommon._
+import hmda.validation.dsl.PredicateSyntax._
+import hmda.validation.dsl.Result
+import hmda.validation.rules.EditCheck
+
+class V110(institution: Institution) extends EditCheck[TransmittalSheet] {
+  override def name: String = "V110"
+
+  override def apply(ts: TransmittalSheet): Result = {
+    val parent = ts.parent
+
+    when(institution.institutionType is oneOf(DependentMortgageCompany, Affiliate)) {
+      (parent.name not empty) and
+        (parent.address not empty) and
+        (parent.city not empty) and
+        (parent.state not empty) and
+        (parent.zipCode not empty)
+    }
+  }
+}

--- a/validation/src/main/scala/hmda/validation/rules/ts/quality/Q033.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/quality/Q033.scala
@@ -1,0 +1,14 @@
+package hmda.validation.rules.ts.quality
+
+import hmda.model.fi.ts.TransmittalSheet
+import hmda.model.institution.Institution
+import hmda.validation.dsl.{ Result, Success }
+import hmda.validation.rules.EditCheck
+
+class Q033(institution: Institution) extends EditCheck[TransmittalSheet] {
+  override def name: String = "Q033"
+
+  override def apply(input: TransmittalSheet): Result = {
+    Success() // TODO replace with real implementation
+  }
+}

--- a/validation/src/main/scala/hmda/validation/rules/ts/quality/Q033.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/quality/Q033.scala
@@ -2,13 +2,20 @@ package hmda.validation.rules.ts.quality
 
 import hmda.model.fi.ts.TransmittalSheet
 import hmda.model.institution.Institution
-import hmda.validation.dsl.{ Result, Success }
+import hmda.model.institution.InstitutionType._
+import hmda.validation.dsl.PredicateCommon._
+import hmda.validation.dsl.PredicateHmda._
+import hmda.validation.dsl.PredicateSyntax._
+import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 
-class Q033(institution: Institution) extends EditCheck[TransmittalSheet] {
+class Q033(respondent: Institution) extends EditCheck[TransmittalSheet] {
   override def name: String = "Q033"
 
-  override def apply(input: TransmittalSheet): Result = {
-    Success() // TODO replace with real implementation
+  override def apply(ts: TransmittalSheet): Result = {
+    when((respondent.institutionType is oneOf(Bank, SavingsAndLoan, IndependentMortgageCompany))
+      and (respondent.hasParent is true)) {
+      ts.parent is completeNameAndAddress
+    }
   }
 }

--- a/validation/src/main/scala/hmda/validation/rules/ts/validity/V105.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/validity/V105.scala
@@ -3,7 +3,7 @@ package hmda.validation.rules.ts.validity
 import hmda.model.fi.ts.TransmittalSheet
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
-import hmda.validation.dsl.PredicateCommon._
+import hmda.validation.dsl.PredicateHmda._
 import hmda.validation.dsl.PredicateSyntax._
 
 /*
@@ -12,18 +12,7 @@ import hmda.validation.dsl.PredicateSyntax._
 object V105 extends EditCheck[TransmittalSheet] {
 
   override def apply(ts: TransmittalSheet): Result = {
-    val respondent = ts.respondent
-    val respName = respondent.name
-    val respAddress = respondent.address
-    val respCity = respondent.city
-    val respState = respondent.state
-    val respZipCode = respondent.zipCode
-
-    (respName not empty) and
-      (respAddress not empty) and
-      (respCity not empty) and
-      (respState not empty) and
-      (respZipCode not empty)
+    ts.respondent is completeNameAndAddress
   }
 
   override def name: String = "V105"

--- a/validation/src/main/scala/hmda/validation/rules/ts/validity/V110.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/validity/V110.scala
@@ -1,4 +1,4 @@
-package hmda.validation.rules.lar.validity
+package hmda.validation.rules.ts.validity
 
 import hmda.model.fi.ts.TransmittalSheet
 import hmda.model.institution.Institution

--- a/validation/src/main/scala/hmda/validation/rules/ts/validity/V110.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/validity/V110.scala
@@ -13,7 +13,7 @@ class V110(institution: Institution) extends EditCheck[TransmittalSheet] {
   override def name: String = "V110"
 
   override def apply(ts: TransmittalSheet): Result = {
-    when(institution.institutionType is oneOf(DependentMortgageCompany, Affiliate)) {
+    when(institution.institutionType is oneOf(MBS, Affiliate)) {
       ts.parent is completeNameAndAddress
     }
   }

--- a/validation/src/test/scala/hmda/validation/engine/lar/syntactical/LarSyntacticalEngineSpec.scala
+++ b/validation/src/test/scala/hmda/validation/engine/lar/syntactical/LarSyntacticalEngineSpec.scala
@@ -5,6 +5,8 @@ import hmda.validation.context.ValidationContext
 import org.scalatest.{ MustMatchers, PropSpec }
 import org.scalatest.prop.PropertyChecks
 
+import scalaz.Success
+
 class LarSyntacticalEngineSpec
     extends PropSpec
     with PropertyChecks
@@ -15,14 +17,14 @@ class LarSyntacticalEngineSpec
   property("A LAR must pass syntactical checks") {
     forAll(larGen) { lar =>
       whenever(lar.id == 2) {
-        checkSyntactical(lar, ValidationContext(None)).isSuccess mustBe true
+        checkSyntactical(lar, ValidationContext(None)) mustBe a[Success[_]]
       }
     }
   }
 
   property("Pass syntactical checks on groups of LARs") {
     forAll(larListGen) { lars =>
-      checkSyntacticalCollection(lars).isSuccess mustBe true
+      checkSyntacticalCollection(lars) mustBe a[Success[_]]
     }
   }
 

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V110Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V110Spec.scala
@@ -84,6 +84,7 @@ class V110Spec extends TsEditCheckSpec {
   }
 
   private def whenInstitutionTypeIs(instType: InstitutionType): Unit = {
-    institution = Institution(22, "some bank", Set(), Agency.CFPB, instType)
+    // note: the hasParent boolean is not used in this edit. it's false here, which may not always be realistic.
+    institution = Institution(22, "some bank", Set(), Agency.CFPB, instType, hasParent = false)
   }
 }

--- a/validation/src/test/scala/hmda/validation/rules/lar/validity/V110Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/validity/V110Spec.scala
@@ -1,0 +1,89 @@
+package hmda.validation.rules.lar.validity
+
+import hmda.model.fi.ts.{ Parent, TransmittalSheet }
+import hmda.model.institution.InstitutionType._
+import hmda.model.institution.{ Agency, Institution, InstitutionType }
+import hmda.validation.rules.EditCheck
+import hmda.validation.rules.ts.TsEditCheckSpec
+import org.scalacheck.Gen
+
+class V110Spec extends TsEditCheckSpec {
+
+  private var institution: Institution = _
+
+  override def check: EditCheck[TransmittalSheet] = new V110(institution)
+
+  private val applicableTypes: Set[InstitutionType] = Set(DependentMortgageCompany, Affiliate)
+
+  property("any TS must pass for Institution of type other than MBS or Affiliate") {
+    forAll(tsGen, Gen.oneOf(InstitutionType.values)) { (ts, instType) =>
+      whenever(!applicableTypes.contains(instType)) {
+        whenInstitutionTypeIs(instType)
+        ts.mustPass
+      }
+    }
+  }
+
+  // TODO fix generator so that the previous test will cover this case too. (then remove this one.)
+  property("any TS, even with empty parent info, must pass for Institution of type other than MBS or Affiliate") {
+    forAll(tsGen, Gen.oneOf(InstitutionType.values)) { (ts, instType) =>
+      whenever(!applicableTypes.contains(instType)) {
+        whenInstitutionTypeIs(instType)
+        val noParentTS = ts.copy(parent = Parent("", "", "", "", ""))
+        noParentTS.mustPass
+      }
+    }
+  }
+
+  property("TS must pass if parent info is populated and Institution is dependent MBS or Affiliate") {
+    forAll(tsGen, Gen.oneOf(applicableTypes.toList)) { (ts, instType) =>
+      whenInstitutionTypeIs(instType)
+      val validTS = ts.copy(parent = Parent("a bank", "12 Main St", "Washington", "DC", "12345"))
+      validTS.mustPass
+    }
+  }
+
+  property("TS must fail if parent name is missing and Institution is dependent MBS or Affiliate") {
+    forAll(tsGen, Gen.oneOf(applicableTypes.toList)) { (ts, instType) =>
+      whenInstitutionTypeIs(instType)
+      val invalidTS = ts.copy(parent = ts.parent.copy(name = ""))
+      invalidTS.mustFail
+    }
+  }
+
+  property("TS must fail if parent address is missing and Institution is dependent MBS or Affiliate") {
+    forAll(tsGen, Gen.oneOf(applicableTypes.toList)) { (ts, instType) =>
+      whenInstitutionTypeIs(instType)
+      val invalidTS = ts.copy(parent = ts.parent.copy(address = ""))
+      invalidTS.mustFail
+    }
+  }
+
+  property("TS must fail if parent city is missing and Institution is dependent MBS or Affiliate") {
+    forAll(tsGen, Gen.oneOf(applicableTypes.toList)) { (ts, instType) =>
+      whenInstitutionTypeIs(instType)
+      val invalidTS = ts.copy(parent = ts.parent.copy(city = ""))
+      invalidTS.mustFail
+    }
+  }
+
+  property("TS must fail if parent state is missing and Institution is dependent MBS or Affiliate") {
+    forAll(tsGen, Gen.oneOf(applicableTypes.toList)) { (ts, instType) =>
+      whenInstitutionTypeIs(instType)
+      val invalidTS = ts.copy(parent = ts.parent.copy(state = ""))
+      invalidTS.mustFail
+    }
+  }
+
+  property("TS must fail if parent zip is missing and Institution is dependent MBS or Affiliate") {
+    forAll(tsGen, Gen.oneOf(applicableTypes.toList)) { (ts, instType) =>
+      whenInstitutionTypeIs(instType)
+      val invalidTS = ts.copy(parent = ts.parent.copy(zipCode = ""))
+      invalidTS.mustFail
+    }
+  }
+
+  private def whenInstitutionTypeIs(instType: InstitutionType): Unit = {
+    institution = Institution(22, "some bank", Set(), Agency.CFPB, instType)
+  }
+}

--- a/validation/src/test/scala/hmda/validation/rules/ts/quality/Q033Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/ts/quality/Q033Spec.scala
@@ -38,6 +38,6 @@ class Q033Spec extends TsEditCheckSpec {
   // TODO try switching to a test style that would make common setup/branching cases more obvious
 
   private def whenInstitutionTypeIs(instType: InstitutionType): Unit = {
-    institution = Institution(22, "some bank", Set(), Agency.CFPB, instType)
+    institution = Institution(22, "some bank", Set(), Agency.CFPB, instType, hasParent = false)
   }
 }

--- a/validation/src/test/scala/hmda/validation/rules/ts/quality/Q033Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/ts/quality/Q033Spec.scala
@@ -12,32 +12,43 @@ class Q033Spec extends TsEditCheckSpec {
   private var institution: Institution = _
   override def check: EditCheck[TransmittalSheet] = new Q033(institution)
 
-  private val applicableTypes: Set[InstitutionType] = Set(Bank, SavingsAndLoan, IndependentMortgageCompany)
+  private val applicableTypes = Set(Bank, SavingsAndLoan, IndependentMortgageCompany)
+  private val otherTypes = InstitutionType.values.toSet -- applicableTypes
+
+  private val boolGen: Gen[Boolean] = Gen.oneOf(true, false)
 
   property("any TS must pass for Institution of type other than bank, savings assn, or independent mortgage company") {
-    forAll(tsGen, Gen.oneOf(InstitutionType.values)) { (ts, instType) =>
-      whenever(!applicableTypes.contains(instType)) {
-        whenInstitutionTypeIs(instType)
-        ts.mustPass
-      }
+    forAll(tsGen, Gen.oneOf(otherTypes.toList), boolGen) { (ts, otherType, eitherWay) =>
+      whenInstitution(instType = otherType, hasParent = eitherWay)
+      ts.mustPass
     }
   }
 
-  property("TS must pass if parent info is present and filer is a bank, savings assn, or indep mortgage company") {
-    forAll(tsGen, Gen.oneOf(applicableTypes.toList)) { (ts, instType) =>
-      whenInstitutionTypeIs(instType)
+  property("TS must pass if parent info is present and respondent is a bank, savings assn, or indep mortgage company") {
+    forAll(tsGen, Gen.oneOf(applicableTypes.toList), boolGen) { (ts, relevantType, eitherWay) =>
+      whenInstitution(instType = relevantType, hasParent = eitherWay)
       val validTS = ts.copy(parent = Parent("a bank", "12 Main St", "Washington", "DC", "12345"))
       validTS.mustPass
     }
   }
 
-  property("TS must fail if parent name is missing, filer is of an applicable type, and filer has a parent company") {
-    // TODO implement
+  property("TS must fail if parent info is missing, when respondent is of a relevant type and has a parent company") {
+    forAll(tsGen, Gen.oneOf(applicableTypes.toList)) { (ts, relevantType) =>
+      whenInstitution(instType = relevantType, hasParent = true)
+      val invalidTS = ts.copy(parent = Parent("", "", "", "DC", "12345"))
+      invalidTS.mustFail
+    }
   }
 
-  // TODO try switching to a test style that would make common setup/branching cases more obvious
+  property("TS must pass if parent info is missing, when respondent is of a relevant type but has NO parent company") {
+    forAll(tsGen, Gen.oneOf(applicableTypes.toList)) { (ts, relevantType) =>
+      whenInstitution(instType = relevantType, hasParent = false)
+      val validTS = ts.copy(parent = Parent("", "", "", "", ""))
+      validTS.mustPass
+    }
+  }
 
-  private def whenInstitutionTypeIs(instType: InstitutionType): Unit = {
-    institution = Institution(22, "some bank", Set(), Agency.CFPB, instType, hasParent = false)
+  private def whenInstitution(instType: InstitutionType, hasParent: Boolean): Unit = {
+    institution = Institution(22, "some bank", Set(), Agency.CFPB, instType, hasParent)
   }
 }

--- a/validation/src/test/scala/hmda/validation/rules/ts/quality/Q033Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/ts/quality/Q033Spec.scala
@@ -1,0 +1,43 @@
+package hmda.validation.rules.ts.quality
+
+import hmda.model.fi.ts.{ Parent, TransmittalSheet }
+import hmda.model.institution.{ Agency, Institution, InstitutionType }
+import hmda.model.institution.InstitutionType._
+import hmda.validation.rules.EditCheck
+import hmda.validation.rules.ts.TsEditCheckSpec
+import org.scalacheck.Gen
+
+class Q033Spec extends TsEditCheckSpec {
+
+  private var institution: Institution = _
+  override def check: EditCheck[TransmittalSheet] = new Q033(institution)
+
+  private val applicableTypes: Set[InstitutionType] = Set(Bank, SavingsAndLoan, IndependentMortgageCompany)
+
+  property("any TS must pass for Institution of type other than bank, savings assn, or independent mortgage company") {
+    forAll(tsGen, Gen.oneOf(InstitutionType.values)) { (ts, instType) =>
+      whenever(!applicableTypes.contains(instType)) {
+        whenInstitutionTypeIs(instType)
+        ts.mustPass
+      }
+    }
+  }
+
+  property("TS must pass if parent info is present and filer is a bank, savings assn, or indep mortgage company") {
+    forAll(tsGen, Gen.oneOf(applicableTypes.toList)) { (ts, instType) =>
+      whenInstitutionTypeIs(instType)
+      val validTS = ts.copy(parent = Parent("a bank", "12 Main St", "Washington", "DC", "12345"))
+      validTS.mustPass
+    }
+  }
+
+  property("TS must fail if parent name is missing, filer is of an applicable type, and filer has a parent company") {
+    // TODO implement
+  }
+
+  // TODO try switching to a test style that would make common setup/branching cases more obvious
+
+  private def whenInstitutionTypeIs(instType: InstitutionType): Unit = {
+    institution = Institution(22, "some bank", Set(), Agency.CFPB, instType)
+  }
+}

--- a/validation/src/test/scala/hmda/validation/rules/ts/syntactical/S025Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/ts/syntactical/S025Spec.scala
@@ -23,7 +23,7 @@ class S025Spec extends WordSpec with MustMatchers {
 
     val ts = TransmittalSheet(
       1,
-      9, //CFPB,
+      CFPB.value,
       201602021453L,
       2017,
       "12-3456789",
@@ -33,21 +33,21 @@ class S025Spec extends WordSpec with MustMatchers {
     )
 
     "succeed when TS's agency code and respondent ID match the Institution's" in {
-      val institution = Institution(1, "Test Bank", Set(ExternalId("999999", RssdId), ExternalId("9876543-21", FederalTaxId)), CFPB, Bank, Active)
+      val institution = createBank(Set(ExternalId("999999", RssdId), ExternalId("9876543-21", FederalTaxId)))
       val ctx = ValidationContext(Some(institution))
 
       S025(ts, ctx) mustBe Success()
     }
 
     "fail when TS's agency code and respondent ID do NOT match the Institution's" in {
-      val institution = Institution(1, "Test Bank", Set(ExternalId("111111", RssdId), ExternalId("9876543-21", FederalTaxId)), CFPB, Bank, Active)
+      val institution = createBank(Set(ExternalId("111111", RssdId), ExternalId("9876543-21", FederalTaxId)))
       val ctx = ValidationContext(Some(institution))
 
       S025(ts, ctx) mustBe Failure()
     }
 
     "fail when the Institution's respondent ID cannot be derived" in {
-      val institution = Institution(1, "Test Bank", Set(ExternalId("111111", FdicCertNo), ExternalId("9876543-21", FederalTaxId)), CFPB, Bank, Active)
+      val institution = createBank(Set(ExternalId("111111", FdicCertNo), ExternalId("9876543-21", FederalTaxId)))
       val ctx = ValidationContext(Some(institution))
 
       S025(ts, ctx) mustBe Failure()
@@ -80,26 +80,29 @@ class S025Spec extends WordSpec with MustMatchers {
     }
 
     "fail when the Institution's respondent ID cannot be derived" in {
-      val institution = Institution(1, "Test Bank", Set(ExternalId("111111", FdicCertNo), ExternalId("9876543-21", FederalTaxId)), CFPB, Bank, Active)
+      val institution = createBank(Set(ExternalId("111111", FdicCertNo), ExternalId("9876543-21", FederalTaxId)))
       val ctx = ValidationContext(Some(institution))
 
       S025(lar, ctx) mustBe Failure()
     }
 
     "succeed when LAR's agency code and respondent ID match the Institution's" in {
-      val institution = Institution(1, "Test Bank", Set(ExternalId("999999", RssdId), ExternalId("9876543-21", FederalTaxId)), CFPB, Bank, Active)
+      val institution = createBank(Set(ExternalId("999999", RssdId), ExternalId("9876543-21", FederalTaxId)))
       val ctx = ValidationContext(Some(institution))
 
       S025(lar, ctx) mustBe Success()
     }
 
     "fail when LAR's agency code and respondent ID do NOT match the Institution's" in {
-      val institution = Institution(1, "Test Bank", Set(ExternalId("111111", RssdId), ExternalId("9876543-21", FederalTaxId)), CFPB, Bank, Active)
+      val institution = createBank(Set(ExternalId("111111", RssdId), ExternalId("9876543-21", FederalTaxId)))
       val ctx = ValidationContext(Some(institution))
 
       S025(lar, ctx) mustBe Failure()
     }
   }
 
+  def createBank(externalIds: Set[ExternalId]): Institution = {
+    Institution(1, "Test Bank", externalIds, CFPB, Bank, Active)
+  }
 }
 

--- a/validation/src/test/scala/hmda/validation/rules/ts/syntactical/S025Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/ts/syntactical/S025Spec.scala
@@ -32,14 +32,14 @@ class S025Spec extends WordSpec with MustMatchers {
       Contact("Test Contact", "123-456-7890", "987-654-3210", "test@contact.org")
     )
 
-    "succeed when TS's agency code and respondent ID match the Instititution's" in {
+    "succeed when TS's agency code and respondent ID match the Institution's" in {
       val institution = Institution(1, "Test Bank", Set(ExternalId("999999", RssdId), ExternalId("9876543-21", FederalTaxId)), CFPB, Bank, Active)
       val ctx = ValidationContext(Some(institution))
 
       S025(ts, ctx) mustBe Success()
     }
 
-    "fail when TS's agency code and respondent ID do NOT match the Instititution's" in {
+    "fail when TS's agency code and respondent ID do NOT match the Institution's" in {
       val institution = Institution(1, "Test Bank", Set(ExternalId("111111", RssdId), ExternalId("9876543-21", FederalTaxId)), CFPB, Bank, Active)
       val ctx = ValidationContext(Some(institution))
 
@@ -86,14 +86,14 @@ class S025Spec extends WordSpec with MustMatchers {
       S025(lar, ctx) mustBe Failure()
     }
 
-    "succeed when LAR's agency code and respondent ID match the Instititution's" in {
+    "succeed when LAR's agency code and respondent ID match the Institution's" in {
       val institution = Institution(1, "Test Bank", Set(ExternalId("999999", RssdId), ExternalId("9876543-21", FederalTaxId)), CFPB, Bank, Active)
       val ctx = ValidationContext(Some(institution))
 
       S025(lar, ctx) mustBe Success()
     }
 
-    "fail when LAR's agency code and respondent ID do NOT match the Instititution's" in {
+    "fail when LAR's agency code and respondent ID do NOT match the Institution's" in {
       val institution = Institution(1, "Test Bank", Set(ExternalId("111111", RssdId), ExternalId("9876543-21", FederalTaxId)), CFPB, Bank, Active)
       val ctx = ValidationContext(Some(institution))
 

--- a/validation/src/test/scala/hmda/validation/rules/ts/syntactical/S025Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/ts/syntactical/S025Spec.scala
@@ -102,7 +102,7 @@ class S025Spec extends WordSpec with MustMatchers {
   }
 
   def createBank(externalIds: Set[ExternalId]): Institution = {
-    Institution(1, "Test Bank", externalIds, CFPB, Bank, Active)
+    Institution(1, "Test Bank", externalIds, CFPB, Bank, hasParent = true, Active)
   }
 }
 

--- a/validation/src/test/scala/hmda/validation/rules/ts/validity/V110Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/ts/validity/V110Spec.scala
@@ -13,9 +13,9 @@ class V110Spec extends TsEditCheckSpec {
 
   override def check: EditCheck[TransmittalSheet] = new V110(institution)
 
-  private val applicableTypes: Set[InstitutionType] = Set(DependentMortgageCompany, Affiliate)
+  private val applicableTypes: Set[InstitutionType] = Set(MBS, Affiliate)
 
-  property("any TS must pass for Institution of type other than MBS or Affiliate") {
+  property("any TS must pass for respondent Institution of type other than MBS or Affiliate") {
     forAll(tsGen, Gen.oneOf(InstitutionType.values)) { (ts, instType) =>
       whenever(!applicableTypes.contains(instType)) {
         whenInstitutionTypeIs(instType)
@@ -25,7 +25,7 @@ class V110Spec extends TsEditCheckSpec {
   }
 
   // TODO fix generator so that the previous test will cover this case too. (then remove this one.)
-  property("any TS, even with empty parent info, must pass for Institution of type other than MBS or Affiliate") {
+  property("any TS, even with empty parent info, must pass for respondent of type other than MBS or Affiliate") {
     forAll(tsGen, Gen.oneOf(InstitutionType.values)) { (ts, instType) =>
       whenever(!applicableTypes.contains(instType)) {
         whenInstitutionTypeIs(instType)
@@ -35,7 +35,7 @@ class V110Spec extends TsEditCheckSpec {
     }
   }
 
-  property("TS must pass if parent info is populated and Institution is dependent MBS or Affiliate") {
+  property("TS must pass if parent info is populated and respondent is MBS or Affiliate") {
     forAll(tsGen, Gen.oneOf(applicableTypes.toList)) { (ts, instType) =>
       whenInstitutionTypeIs(instType)
       val validTS = ts.copy(parent = Parent("a bank", "12 Main St", "Washington", "DC", "12345"))
@@ -43,7 +43,7 @@ class V110Spec extends TsEditCheckSpec {
     }
   }
 
-  property("TS must fail if parent name is missing and Institution is dependent MBS or Affiliate") {
+  property("TS must fail if parent name is missing and respondent is MBS or Affiliate") {
     forAll(tsGen, Gen.oneOf(applicableTypes.toList)) { (ts, instType) =>
       whenInstitutionTypeIs(instType)
       val invalidTS = ts.copy(parent = ts.parent.copy(name = ""))
@@ -51,7 +51,7 @@ class V110Spec extends TsEditCheckSpec {
     }
   }
 
-  property("TS must fail if parent address is missing and Institution is dependent MBS or Affiliate") {
+  property("TS must fail if parent address is missing and respondent is MBS or Affiliate") {
     forAll(tsGen, Gen.oneOf(applicableTypes.toList)) { (ts, instType) =>
       whenInstitutionTypeIs(instType)
       val invalidTS = ts.copy(parent = ts.parent.copy(address = ""))
@@ -59,7 +59,7 @@ class V110Spec extends TsEditCheckSpec {
     }
   }
 
-  property("TS must fail if parent city is missing and Institution is dependent MBS or Affiliate") {
+  property("TS must fail if parent city is missing and respondent is MBS or Affiliate") {
     forAll(tsGen, Gen.oneOf(applicableTypes.toList)) { (ts, instType) =>
       whenInstitutionTypeIs(instType)
       val invalidTS = ts.copy(parent = ts.parent.copy(city = ""))
@@ -67,7 +67,7 @@ class V110Spec extends TsEditCheckSpec {
     }
   }
 
-  property("TS must fail if parent state is missing and Institution is dependent MBS or Affiliate") {
+  property("TS must fail if parent state is missing and respondent is MBS or Affiliate") {
     forAll(tsGen, Gen.oneOf(applicableTypes.toList)) { (ts, instType) =>
       whenInstitutionTypeIs(instType)
       val invalidTS = ts.copy(parent = ts.parent.copy(state = ""))
@@ -75,7 +75,7 @@ class V110Spec extends TsEditCheckSpec {
     }
   }
 
-  property("TS must fail if parent zip is missing and Institution is dependent MBS or Affiliate") {
+  property("TS must fail if parent zip is missing and respondent is MBS or Affiliate") {
     forAll(tsGen, Gen.oneOf(applicableTypes.toList)) { (ts, instType) =>
       whenInstitutionTypeIs(instType)
       val invalidTS = ts.copy(parent = ts.parent.copy(zipCode = ""))
@@ -84,7 +84,7 @@ class V110Spec extends TsEditCheckSpec {
   }
 
   private def whenInstitutionTypeIs(instType: InstitutionType): Unit = {
-    // note: the hasParent boolean is not used in this edit. it's false here, which may not always be realistic.
+    // note: the hasParent boolean is not used in this edit. it's false here, which is not realistic for all types.
     institution = Institution(22, "some bank", Set(), Agency.CFPB, instType, hasParent = false)
   }
 }

--- a/validation/src/test/scala/hmda/validation/rules/ts/validity/V110Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/ts/validity/V110Spec.scala
@@ -24,17 +24,6 @@ class V110Spec extends TsEditCheckSpec {
     }
   }
 
-  // TODO fix generator so that the previous test will cover this case too. (then remove this one.)
-  property("any TS, even with empty parent info, must pass for respondent of type other than MBS or Affiliate") {
-    forAll(tsGen, Gen.oneOf(InstitutionType.values)) { (ts, instType) =>
-      whenever(!applicableTypes.contains(instType)) {
-        whenInstitutionTypeIs(instType)
-        val noParentTS = ts.copy(parent = Parent("", "", "", "", ""))
-        noParentTS.mustPass
-      }
-    }
-  }
-
   property("TS must pass if parent info is populated and respondent is MBS or Affiliate") {
     forAll(tsGen, Gen.oneOf(applicableTypes.toList)) { (ts, instType) =>
       whenInstitutionTypeIs(instType)

--- a/validation/src/test/scala/hmda/validation/rules/ts/validity/V110Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/ts/validity/V110Spec.scala
@@ -1,4 +1,4 @@
-package hmda.validation.rules.lar.validity
+package hmda.validation.rules.ts.validity
 
 import hmda.model.fi.ts.{ Parent, TransmittalSheet }
 import hmda.model.institution.InstitutionType._

--- a/validation/src/test/scala/hmda/validation/rules/ts/validity/V120Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/ts/validity/V120Spec.scala
@@ -1,10 +1,8 @@
-package hmda.validation.rules.lar.validity
+package hmda.validation.rules.ts.validity
 
 import hmda.model.fi.ts.TransmittalSheet
 import hmda.validation.rules.EditCheck
 import hmda.validation.rules.ts.TsEditCheckSpec
-import hmda.validation.rules.ts.validity.{ V120, ValidityUtils }
-import org.scalacheck.Gen
 
 class V120Spec extends TsEditCheckSpec with ValidityUtils {
 
@@ -14,7 +12,7 @@ class V120Spec extends TsEditCheckSpec with ValidityUtils {
     }
   }
 
-  property("fail with other seperators") {
+  property("fail with other separators") {
     forAll(tsGen, badPhoneNumberGen) { (ts: TransmittalSheet, x: String) =>
       val badContact = ts.contact.copy(phone = x)
       val badTs = ts.copy(contact = badContact)

--- a/validation/src/test/scala/hmda/validation/rules/ts/validity/V135Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/ts/validity/V135Spec.scala
@@ -1,9 +1,8 @@
-package hmda.validation.rules.lar.validity
+package hmda.validation.rules.ts.validity
 
 import hmda.model.fi.ts.TransmittalSheet
 import hmda.validation.rules.EditCheck
 import hmda.validation.rules.ts.TsEditCheckSpec
-import hmda.validation.rules.ts.validity.{ V135, ValidityUtils }
 
 class V135Spec extends TsEditCheckSpec with ValidityUtils {
 
@@ -13,7 +12,7 @@ class V135Spec extends TsEditCheckSpec with ValidityUtils {
     }
   }
 
-  property("fail with other seperators") {
+  property("fail with other separators") {
     forAll(tsGen, badPhoneNumberGen) { (ts: TransmittalSheet, x: String) =>
       val badContact = ts.contact.copy(fax = x)
       val badTs = ts.copy(contact = badContact)

--- a/validation/src/test/scala/hmda/validation/rules/ts/validity/ValidityUtils.scala
+++ b/validation/src/test/scala/hmda/validation/rules/ts/validity/ValidityUtils.scala
@@ -28,7 +28,7 @@ trait ValidityUtils {
       p2 <- Gen.numStr
       p3 <- Gen.numStr
       sep <- Gen.oneOf(List(".", "/", ""))
-    } yield List(p1.take(3).toString, sep, p2.take(3).toString, sep, p3.take(4).toString).mkString
+    } yield List(p1.take(3), p2.take(3), p3.take(4)).mkString(sep)
   }
 
   def invalidZipGen: Gen[String] = Gen.numStr.filter(s => !s.isEmpty && s.length != 5)


### PR DESCRIPTION
addresses #438
addresses #105
addresses #178

This PR adds `InstitutionType`s as mentioned in #438 and needed for edits V110 and Q033.  It does not yet add parent info.

The current plan for parent info is to create a `hasParent` boolean on the `Institution` as part of #438, and to create a new issue for determining how to represent parent institutions (potentially non-filers) and their relationships with filers, as needed by other parts of the system.  This is enough to un-block the two edits here, and it may make merge conflicts with #481 smaller (and easier to deal with).

Feedback requested from @Kibrael, @debseidner, and/or @lesgou:
 * are the institution types in the code the correct ones needed by these edits?
 * do you have suggestions for better names for them? (Sometimes I used one phrasing in the name, and another in the test description. Which one sounds better? And, importantly, are they accurate?)
 * is V110 implemented as intended? There was some back-and-forth on that one, and I took [this comment](https://github.com/cfpb/hmda-platform/issues/105#issuecomment-231726829) as the latest.
 * for Q033, does the test description look correct?

Note that this code is incomplete: Q033 is not fully implemented, and neither edit is hooked up to run as part of validation.  It is, however, safe to merge if it helps reduce future conflicts; it won't break anything, and it won't prematurely close the issues listed above.