### PR TITLE
Increase eventFilter timeout time

### DIFF
--- a/api/src/test/resources/application.conf
+++ b/api/src/test/resources/application.conf
@@ -2,7 +2,7 @@ akka {
   loggers = ["akka.event.Logging$DefaultLogger"]
   stdout-loglevel = "OFF"
   loglevel = "OFF"
-  testKit.filter-leeway = 5s
+  testKit.filter-leeway = 10s
 }
 
 hmda {

--- a/api/src/test/resources/application.conf
+++ b/api/src/test/resources/application.conf
@@ -2,6 +2,7 @@ akka {
   loggers = ["akka.event.Logging$DefaultLogger"]
   stdout-loglevel = "OFF"
   loglevel = "OFF"
+  testKit.filter-leeway = 5s
 }
 
 hmda {


### PR DESCRIPTION
This PR increases the timeout for eventFilter to 5s from 3s in order to avoid random timeouts in travis.

closes #532 