### PR TITLE
Add id to validation error

### DIFF
--- a/api/src/main/scala/hmda/api/protocol/validation/ValidationResultProtocol.scala
+++ b/api/src/main/scala/hmda/api/protocol/validation/ValidationResultProtocol.scala
@@ -4,5 +4,5 @@ import hmda.validation.engine.ValidationError
 import spray.json.DefaultJsonProtocol
 
 trait ValidationResultProtocol extends DefaultJsonProtocol {
-  implicit val validationErrorFormat = jsonFormat1(ValidationError.apply)
+  implicit val validationErrorFormat = jsonFormat2(ValidationError.apply)
 }

--- a/validation/src/main/scala/hmda/validation/api/ValidationApi.scala
+++ b/validation/src/main/scala/hmda/validation/api/ValidationApi.scala
@@ -8,14 +8,14 @@ import scalaz.Scalaz._
 
 trait ValidationApi {
 
-  def check[T](editCheck: EditCheck[T], input: T): ValidationNel[ValidationError, T] = {
-    convertResult(input, editCheck(input), editCheck.name)
+  def check[T](editCheck: EditCheck[T], input: T, inputId: String): ValidationNel[ValidationError, T] = {
+    convertResult(input, editCheck(input), editCheck.name, inputId)
   }
 
-  def convertResult[T](input: T, result: Result, ruleName: String): ValidationNel[ValidationError, T] = {
+  def convertResult[T](input: T, result: Result, ruleName: String, inputId: String): ValidationNel[ValidationError, T] = {
     result match {
       case Success() => input.success
-      case Failure() => ValidationError(ruleName).failure.toValidationNel
+      case Failure() => ValidationError(inputId, ruleName).failure.toValidationNel
     }
   }
 

--- a/validation/src/main/scala/hmda/validation/engine/ValidationError.scala
+++ b/validation/src/main/scala/hmda/validation/engine/ValidationError.scala
@@ -1,3 +1,3 @@
 package hmda.validation.engine
 
-case class ValidationError(msg: String)
+case class ValidationError(id: String, msg: String)

--- a/validation/src/main/scala/hmda/validation/engine/lar/quality/LarQualityEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/lar/quality/LarQualityEngine.scala
@@ -9,7 +9,7 @@ import hmda.validation.rules.lar.quality._
 trait LarQualityEngine extends LarCommonEngine with ValidationApi {
 
   private def q022(lar: LoanApplicationRegister): LarValidation = {
-    convertResult(lar, Q022(lar, 2017), "Q022")
+    convertResult(lar, Q022(lar, 2017), "Q022", lar.loan.id)
   }
 
   def checkQuality(lar: LoanApplicationRegister, ctx: ValidationContext): LarValidation = {
@@ -44,7 +44,7 @@ trait LarQualityEngine extends LarCommonEngine with ValidationApi {
       Q066,
       Q067,
       Q068
-    ).map(check(_, lar))
+    ).map(check(_, lar, lar.loan.id))
 
     val allChecks = checks :+ q022(lar)
 

--- a/validation/src/main/scala/hmda/validation/engine/lar/syntactical/LarSyntacticalEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/lar/syntactical/LarSyntacticalEngine.scala
@@ -10,7 +10,7 @@ import hmda.validation.rules.lar.syntactical._
 trait LarSyntacticalEngine extends LarCommonEngine with ValidationApi {
 
   private def s025(lar: LoanApplicationRegister, ctx: ValidationContext): LarValidation = {
-    convertResult(lar, S025(lar, ctx), "S025")
+    convertResult(lar, S025(lar, ctx), "S025", lar.loan.id)
   }
 
   def checkSyntactical(lar: LoanApplicationRegister, ctx: ValidationContext): LarValidation = {
@@ -18,7 +18,7 @@ trait LarSyntacticalEngine extends LarCommonEngine with ValidationApi {
       S010,
       S020,
       S205
-    ).map(check(_, lar))
+    ).map(check(_, lar, lar.loan.id))
 
     val allChecks = checks :+ s025(lar, ctx)
 
@@ -29,7 +29,7 @@ trait LarSyntacticalEngine extends LarCommonEngine with ValidationApi {
     val checks = List(
       S011,
       S040
-    ).map(check(_, lars))
+    ).map(check(_, lars, ""))
 
     validateAll(checks, lars)
   }

--- a/validation/src/main/scala/hmda/validation/engine/lar/validity/LarValidityEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/lar/validity/LarValidityEngine.scala
@@ -74,7 +74,7 @@ trait LarValidityEngine extends LarCommonEngine with ValidationApi {
       V565,
       V570,
       V575
-    ).map(check(_, lar))
+    ).map(check(_, lar, lar.loan.id))
 
     validateAll(checks, lar)
   }

--- a/validation/src/main/scala/hmda/validation/engine/ts/quality/TsQualityEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/ts/quality/TsQualityEngine.scala
@@ -8,9 +8,10 @@ import hmda.validation.rules.ts.quality._
 trait TsQualityEngine extends TsCommonEngine with ValidationApi {
 
   def checkQuality(ts: TransmittalSheet): TsValidation = {
+    val tsId = ts.agencyCode + ts.respondent.id
     val checks = List(
       Q020
-    ).map(check(_, ts))
+    ).map(check(_, ts, tsId))
 
     validateAll(checks, ts)
   }

--- a/validation/src/main/scala/hmda/validation/engine/ts/syntactical/TsSyntacticalEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/ts/syntactical/TsSyntacticalEngine.scala
@@ -13,31 +13,31 @@ import scalaz.Scalaz._
 trait TsSyntacticalEngine extends TsCommonEngine with ValidationApi with TsValidationApi {
 
   private def s010(t: TransmittalSheet): TsValidation = {
-    convertResult(t, S010(t), "S010")
+    convertResult(t, S010(t), "S010", t.agencyCode + t.respondent.id)
   }
 
   private def s020(t: TransmittalSheet): TsValidation = {
-    convertResult(t, S020(t), "S020")
+    convertResult(t, S020(t), "S020", t.agencyCode + t.respondent.id)
   }
 
   private def s025(t: TransmittalSheet, ctx: ValidationContext): TsValidation = {
-    convertResult(t, S025(t, ctx), "S025")
+    convertResult(t, S025(t, ctx), "S025", t.agencyCode + t.respondent.id)
   }
 
   private def s100(t: TransmittalSheet): Future[TsValidation] = {
     S100(t, findYearProcessed).map { result =>
-      convertResult(t, result, "S100")
+      convertResult(t, result, "S100", t.agencyCode + t.respondent.id)
     }
   }
 
   private def s013(t: TransmittalSheet): Future[TsValidation] = {
     S013(t, findTimestamp).map { result =>
-      convertResult(t, result, "S013")
+      convertResult(t, result, "S013", t.agencyCode + t.respondent.id)
     }
   }
 
   private def s028(t: TransmittalSheet): TsValidation = {
-    convertResult(t, S028(t), "S028")
+    convertResult(t, S028(t), "S028", t.agencyCode + t.respondent.id)
   }
 
   def checkSyntactical(ts: TransmittalSheet, ctx: ValidationContext): Future[TsValidation] = {

--- a/validation/src/main/scala/hmda/validation/engine/ts/validity/TsValidityEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/ts/validity/TsValidityEngine.scala
@@ -8,6 +8,7 @@ import hmda.validation.rules.ts.validity._
 trait TsValidityEngine extends TsCommonEngine with ValidationApi {
 
   def checkValidity(ts: TransmittalSheet): TsValidation = {
+    val tsId = ts.agencyCode + ts.respondent.id
     val checks: List[TsValidation] = List(
       V105,
       V108,
@@ -21,7 +22,7 @@ trait TsValidityEngine extends TsCommonEngine with ValidationApi {
       V145,
       V150,
       V155
-    ).map(check(_, ts))
+    ).map(check(_, ts, tsId))
 
     validateAll(checks, ts)
   }


### PR DESCRIPTION
Adds id to validation error. For the HMDA domain:

* Loan id for `Loan Application Register` validation errors
* Agency code + respondent id for `Transmittal Sheet`
* Empty string for edits on groups of LARs (these might be refactored out completely, see #474)