### PR TITLE
Parse and Validate endpoint

### DIFF
--- a/api/src/main/scala/hmda/api/http/LarHttpApi.scala
+++ b/api/src/main/scala/hmda/api/http/LarHttpApi.scala
@@ -2,25 +2,19 @@ package hmda.api.http
 
 import akka.actor.ActorSystem
 import akka.event.LoggingAdapter
-<<<<<<< HEAD
 import akka.http.javadsl.server.directives.RouteDirectives
 import akka.http.scaladsl
-=======
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
->>>>>>> master
 import akka.http.scaladsl.marshalling.ToResponseMarshallable
 import akka.http.scaladsl.model.{ ContentTypes, _ }
 import akka.http.scaladsl.server.Directives._
 import akka.pattern.ask
-<<<<<<< HEAD
 import hmda.parser.fi.lar.LarCsvParser
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.{ ContentTypes, _ }
 import akka.http.scaladsl.server
 import akka.http.scaladsl.server.StandardRoute
-=======
 import akka.stream.ActorMaterializer
->>>>>>> master
 import akka.util.Timeout
 import hmda.api.model.SingleValidationErrorResult
 import hmda.api.protocol.fi.lar.LarProtocol
@@ -63,7 +57,6 @@ trait LarHttpApi extends LarProtocol with ValidationResultProtocol with HmdaCust
         parameters('check.as[String] ? "all") { (checkType) =>
           timedPost {
             entity(as[LoanApplicationRegister]) { lar =>
-<<<<<<< HEAD
               validateRoute(lar, checkType)
             }
           }
@@ -80,20 +73,6 @@ trait LarHttpApi extends LarProtocol with ValidationResultProtocol with HmdaCust
               LarCsvParser(s) match {
                 case Right(lar) => validateRoute(lar, checkType)
                 case Left(errors) => complete(errorsAsResponse(errors))
-=======
-              val larValidation = system.actorSelection("/user/larValidation")
-              val checkMessage = checkType match {
-                case "syntactical" => CheckSyntactical(lar, ValidationContext(None))
-                case "validity" => CheckValidity(lar, ValidationContext(None))
-                case "quality" => CheckQuality(lar, ValidationContext(None))
-                case _ => CheckAll(lar, ValidationContext(None))
-              }
-              onComplete((larValidation ? checkMessage).mapTo[ValidationErrors]) {
-                case Success(xs) =>
-                  complete(ToResponseMarshallable(aggregateErrors(xs)))
-                case Failure(e) =>
-                  complete(HttpResponse(StatusCodes.InternalServerError))
->>>>>>> master
               }
             }
           }
@@ -101,7 +80,6 @@ trait LarHttpApi extends LarProtocol with ValidationResultProtocol with HmdaCust
       }
     }
 
-<<<<<<< HEAD
   def validateRoute(lar: LoanApplicationRegister, checkType: String): scaladsl.server.Route = {
     val larValidation = system.actorSelection("/user/larValidation")
     val checkMessage = checkType match {
@@ -110,13 +88,14 @@ trait LarHttpApi extends LarProtocol with ValidationResultProtocol with HmdaCust
       case "quality" => CheckQuality(lar, ValidationContext(None))
       case _ => CheckAll(lar, ValidationContext(None))
     }
-    onComplete((larValidation ? checkMessage).mapTo[List[ValidationError]]) {
+    onComplete((larValidation ? checkMessage).mapTo[ValidationErrors]) {
       case Success(xs) =>
-        complete(ToResponseMarshallable(xs))
+        complete(ToResponseMarshallable(aggregateErrors(xs)))
       case Failure(e) =>
         complete(HttpResponse(StatusCodes.InternalServerError))
     }
-=======
+  }
+
   def aggregateErrors(validationErrors: ValidationErrors): SingleValidationErrorResult = {
     val errors = validationErrors.errors.groupBy(_.errorType)
     def allOfType(errorType: ValidationErrorType): Seq[String] = {
@@ -128,8 +107,6 @@ trait LarHttpApi extends LarProtocol with ValidationResultProtocol with HmdaCust
       ValidationErrorsSummary(allOfType(Validity)),
       ValidationErrorsSummary(allOfType(Quality))
     )
-
->>>>>>> master
   }
 
   def errorsAsResponse(list: List[String]): HttpResponse = {

--- a/api/src/main/scala/hmda/api/http/LarHttpApi.scala
+++ b/api/src/main/scala/hmda/api/http/LarHttpApi.scala
@@ -2,6 +2,8 @@ package hmda.api.http
 
 import akka.actor.ActorSystem
 import akka.event.LoggingAdapter
+import akka.http.javadsl.server.directives.RouteDirectives
+import akka.http.scaladsl
 import akka.http.scaladsl.marshalling.ToResponseMarshallable
 import akka.stream.ActorMaterializer
 import akka.http.scaladsl.server.Directives._
@@ -10,6 +12,8 @@ import akka.pattern.ask
 import hmda.parser.fi.lar.LarCsvParser
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.{ ContentTypes, _ }
+import akka.http.scaladsl.server
+import akka.http.scaladsl.server.StandardRoute
 import akka.util.Timeout
 import hmda.api.processing.lar.SingleLarValidation.{ CheckAll, CheckQuality, CheckSyntactical, CheckValidity }
 import hmda.api.protocol.fi.lar.LarProtocol
@@ -49,19 +53,7 @@ trait LarHttpApi extends LarProtocol with ValidationResultProtocol with HmdaCust
         parameters('check.as[String] ? "all") { (checkType) =>
           timedPost {
             entity(as[LoanApplicationRegister]) { lar =>
-              val larValidation = system.actorSelection("/user/larValidation")
-              val checkMessage = checkType match {
-                case "syntactical" => CheckSyntactical(lar, ValidationContext(None))
-                case "validity" => CheckValidity(lar, ValidationContext(None))
-                case "quality" => CheckQuality(lar, ValidationContext(None))
-                case _ => CheckAll(lar, ValidationContext(None))
-              }
-              onComplete((larValidation ? checkMessage).mapTo[List[ValidationError]]) {
-                case Success(xs) =>
-                  complete(ToResponseMarshallable(xs))
-                case Failure(e) =>
-                  complete(HttpResponse(StatusCodes.InternalServerError))
-              }
+              validateRoute(lar, checkType)
             }
           }
         }
@@ -75,20 +67,7 @@ trait LarHttpApi extends LarProtocol with ValidationResultProtocol with HmdaCust
           timedPost {
             entity(as[String]) { s =>
               LarCsvParser(s) match {
-                case Right(lar) =>
-                  val larValidation = system.actorSelection("/user/larValidation")
-                  val checkMessage = checkType match {
-                    case "syntactical" => CheckSyntactical(lar, ValidationContext(None))
-                    case "validity" => CheckValidity(lar, ValidationContext(None))
-                    case "quality" => CheckQuality(lar, ValidationContext(None))
-                    case _ => CheckAll(lar, ValidationContext(None))
-                  }
-                  onComplete((larValidation ? checkMessage).mapTo[List[ValidationError]]) {
-                    case Success(xs) =>
-                      complete(ToResponseMarshallable(xs))
-                    case Failure(e) =>
-                      complete(HttpResponse(StatusCodes.InternalServerError))
-                  }
+                case Right(lar) => validateRoute(lar, checkType)
                 case Left(errors) => complete(errorsAsResponse(errors))
               }
             }
@@ -96,6 +75,22 @@ trait LarHttpApi extends LarProtocol with ValidationResultProtocol with HmdaCust
         }
       }
     }
+
+  def validateRoute(lar: LoanApplicationRegister, checkType: String): scaladsl.server.Route = {
+    val larValidation = system.actorSelection("/user/larValidation")
+    val checkMessage = checkType match {
+      case "syntactical" => CheckSyntactical(lar, ValidationContext(None))
+      case "validity" => CheckValidity(lar, ValidationContext(None))
+      case "quality" => CheckQuality(lar, ValidationContext(None))
+      case _ => CheckAll(lar, ValidationContext(None))
+    }
+    onComplete((larValidation ? checkMessage).mapTo[List[ValidationError]]) {
+      case Success(xs) =>
+        complete(ToResponseMarshallable(xs))
+      case Failure(e) =>
+        complete(HttpResponse(StatusCodes.InternalServerError))
+    }
+  }
 
   def errorsAsResponse(list: List[String]): HttpResponse = {
     val errorEntity = HttpEntity(ContentTypes.`application/json`, list.toJson.toString)

--- a/api/src/test/scala/hmda/api/http/InstitutionsHttpApiSpec.scala
+++ b/api/src/test/scala/hmda/api/http/InstitutionsHttpApiSpec.scala
@@ -2,7 +2,7 @@ package hmda.api.http
 
 import java.io.File
 
-import akka.event.{LoggingAdapter, NoLogging}
+import akka.event.{ LoggingAdapter, NoLogging }
 import akka.http.javadsl.server.AuthorizationFailedRejection
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.testkit.ScalatestRouteTest
@@ -15,7 +15,7 @@ import hmda.api.model._
 import hmda.model.fi._
 import hmda.persistence.CommonMessages._
 import hmda.persistence.demo.DemoData
-import org.scalatest.{BeforeAndAfterAll, MustMatchers, WordSpec}
+import org.scalatest.{ BeforeAndAfterAll, MustMatchers, WordSpec }
 import hmda.persistence.institutions.InstitutionPersistence._
 import hmda.persistence.institutions.SubmissionPersistence
 import hmda.persistence.institutions.SubmissionPersistence.UpdateSubmissionStatus

--- a/api/src/test/scala/hmda/api/http/LarHttpApiSpec.scala
+++ b/api/src/test/scala/hmda/api/http/LarHttpApiSpec.scala
@@ -95,6 +95,28 @@ class LarHttpApiSpec extends WordSpec with MustMatchers with ScalatestRouteTest
         responseAs[List[ValidationError]].length mustBe 1
       }
     }
+
+    "return a parsed and validated LAR" in {
+      postWithCfpbHeaders("/lar/parseAndValidate", larCsv) ~> larRoutes ~> check {
+        status mustEqual StatusCodes.OK
+        responseAs[List[ValidationError]] mustBe Nil
+      }
+    }
+
+    "return parsing errors for an invalid LAR" in {
+      postWithCfpbHeaders("/lar/parseAndValidate", invalidLarCsv) ~> larRoutes ~> check {
+        status mustEqual StatusCodes.BAD_REQUEST
+        responseAs[List[String]].length mustBe 2
+      }
+    }
+
+    "return a list of validation errors for an invalid LAR" in {
+      val badLar = lar.copy(agencyCode = 0)
+      postWithCfpbHeaders("/lar/parseAndValidate", badLar.toCSV) ~> larRoutes ~> check {
+        status mustEqual StatusCodes.OK
+        responseAs[List[ValidationError]].length mustBe 1
+      }
+    }
   }
 
   /*

--- a/api/src/test/scala/hmda/api/http/LarHttpApiSpec.scala
+++ b/api/src/test/scala/hmda/api/http/LarHttpApiSpec.scala
@@ -106,10 +106,15 @@ class LarHttpApiSpec extends WordSpec with MustMatchers with ScalatestRouteTest
       }
     }
 
-    "return a parsed and validated LAR" in {
+    "return no errors when parsing and validating a valid LAR" in {
       postWithCfpbHeaders("/lar/parseAndValidate", larCsv) ~> larRoutes ~> check {
         status mustEqual StatusCodes.OK
-        responseAs[List[ValidationError]] mustBe Nil
+        responseAs[SingleValidationErrorResult] mustBe
+          SingleValidationErrorResult(
+            ValidationErrorsSummary(Nil),
+            ValidationErrorsSummary(Nil),
+            ValidationErrorsSummary(Nil)
+          )
       }
     }
 
@@ -124,7 +129,7 @@ class LarHttpApiSpec extends WordSpec with MustMatchers with ScalatestRouteTest
       val badLar = lar.copy(agencyCode = 0)
       postWithCfpbHeaders("/lar/parseAndValidate", badLar.toCSV) ~> larRoutes ~> check {
         status mustEqual StatusCodes.OK
-        responseAs[List[ValidationError]].length mustBe 1
+        responseAs[SingleValidationErrorResult].syntactical.errors.length mustBe 1
       }
     }
   }


### PR DESCRIPTION
Not sure if there's a way to just combine the two routes (maybe with `redirect`?), without just copying and reorganizing the code.  

Closes #501 

