### PR TITLE
Update states doc

### DIFF
--- a/Documents/submission-status.md
+++ b/Documents/submission-status.md
@@ -5,18 +5,30 @@ Every submission will store a `SubmissionStatus` object with the following struc
 * `code`: `Integer`
 * `message`: `String`
 
+For example:
+
+```json
+{
+  "id": 3,
+  "status": {
+    "code": 1,
+    "message": "created"
+  }
+}
+```
+
 In order to track the status of a filing for a financial institution, the following states are captured by the backend:
 
-* `1`: `Created` - The filing has been created and is ready to accept data.
+* `1`: `Created` - The submission for a filing period has been created and is ready to accept data.
 * `2`: `Uploading` - Data is currently being uploaded to the system.
-* `3`: `Uploaded` - Data has finished uploading, is stored in the `HMDA Platform` and is ready to be checked.
-* `4`: `Parsing` - The submitted information is being checked for parsing errors according to the [HMDA File Specification](2017_File_Spec_LAR.csv).
-* `5`: `ParsedWithErrors` - Filed data is incorrectly formatted, requires resubmission.
-* `6`: `Parsed` - Filed data conforms to the requirements and is ready to be validated by the rule engine.
-* `7`: `Validating` - Submitted data is being run through the validation engine that checks for [Edit Checks]().
-* `8`: `ValidatedWithErrors` - There are validation errors in the provided information. Depending on the type of error (syntactical and / or validity) a new submission might be necessary.
-* `9`: `Validated` - Information submitted is valid and the IRS report can be generated.
+* `3`: `Uploaded` - Data has finished uploading, is stored in the `HMDA Platform`, and is ready to be parsed.
+* `4`: `Parsing` - The submitted data is being checked for parsing errors according to the [HMDA File Specification](2017_File_Spec_LAR.csv).
+* `5`: `ParsedWithErrors` - The data is incorrectly formatted and requires resubmission. No syntactical, validity, quality, or macro edit checks will be performed.
+* `6`: `Parsed` - The data conforms to the requirements and is ready to have the syntactical, validity, quality, and macro edit checks performed by the rules engine.
+* `7`: `Validating` - Submitted data is being run through the rules engine that checks for syntactical, validity, quality, and macro edits. All edit checks are performed in this state.
+* `8`: `ValidatedWithErrors` - There are edits (errors) in the provided data. These edits could consist of any combination of syntactical, validity, quality, and macro edits. If syntactical or validity edits exist a resubmission of the data is required. If quality or macro edits exist they will need verification before moving to the next state.
+* `9`: `Validated` - Data submitted passes all syntactical and validity edits and all quality and macro edits, if the existed, have been verified. The data is now considered valid and the IRS report can be generated.
 * `10`: `IRSGenerated` - The IRS report has been generated.
-* `11`: `IRSVerified` - The IRS report has been verified by the financial institution.
-* `12`: `Signed` - The financial institution has certified that the data is correct. This finishes the HMDA filing process.
+* `11`: `IRSVerified` - The IRS report has been verified by the financial institution and the submission can be signed.
+* `12`: `Signed` - The financial institution has certified that the data is correct. This completes the HMDA filing process.
 * `-1`: `Failed` - An error occurred in the process of submitting data, the submission needs to be performed again.

--- a/Documents/submission-status.md
+++ b/Documents/submission-status.md
@@ -7,19 +7,16 @@ Every submission will store a `SubmissionStatus` object with the following struc
 
 In order to track the status of a filing for a financial institution, the following states are captured by the backend:
 
-* `1`: `Created`. The filing has been created and is ready to accept data
-* `2`: `Uploading`. Data is currently being uploaded to the system
-* `3`: `Uploaded`. Data has finished uploading, is stored in the `HMDA Platform` and is ready to be checked
-* `4`: `Parsing`. The submitted information is being checked for parsing errors according to the [HMDA File Specification](2017_File_Spec_LAR.csv).
-* `5`: `Parsed`. Filed data is conformant and is ready to be validated by the rule engine
-* `6`: `ParsedWithErrors`. Filed data is incorrectly formatted, requires resubmission.
-* `7`: `Validating`. Submitted data is being run through the validation engine that checks for [Edit Checks]()
-* `8`: `ValidatedWithErrors`. There are validation errors in the provided information. Depending on the type of error (syntactical and / or validity) a new submission might be necessary
-* `9`: `Validated`. Information submitted is valid and can be `Signed`
-* `10`: `IRSGenerated`. The IRS report has been generated
-* `11`: `IRSVerified`. The IRS report has been verified by the financial institution.
-* `12`: `Signed`. The financial institution has certified that the data is correct. This finishes the HMDA filing process
-* `-1`: `Failed`. An error occurred in the process of submitting data, the submission needs to be performed again
-
-
-
+* `1`: `Created` - The filing has been created and is ready to accept data.
+* `2`: `Uploading` - Data is currently being uploaded to the system.
+* `3`: `Uploaded` - Data has finished uploading, is stored in the `HMDA Platform` and is ready to be checked.
+* `4`: `Parsing` - The submitted information is being checked for parsing errors according to the [HMDA File Specification](2017_File_Spec_LAR.csv).
+* `5`: `ParsedWithErrors` - Filed data is incorrectly formatted, requires resubmission.
+* `6`: `Parsed` - Filed data conforms to the requirements and is ready to be validated by the rule engine.
+* `7`: `Validating` - Submitted data is being run through the validation engine that checks for [Edit Checks]().
+* `8`: `ValidatedWithErrors` - There are validation errors in the provided information. Depending on the type of error (syntactical and / or validity) a new submission might be necessary.
+* `9`: `Validated` - Information submitted is valid and the IRS report can be generated.
+* `10`: `IRSGenerated` - The IRS report has been generated.
+* `11`: `IRSVerified` - The IRS report has been verified by the financial institution.
+* `12`: `Signed` - The financial institution has certified that the data is correct. This finishes the HMDA filing process.
+* `-1`: `Failed` - An error occurred in the process of submitting data, the submission needs to be performed again.

--- a/Documents/submission-status.md
+++ b/Documents/submission-status.md
@@ -26,8 +26,8 @@ In order to track the status of a filing for a financial institution, the follow
 * `5`: `ParsedWithErrors` - The data is incorrectly formatted and requires resubmission. No syntactical, validity, quality, or macro edit checks will be performed.
 * `6`: `Parsed` - The data conforms to the requirements and is ready to have the syntactical, validity, quality, and macro edit checks performed by the rules engine.
 * `7`: `Validating` - Submitted data is being run through the rules engine that checks for syntactical, validity, quality, and macro edits. All edit checks are performed in this state.
-* `8`: `ValidatedWithErrors` - There are edits (errors) in the provided data. These edits could consist of any combination of syntactical, validity, quality, and macro edits. If syntactical or validity edits exist a resubmission of the data is required. If quality or macro edits exist they will need verification before moving to the next state.
-* `9`: `Validated` - Data submitted passes all syntactical and validity edits and all quality and macro edits, if the existed, have been verified. The data is now considered valid and the IRS report can be generated.
+* `8`: `ValidatedWithErrors` - The validation process is complete but there are edits (errors) in the provided data. These edits could consist of any combination of syntactical, validity, quality, and macro edits. If syntactical or validity edits exist a resubmission of the data is required. If quality or macro edits exist they will need verification before moving to the next state.
+* `9`: `Validated` - The validation process is complete and the data submitted passes all syntactical and validity edits and all quality and macro edits, if they existed, have been verified. The data is now considered valid and the IRS report can be generated.
 * `10`: `IRSGenerated` - The IRS report has been generated.
 * `11`: `IRSVerified` - The IRS report has been verified by the financial institution and the submission can be signed.
 * `12`: `Signed` - The financial institution has certified that the data is correct. This completes the HMDA filing process.


### PR DESCRIPTION
The diff doesn't show it very well but this contains
- small changes in wording in state `9`, it isn't ready to be `Signed` until state `11`
- but notice that this proposes to swap states 5 and 6. this is to keep the states consistent in the order of:
  - `<state>ing`
  - `<state>edWithErrors`
  - `<state>ed`

The `Validating` states are currently in this order, `Parsed` states were not.

If the change to the order of the states is ok we'll need to create an issue to update the back-end. If we want to leave it as is, I'll remove that update.
