### PR TITLE
Update docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,7 @@ services:
   api:
     build: .
   ui:
-    build:
-      context: ../hmda-platform-ui
-      args:
-        dev: build:docker
+    build: ../hmda-platform-ui
     ports:
       - "80:80"
     depends_on:


### PR DESCRIPTION
- removes unnecessary args from ui build which were causing compose to fail
  - the error was `ERROR: Service 'ui' failed to build: One or more build-args [dev] were not consumed, failing build.`
  - the UI `dockerfile` no longer depends on the `dev` argument