### PR TITLE
Added 405 error route to /latest

### DIFF
--- a/api/src/main/scala/hmda/api/http/InstitutionsHttpApi.scala
+++ b/api/src/main/scala/hmda/api/http/InstitutionsHttpApi.scala
@@ -169,7 +169,11 @@ trait InstitutionsHttpApi extends InstitutionProtocol with ApiErrorProtocol with
             submissionsActor ! Shutdown
             completeWithInternalError(path, error)
         }
-      }
+      } ~
+        timedPost {
+          val errorResponse = ErrorResponse(405, "Method not allowed", path)
+          complete(ToResponseMarshallable(StatusCodes.MethodNotAllowed -> errorResponse))
+        }
     }
 
   val uploadPath =

--- a/api/src/test/scala/hmda/api/http/InstitutionsHttpApiSpec.scala
+++ b/api/src/test/scala/hmda/api/http/InstitutionsHttpApiSpec.scala
@@ -165,6 +165,13 @@ class InstitutionsHttpApiSpec extends WordSpec with MustMatchers with ScalatestR
         responseAs[ErrorResponse] mustBe ErrorResponse(400, "Submission already exists", "institutions/0/filings/2017/submissions/1")
       }
     }
+
+    "return 405 when trying to POST to the /latest endpoint" in {
+      postWithCfpbHeaders("/institutions/0/filings/2017/submissions/latest") ~> institutionsRoutes ~> check {
+        status mustBe StatusCodes.MethodNotAllowed
+        responseAs[ErrorResponse] mustBe ErrorResponse(405, "Method not allowed", "institutions/0/filings/2017/submissions/latest")
+      }
+    }
   }
 
   "Institutions API Authorization and rejection handling" must {


### PR DESCRIPTION
Thanks to some amazing sleuthing from @schbetsy, I found out that `POST`ing to the /latest endpoint will redirect to the `uploadPath` route (as opposed to the `submissionLatestPath`, where we want the request to go).  In the `uploadPath` route, the "latest" String will fail to parse as an Integer, returning a 500 error.  

I decided to hard-code a `405` route instead of changing any path signatures to avoid forcing any changes on the front-end.

Closes #535 