### PR TITLE
update api docs

### DIFF
--- a/Documents/API.md
+++ b/Documents/API.md
@@ -79,7 +79,7 @@ All endpoints in the `/institutions` namespace require two headers (see "Authori
     ```json
    {
      "filing": {
-     "id": "2017",
+     "period": "2017",
      "institutionId": "12345",
      "status": "not-started"
    },

--- a/Documents/API.md
+++ b/Documents/API.md
@@ -57,12 +57,12 @@ All endpoints in the `/institutions` namespace require two headers (see "Authori
     },
       "filings": [
         {
-          "id": "2017",
+          "period": "2017",
           "institutionId": "12345",
           "status": "not-started"
         },
         {
-          "id": "2016",
+          "period": "2016",
           "institutionId": "12345",
           "status": "completed"
         }


### PR DESCRIPTION
Update to reflect that we are using period instead of id to refer to the filing year in the api response.

closes #525 
