### PR TITLE
Prevent upload to existing submission

### DIFF
--- a/api/src/main/scala/hmda/api/http/HmdaCustomDirectives.scala
+++ b/api/src/main/scala/hmda/api/http/HmdaCustomDirectives.scala
@@ -1,11 +1,30 @@
 package hmda.api.http
 
+import akka.actor.{ Actor, ActorSystem }
 import akka.http.scaladsl.server.Directive0
 import akka.http.scaladsl.server.Directives._
 import akka.event.LoggingAdapter
+import akka.http.scaladsl.marshalling.ToResponseMarshallable
+import akka.http.scaladsl.model.{ HttpRequest, HttpResponse, StatusCodes }
+import akka.stream.ActorMaterializer
+import hmda.api.model.ErrorResponse
+import hmda.model.fi.{ Created, Submission }
+import akka.pattern.ask
+import akka.util.Timeout
+import hmda.api.protocol.processing.ApiErrorProtocol
+import hmda.persistence.institutions.SubmissionPersistence
+import hmda.persistence.institutions.SubmissionPersistence.GetSubmissionById
+import hmda.persistence.CommonMessages._
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 
-trait HmdaCustomDirectives {
+import scala.util.{ Failure, Success }
+
+trait HmdaCustomDirectives extends ApiErrorProtocol {
+
   val log: LoggingAdapter
+  implicit val system: ActorSystem
+  implicit val materializer: ActorMaterializer
+  implicit val timeout: Timeout
 
   def time: Directive0 = {
     val startTime = System.currentTimeMillis()
@@ -18,5 +37,24 @@ trait HmdaCustomDirectives {
     }
 
   }
+
+  def preventSubmissionOverwrite(fid: String, filingId: String, submissionId: Int, path: String) =
+    mapInnerRoute { route =>
+      val submissionsActor = system.actorOf(SubmissionPersistence.props(fid, filingId))
+      val submission = (submissionsActor ? GetSubmissionById(submissionId)).mapTo[Submission]
+      onComplete(submission) {
+        case Success(submission) =>
+          submissionsActor ! Shutdown
+          if (submission.submissionStatus == Created) route
+          else {
+            val errorResponse = ErrorResponse(400, "Submission already exists", path)
+            complete(ToResponseMarshallable(StatusCodes.BadRequest -> errorResponse))
+          }
+        case Failure(error) =>
+          submissionsActor ! Shutdown
+          val errorResponse = ErrorResponse(500, "Internal server error", path)
+          complete(ToResponseMarshallable(StatusCodes.InternalServerError -> errorResponse))
+      }
+    }
 
 }

--- a/api/src/test/scala/hmda/api/http/HttpApiSpec.scala
+++ b/api/src/test/scala/hmda/api/http/HttpApiSpec.scala
@@ -1,16 +1,18 @@
 package hmda.api.http
 
-import akka.event.{ NoLogging, LoggingAdapter }
-import akka.http.scaladsl.model._
+import akka.event.{ LoggingAdapter, NoLogging }
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import hmda.api.model.Status
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+import akka.util.Timeout
 import org.scalatest.{ MustMatchers, WordSpec }
 
 import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
 
 class HttpApiSpec extends WordSpec with MustMatchers with ScalatestRouteTest with HttpApi {
   override val log: LoggingAdapter = NoLogging
+  override implicit val timeout: Timeout = Timeout(5.seconds)
   val ec: ExecutionContext = system.dispatcher
 
   "Http API service" must {


### PR DESCRIPTION
This PR creates a directive to prevent the uploading of a file to a submission with a status other than created.

Closes #484 