### PR TITLE
add 202 to upload endpoint success respose

### DIFF
--- a/api/src/main/scala/hmda/api/http/InstitutionsHttpApi.scala
+++ b/api/src/main/scala/hmda/api/http/InstitutionsHttpApi.scala
@@ -161,9 +161,7 @@ trait InstitutionsHttpApi extends InstitutionProtocol with ApiErrorProtocol with
               case Success(response) =>
                 processingActor ! CompleteUpload
                 processingActor ! Shutdown
-                complete {
-                  "uploaded"
-                }
+                complete(ToResponseMarshallable(StatusCodes.Accepted -> "uploaded"))
               case Failure(error) =>
                 processingActor ! Shutdown
                 log.error(error.getLocalizedMessage)

--- a/api/src/test/scala/hmda/api/http/InstitutionsHttpApiSpec.scala
+++ b/api/src/test/scala/hmda/api/http/InstitutionsHttpApiSpec.scala
@@ -117,7 +117,7 @@ class InstitutionsHttpApiSpec extends WordSpec with MustMatchers with ScalatestR
       val file = multiPartFile(csv, "sample.txt")
 
       postWithCfpbHeaders("/institutions/12345/filings/2017/submissions/1", file) ~> institutionsRoutes ~> check {
-        status mustBe StatusCodes.OK
+        status mustBe StatusCodes.Accepted
         responseAs[String] mustBe "uploaded"
       }
     }


### PR DESCRIPTION
In talking to the front end Wyatt suggested that all the ui checked for was the status code of the response and that it made sense for it to be a 202 but that no other change was needed.

Closes #503 