### PR TITLE
Update API Documentation

### DIFF
--- a/Documents/API.md
+++ b/Documents/API.md
@@ -58,12 +58,12 @@ All endpoints below require two headers (see "Authorization" section below for m
       "filings": [
         {
           "id": "2017",
-          "fid": "12345",
+          "institutionId": "12345",
           "status": "not-started"
         },
         {
           "id": "2016",
-          "fid": "12345",
+          "institutionId": "12345",
           "status": "completed"
         }
       ]
@@ -80,7 +80,7 @@ All endpoints below require two headers (see "Authorization" section below for m
    {
      "filing": {
      "id": "2017",
-     "fid": "12345",
+     "institutionId": "12345",
      "status": "not-started"
    },
    "submissions": [
@@ -129,12 +129,12 @@ All endpoints below require two headers (see "Authorization" section below for m
       "filings": [
         {
           "period": "2017",
-          "fid": "12345",
+          "institutionId": "12345",
           "status": "not-started"
         },
         {
           "period": "2016",
-          "fid": "12345",
+          "institutionId": "12345",
           "status": "completed"
         }
       ]

--- a/Documents/API.md
+++ b/Documents/API.md
@@ -4,9 +4,9 @@
 
 * `/`
     * `GET` - Root endpoint, with information about the HMDA Platform service. Used for health checks
-    
+
     Example response, with HTTP code 200:
-    
+
     ```json
     {
       "status": "OK",
@@ -15,14 +15,14 @@
       "host": "localhost"
     }
     ```
-    
-    
+
+
 
 * `/institutions`
     * `GET` - List of Financial Institutions
-    
-    Example response, with HTTP code 200: 
-    
+
+    Example response, with HTTP code 200:
+
     ```json
     {
       "institutions": [
@@ -42,9 +42,9 @@
 
 * `/institutions/<institution>`
     * `GET` - Details for Financial Institution
-    
-    Example response, with HTTP code 200: 
-    
+
+    Example response, with HTTP code 200:
+
     ```json
     {
       "institution": {
@@ -64,15 +64,15 @@
           "status": "completed"
         }
       ]
-    } 
+    }
     ```
-    
-    
+
+
 * `/institutions/<institution>/filings/<period>`
     * `GET` - Details for a filing
-    
+
     Example response, with HTTP code 200:
-    
+
     ```json
    {
      "filing": {
@@ -94,31 +94,31 @@
        "submissionStatus": "created"
      }
    ]
-   } 
+   }
     ```
-    
+
 * `/institutions/<institution>/filings/<period>/submissions`
-    
+
     * `POST` - Create a new submission
-    
+
     Example response, with HTTP code 201:
-    
+
     ```json
     {
         "id": 4,
         "submissionStatus": "created"
     }
     ```
-    
+
 * `/institutions/<institution>/filings/<period>/submissions/<submissionId>`
     * `POST` - Upload HMDA data to submission
-    
-    
+
+
 * `/institutions/<institution>/summary`
     * `GET` - Summary for Financial Institution, including filing information
-    
+
     Example response, with HTTP code 200:
-    
+
     ```json
     {
       "id": "12345",

--- a/Documents/API.md
+++ b/Documents/API.md
@@ -137,3 +137,16 @@
       ]
     }
     ```
+
+## Authorization
+Each endpoint (excluding `/`) is protected by three authorization requirements.
+
+* Requests must include the `CFPB-HMDA-Username` header.
+  * Its value should be the username of the user making the request.
+* Requests must include the `CFPB-HMDA-Institutions` header.
+  * This header will contain the comma-separated list of institution IDs
+    that the user is authorized to view.
+* For requests to institution-specific paths, such as `/institutions/<institution>`
+  and `/institutions/<institution>/summary` (any endpoint in the `/institutions` namespace
+  except `/institutions`), the institution ID requested must match one of the IDs in the
+  `CFPB-HMDA-Institutions` header.

--- a/Documents/API.md
+++ b/Documents/API.md
@@ -16,6 +16,9 @@
     }
     ```
 
+All endpoints below require two headers (see "Authorization" section below for more detail):
+* `CFPB-HMDA-Username`, containing a string
+* `CFPB-HMDA-Institutions`, containing a list of integers
 
 
 * `/institutions`

--- a/Documents/API.md
+++ b/Documents/API.md
@@ -16,7 +16,7 @@
     }
     ```
 
-All endpoints below require two headers (see "Authorization" section below for more detail):
+All endpoints in the `/institutions` namespace require two headers (see "Authorization" section below for more detail):
 * `CFPB-HMDA-Username`, containing a string
 * `CFPB-HMDA-Institutions`, containing a list of integers
 
@@ -142,7 +142,7 @@ All endpoints below require two headers (see "Authorization" section below for m
     ```
 
 ## Authorization
-Each endpoint (excluding `/`) is protected by three authorization requirements.
+Each endpoint that starts with `/institutions` is protected by three authorization requirements.
 
 * Requests must include the `CFPB-HMDA-Username` header.
   * Its value should be the username of the user making the request.
@@ -150,6 +150,8 @@ Each endpoint (excluding `/`) is protected by three authorization requirements.
   * This header will contain the comma-separated list of institution IDs
     that the user is authorized to view.
 * For requests to institution-specific paths, such as `/institutions/<institution>`
-  and `/institutions/<institution>/summary` (any endpoint in the `/institutions` namespace
-  except `/institutions`), the institution ID requested must match one of the IDs in the
-  `CFPB-HMDA-Institutions` header.
+  and `/institutions/<institution>/summary` (any endpoint except `/institutions`),
+  the institution ID requested must match one of the IDs in the `CFPB-HMDA-Institutions`
+  header. (As of 8/18/2016, this requirement is not yet implemented.
+  [#504](https://github.com/cfpb/hmda-platform/issues/504) describes the specifications for
+  this feature.)


### PR DESCRIPTION
Closes #507 
Also removes trailing whitespace.

I updated all instances of `fid` in API responses to to `institutionId`. Is that correct?
