### PR TITLE
Prevent uploading to submission with data 3

### DIFF
--- a/api/src/test/scala/hmda/api/http/InstitutionsHttpApiSpec.scala
+++ b/api/src/test/scala/hmda/api/http/InstitutionsHttpApiSpec.scala
@@ -2,12 +2,15 @@ package hmda.api.http
 
 import java.io.File
 
-import akka.event.{ LoggingAdapter, NoLogging }
+import akka.actor.ActorSystem
+import akka.event.{ Logging, LoggingAdapter, NoLogging }
 import akka.http.scaladsl.model.{ ContentTypes, HttpEntity, Multipart, StatusCodes }
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.util.Timeout
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+import akka.testkit.EventFilter
 import com.typesafe.config.ConfigFactory
+import hmda.api.HmdaApi._
 import hmda.api.model._
 import hmda.model.fi._
 import hmda.persistence.CommonMessages._
@@ -21,6 +24,7 @@ import org.iq80.leveldb.util.FileUtils
 import scala.concurrent.duration._
 
 class InstitutionsHttpApiSpec extends WordSpec with MustMatchers with ScalatestRouteTest with InstitutionsHttpApi with BeforeAndAfterAll {
+
   override val log: LoggingAdapter = NoLogging
   override implicit val timeout: Timeout = Timeout(5.seconds)
 


### PR DESCRIPTION
PR #495 has been chosen over this one.

This PR along with #495 replace #489

This PR is an alternate implementation to #495. They are not meant to both be merged.

It is an implementation of preventing an upload to a submission that already has data using this PR puts both the submission checking logic and uploading logic in separate functions in order to segregate the logic. This implementation currently needs to be cleaned up if it is to be used, however I wanted to put up now so that the two implementations that I have come up with can be compared.