### PR TITLE
Improve API error messaging

### DIFF
--- a/api/src/main/scala/hmda/api/http/HmdaCustomDirectives.scala
+++ b/api/src/main/scala/hmda/api/http/HmdaCustomDirectives.scala
@@ -29,8 +29,8 @@ trait HmdaCustomDirectives extends ApiErrorProtocol {
       }
       .result()
 
-  def timedGet: Directive0 = get & time
-  def timedPost: Directive0 = post & time
+  def timedGet = get & time & extractUri
+  def timedPost = post & time & extractUri
 
   def headerAuthorize: Directive0 =
     authorize(ctx =>

--- a/api/src/main/scala/hmda/api/http/HmdaCustomDirectives.scala
+++ b/api/src/main/scala/hmda/api/http/HmdaCustomDirectives.scala
@@ -4,7 +4,7 @@ import akka.http.scaladsl.server._
 import akka.http.scaladsl.server.Directives._
 import akka.event.LoggingAdapter
 import akka.http.scaladsl.marshalling.ToResponseMarshallable
-import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.{ StatusCodes, Uri }
 import hmda.api.model.ErrorResponse
 import hmda.api.protocol.processing.ApiErrorProtocol
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
@@ -17,13 +17,13 @@ trait HmdaCustomDirectives extends ApiErrorProtocol {
       .handle {
         case AuthorizationFailedRejection =>
           extractUri { uri =>
-            val errorResponse = ErrorResponse(403, "Unauthorized Access", uri.path.toString)
+            val errorResponse = ErrorResponse(403, "Unauthorized Access", uri.path)
             complete(ToResponseMarshallable(StatusCodes.Forbidden -> errorResponse))
           }
       }
       .handleNotFound {
         extractUri { uri =>
-          val errorResponse = ErrorResponse(404, "Not Found", uri.path.toString)
+          val errorResponse = ErrorResponse(404, "Not Found", uri.path)
           complete(ToResponseMarshallable(StatusCodes.NotFound -> errorResponse))
         }
       }
@@ -61,9 +61,9 @@ trait HmdaCustomDirectives extends ApiErrorProtocol {
 
   }
 
-  def completeWithInternalError(path: String, error: Throwable): StandardRoute = {
+  def completeWithInternalError(uri: Uri, error: Throwable): StandardRoute = {
     log.error(error.getLocalizedMessage)
-    val errorResponse = ErrorResponse(500, "Internal server error", path)
+    val errorResponse = ErrorResponse(500, "Internal server error", uri.path)
     complete(ToResponseMarshallable(StatusCodes.InternalServerError -> errorResponse))
 
   }

--- a/api/src/main/scala/hmda/api/http/HttpApi.scala
+++ b/api/src/main/scala/hmda/api/http/HttpApi.scala
@@ -20,7 +20,7 @@ trait HttpApi extends HmdaApiProtocol with HmdaCustomDirectives {
 
   val rootPath =
     pathSingleSlash {
-      timedGet {
+      timedGet { uri =>
         complete {
           val now = Instant.now.toString
           val host = InetAddress.getLocalHost.getHostName

--- a/api/src/main/scala/hmda/api/http/LarHttpApi.scala
+++ b/api/src/main/scala/hmda/api/http/LarHttpApi.scala
@@ -35,7 +35,7 @@ trait LarHttpApi extends LarProtocol with ValidationResultProtocol with HmdaCust
   val parseLarRoute =
     pathPrefix("lar") {
       path("parse") {
-        timedPost {
+        timedPost { uri =>
           entity(as[String]) { s =>
             LarCsvParser(s) match {
               case Right(lar) => complete(ToResponseMarshallable(lar))
@@ -51,7 +51,7 @@ trait LarHttpApi extends LarProtocol with ValidationResultProtocol with HmdaCust
       path("validate") {
         val path = "lar/validate"
         parameters('check.as[String] ? "all") { (checkType) =>
-          timedPost {
+          timedPost { uri =>
             entity(as[LoanApplicationRegister]) { lar =>
               validateRoute(lar, checkType, path)
             }
@@ -65,7 +65,7 @@ trait LarHttpApi extends LarProtocol with ValidationResultProtocol with HmdaCust
       path("parseAndValidate") {
         val path = "lar/parseAndValidate"
         parameters('check.as[String] ? "all") { (checkType) =>
-          timedPost {
+          timedPost { uri =>
             entity(as[String]) { s =>
               LarCsvParser(s) match {
                 case Right(lar) => validateRoute(lar, checkType, path)

--- a/api/src/main/scala/hmda/api/http/institutions/FilingPaths.scala
+++ b/api/src/main/scala/hmda/api/http/institutions/FilingPaths.scala
@@ -28,11 +28,11 @@ trait FilingPaths extends InstitutionProtocol with ApiErrorProtocol with HmdaCus
 
   implicit val timeout: Timeout
 
+  // institutions/<institutionId>/filings/<period>
   def filingByPeriodPath(institutionId: String) =
     path("filings" / Segment) { period =>
-      val path = s"institutions/$institutionId/filings/$period"
       extractExecutionContext { executor =>
-        timedGet {
+        timedGet { uri =>
           implicit val ec: ExecutionContext = executor
           val supervisor = system.actorSelection("/user/supervisor")
           val fFilings = (supervisor ? FindFilings(FilingPersistence.name, institutionId)).mapTo[ActorRef]
@@ -50,14 +50,14 @@ trait FilingPaths extends InstitutionProtocol with ApiErrorProtocol with HmdaCus
               if (filing.institutionId == institutionId && filing.period == period)
                 complete(ToResponseMarshallable(filingDetails))
               else if (filing.institutionId == institutionId && filing.period != period) {
-                val errorResponse = ErrorResponse(404, s"$period filing not found for institution $institutionId", path)
+                val errorResponse = ErrorResponse(404, s"$period filing not found for institution $institutionId", uri.path.toString)
                 complete(ToResponseMarshallable(StatusCodes.NotFound -> errorResponse))
               } else {
-                val errorResponse = ErrorResponse(404, s"Institution $institutionId not found", path)
+                val errorResponse = ErrorResponse(404, s"Institution $institutionId not found", uri.path.toString)
                 complete(ToResponseMarshallable(StatusCodes.NotFound -> errorResponse))
               }
             case Failure(error) =>
-              completeWithInternalError(path, error)
+              completeWithInternalError(uri.path.toString, error)
           }
         }
       }

--- a/api/src/main/scala/hmda/api/http/institutions/FilingPaths.scala
+++ b/api/src/main/scala/hmda/api/http/institutions/FilingPaths.scala
@@ -50,14 +50,14 @@ trait FilingPaths extends InstitutionProtocol with ApiErrorProtocol with HmdaCus
               if (filing.institutionId == institutionId && filing.period == period)
                 complete(ToResponseMarshallable(filingDetails))
               else if (filing.institutionId == institutionId && filing.period != period) {
-                val errorResponse = ErrorResponse(404, s"$period filing not found for institution $institutionId", uri.path.toString)
+                val errorResponse = ErrorResponse(404, s"$period filing not found for institution $institutionId", uri.path)
                 complete(ToResponseMarshallable(StatusCodes.NotFound -> errorResponse))
               } else {
-                val errorResponse = ErrorResponse(404, s"Institution $institutionId not found", uri.path.toString)
+                val errorResponse = ErrorResponse(404, s"Institution $institutionId not found", uri.path)
                 complete(ToResponseMarshallable(StatusCodes.NotFound -> errorResponse))
               }
             case Failure(error) =>
-              completeWithInternalError(uri.path.toString, error)
+              completeWithInternalError(uri, error)
           }
         }
       }

--- a/api/src/main/scala/hmda/api/http/institutions/InstitutionPaths.scala
+++ b/api/src/main/scala/hmda/api/http/institutions/InstitutionPaths.scala
@@ -47,7 +47,7 @@ trait InstitutionPaths extends InstitutionProtocol with ApiErrorProtocol with Hm
               case Success(institutions) =>
                 val wrappedInstitutions = institutions.map(inst => InstitutionWrapper(inst.id.toString, inst.name, inst.status))
                 complete(ToResponseMarshallable(Institutions(wrappedInstitutions)))
-              case Failure(error) => completeWithInternalError(uri.path.toString, error)
+              case Failure(error) => completeWithInternalError(uri, error)
             }
           }
         }
@@ -74,11 +74,11 @@ trait InstitutionPaths extends InstitutionProtocol with ApiErrorProtocol with Hm
               if (institutionDetails.institution.name != "")
                 complete(ToResponseMarshallable(institutionDetails))
               else {
-                val errorResponse = ErrorResponse(404, s"Institution $institutionId not found", uri.path.toString)
+                val errorResponse = ErrorResponse(404, s"Institution $institutionId not found", uri.path)
                 complete(ToResponseMarshallable(StatusCodes.NotFound -> errorResponse))
               }
             case Failure(error) =>
-              completeWithInternalError(uri.path.toString, error)
+              completeWithInternalError(uri, error)
           }
         }
       }
@@ -105,7 +105,7 @@ trait InstitutionPaths extends InstitutionProtocol with ApiErrorProtocol with Hm
             case Success(summary) =>
               complete(ToResponseMarshallable(summary))
             case Failure(error) =>
-              completeWithInternalError(uri.path.toString, error)
+              completeWithInternalError(uri, error)
           }
         }
       }

--- a/api/src/main/scala/hmda/api/http/institutions/SubmissionPaths.scala
+++ b/api/src/main/scala/hmda/api/http/institutions/SubmissionPaths.scala
@@ -63,17 +63,17 @@ trait SubmissionPaths
                   case Success(submission) =>
                     complete(ToResponseMarshallable(StatusCodes.Created -> submission))
                   case Failure(error) =>
-                    completeWithInternalError(uri.path.toString, error)
+                    completeWithInternalError(uri, error)
                 }
               } else if (!filing.institutionId.isEmpty) {
-                val errorResponse = ErrorResponse(404, s"$period filing not found for institution $institutionId", uri.path.toString)
+                val errorResponse = ErrorResponse(404, s"$period filing not found for institution $institutionId", uri.path)
                 complete(ToResponseMarshallable(StatusCodes.NotFound -> errorResponse))
               } else {
-                val errorResponse = ErrorResponse(404, s"Institution $institutionId not found", uri.path.toString)
+                val errorResponse = ErrorResponse(404, s"Institution $institutionId not found", uri.path)
                 complete(ToResponseMarshallable(StatusCodes.NotFound -> errorResponse))
               }
             case Failure(error) =>
-              completeWithInternalError(uri.path.toString, error)
+              completeWithInternalError(uri, error)
           }
         }
       }
@@ -96,7 +96,7 @@ trait SubmissionPaths
           onComplete(fSubmissions) {
             case Success(submission) =>
               if (submission.id.sequenceNumber == 0) {
-                val errorResponse = ErrorResponse(404, s"No submission found for $institutionId for $period", uri.path.toString)
+                val errorResponse = ErrorResponse(404, s"No submission found for $institutionId for $period", uri.path)
                 complete(ToResponseMarshallable(StatusCodes.NotFound -> errorResponse))
               } else {
                 val statusWrapper = SubmissionStatusWrapper(submission.submissionStatus.code, submission.submissionStatus.message)
@@ -104,7 +104,7 @@ trait SubmissionPaths
                 complete(ToResponseMarshallable(submissionWrapper))
               }
             case Failure(error) =>
-              completeWithInternalError(uri.path.toString, error)
+              completeWithInternalError(uri, error)
           }
         }
       }

--- a/api/src/main/scala/hmda/api/http/institutions/UploadPaths.scala
+++ b/api/src/main/scala/hmda/api/http/institutions/UploadPaths.scala
@@ -36,10 +36,10 @@ trait UploadPaths extends InstitutionProtocol with ApiErrorProtocol with HmdaCus
 
   val splitLines = Framing.delimiter(ByteString("\n"), 2048, allowTruncation = true)
 
+  // institutions/<institutionId>/filings/<period>/submissions/<seqNr>
   def uploadPath(institutionId: String) =
     path("filings" / Segment / "submissions" / IntNumber) { (period, seqNr) =>
-      time {
-        val path = s"institutions/$institutionId/filings/$period/submissions/$seqNr"
+      timedPost { uri =>
         val submissionId = SubmissionId(institutionId, period, seqNr)
         extractExecutionContext { executor =>
           implicit val ec: ExecutionContext = executor

--- a/api/src/main/scala/hmda/api/http/institutions/UploadPaths.scala
+++ b/api/src/main/scala/hmda/api/http/institutions/UploadPaths.scala
@@ -9,6 +9,7 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server._
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+import akka.http.scaladsl.model.Uri.Path
 import akka.pattern.ask
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Framing
@@ -57,12 +58,12 @@ trait UploadPaths extends InstitutionProtocol with ApiErrorProtocol with HmdaCus
           onComplete(fUploadSubmission) {
             case Success((false, processingActor)) =>
               processingActor ! StartUpload
-              uploadFile(processingActor, uploadTimestamp, path)
+              uploadFile(processingActor, uploadTimestamp, uri.path)
             case Success((true, _)) =>
-              val errorResponse = ErrorResponse(400, "Submission already exists", path)
+              val errorResponse = ErrorResponse(400, "Submission already exists", uri.path)
               complete(ToResponseMarshallable(StatusCodes.BadRequest -> errorResponse))
             case Failure(error) =>
-              completeWithInternalError(path, error)
+              completeWithInternalError(uri, error)
           }
         }
       }
@@ -73,7 +74,7 @@ trait UploadPaths extends InstitutionProtocol with ApiErrorProtocol with HmdaCus
     submission.map(_.submissionStatus != Created)
   }
 
-  private def uploadFile(processingActor: ActorRef, uploadTimestamp: Long, path: String): Route = {
+  private def uploadFile(processingActor: ActorRef, uploadTimestamp: Long, path: Path): Route = {
     fileUpload("file") {
       case (metadata, byteSource) if (metadata.fileName.endsWith(".txt")) =>
         val uploadedF = byteSource

--- a/api/src/main/scala/hmda/api/model/ErrorResponse.scala
+++ b/api/src/main/scala/hmda/api/model/ErrorResponse.scala
@@ -1,7 +1,9 @@
 package hmda.api.model
 
+import akka.http.scaladsl.model.Uri.Path
+
 case class ErrorResponse(
   httpStatus: Int,
   message: String,
-  path: String
+  path: Path
 )

--- a/api/src/main/scala/hmda/api/protocol/processing/ApiErrorProtocol.scala
+++ b/api/src/main/scala/hmda/api/protocol/processing/ApiErrorProtocol.scala
@@ -2,7 +2,7 @@ package hmda.api.protocol.processing
 
 import akka.http.scaladsl.model.Uri.Path
 import hmda.api.model.ErrorResponse
-import spray.json.{ DefaultJsonProtocol, JsString, JsValue, RootJsonFormat }
+import spray.json.{ DefaultJsonProtocol, DeserializationException, JsString, JsValue, RootJsonFormat }
 
 trait ApiErrorProtocol extends DefaultJsonProtocol {
   implicit object PathJsonFormat extends RootJsonFormat[Path] {
@@ -10,6 +10,7 @@ trait ApiErrorProtocol extends DefaultJsonProtocol {
     override def read(path: JsValue): Path =
       path match {
         case JsString(s) => Path(s)
+        case _ => throw new DeserializationException("Unable to deserialize")
       }
   }
 

--- a/api/src/main/scala/hmda/api/protocol/processing/ApiErrorProtocol.scala
+++ b/api/src/main/scala/hmda/api/protocol/processing/ApiErrorProtocol.scala
@@ -1,9 +1,17 @@
 package hmda.api.protocol.processing
 
+import akka.http.scaladsl.model.Uri.Path
 import hmda.api.model.ErrorResponse
-import spray.json.DefaultJsonProtocol
+import spray.json.{ DefaultJsonProtocol, JsString, JsValue, RootJsonFormat }
 
 trait ApiErrorProtocol extends DefaultJsonProtocol {
+  implicit object PathJsonFormat extends RootJsonFormat[Path] {
+    override def write(path: Path): JsValue = JsString(path.toString)
+    override def read(path: JsValue): Path =
+      path match {
+        case JsString(s) => Path(s)
+      }
+  }
 
   implicit val apiErrorFormat = jsonFormat3(ErrorResponse.apply)
 

--- a/api/src/test/scala/hmda/api/http/institutions/FilingPathsSpec.scala
+++ b/api/src/test/scala/hmda/api/http/institutions/FilingPathsSpec.scala
@@ -2,7 +2,8 @@ package hmda.api.http.institutions
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.StatusCodes
-import hmda.api.http.{ InstitutionHttpApiSpec }
+import akka.http.scaladsl.model.Uri.Path
+import hmda.api.http.InstitutionHttpApiSpec
 import hmda.api.model.{ ErrorResponse, FilingDetail }
 import hmda.model.fi.{ Filing, NotStarted }
 import hmda.persistence.demo.DemoData
@@ -16,13 +17,17 @@ class FilingPathsSpec extends InstitutionHttpApiSpec with FilingPaths {
       responseAs[FilingDetail] mustBe FilingDetail(filing, DemoData.testSubmissions.reverse)
     }
 
-    getWithCfpbHeaders("/institutions/0/filings/xxxx") ~> institutionsRoutes ~> check {
+    val path1 = Path("/institutions/0/filings/xxxx")
+    println(s"path1 = $path1")
+    getWithCfpbHeaders(path1.toString) ~> institutionsRoutes ~> check {
       status mustBe StatusCodes.NotFound
-      responseAs[ErrorResponse] mustBe ErrorResponse(404, "xxxx filing not found for institution 0", "/institutions/0/filings/xxxx")
+      responseAs[ErrorResponse] mustBe ErrorResponse(404, "xxxx filing not found for institution 0", path1)
     }
-    getWithCfpbHeaders("/institutions/xxxxx/filings/2017") ~> institutionsRoutes ~> check {
+
+    val path2 = Path("/institutions/xxxxx/filings/2017")
+    getWithCfpbHeaders(path2.toString) ~> institutionsRoutes ~> check {
       status mustBe StatusCodes.NotFound
-      responseAs[ErrorResponse] mustBe ErrorResponse(404, "Institution xxxxx not found", "/institutions/xxxxx/filings/2017")
+      responseAs[ErrorResponse] mustBe ErrorResponse(404, "Institution xxxxx not found", path2)
     }
   }
 }

--- a/api/src/test/scala/hmda/api/http/institutions/FilingPathsSpec.scala
+++ b/api/src/test/scala/hmda/api/http/institutions/FilingPathsSpec.scala
@@ -18,11 +18,11 @@ class FilingPathsSpec extends InstitutionHttpApiSpec with FilingPaths {
 
     getWithCfpbHeaders("/institutions/0/filings/xxxx") ~> institutionsRoutes ~> check {
       status mustBe StatusCodes.NotFound
-      responseAs[ErrorResponse] mustBe ErrorResponse(404, "xxxx filing not found for institution 0", "institutions/0/filings/xxxx")
+      responseAs[ErrorResponse] mustBe ErrorResponse(404, "xxxx filing not found for institution 0", "/institutions/0/filings/xxxx")
     }
     getWithCfpbHeaders("/institutions/xxxxx/filings/2017") ~> institutionsRoutes ~> check {
       status mustBe StatusCodes.NotFound
-      responseAs[ErrorResponse] mustBe ErrorResponse(404, "Institution xxxxx not found", "institutions/xxxxx/filings/2017")
+      responseAs[ErrorResponse] mustBe ErrorResponse(404, "Institution xxxxx not found", "/institutions/xxxxx/filings/2017")
     }
   }
 }

--- a/api/src/test/scala/hmda/api/http/institutions/FilingPathsSpec.scala
+++ b/api/src/test/scala/hmda/api/http/institutions/FilingPathsSpec.scala
@@ -18,7 +18,6 @@ class FilingPathsSpec extends InstitutionHttpApiSpec with FilingPaths {
     }
 
     val path1 = Path("/institutions/0/filings/xxxx")
-    println(s"path1 = $path1")
     getWithCfpbHeaders(path1.toString) ~> institutionsRoutes ~> check {
       status mustBe StatusCodes.NotFound
       responseAs[ErrorResponse] mustBe ErrorResponse(404, "xxxx filing not found for institution 0", path1)

--- a/api/src/test/scala/hmda/api/http/institutions/InstitutionsPathsSpec.scala
+++ b/api/src/test/scala/hmda/api/http/institutions/InstitutionsPathsSpec.scala
@@ -35,7 +35,7 @@ class InstitutionsPathsSpec extends InstitutionHttpApiSpec {
       }
       getWithCfpbHeaders("/institutions/xxxxx") ~> institutionsRoutes ~> check {
         status mustBe StatusCodes.NotFound
-        responseAs[ErrorResponse] mustBe ErrorResponse(404, "Institution xxxxx not found", "institutions/xxxxx")
+        responseAs[ErrorResponse] mustBe ErrorResponse(404, "Institution xxxxx not found", "/institutions/xxxxx")
       }
     }
 

--- a/api/src/test/scala/hmda/api/http/institutions/InstitutionsPathsSpec.scala
+++ b/api/src/test/scala/hmda/api/http/institutions/InstitutionsPathsSpec.scala
@@ -3,7 +3,8 @@ package hmda.api.http.institutions
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
-import hmda.api.http.{ InstitutionHttpApiSpec }
+import akka.http.scaladsl.model.Uri.Path
+import hmda.api.http.InstitutionHttpApiSpec
 import hmda.api.model._
 import hmda.model.institution.Institution
 import hmda.persistence.demo.DemoData
@@ -33,9 +34,10 @@ class InstitutionsPathsSpec extends InstitutionHttpApiSpec {
         val filings = DemoData.testFilings.filter(f => f.institutionId == institution.id.toString)
         responseAs[InstitutionDetail] mustBe InstitutionDetail(institutionWrapped, filings.reverse)
       }
-      getWithCfpbHeaders("/institutions/xxxxx") ~> institutionsRoutes ~> check {
+      val path = Path("/institutions/xxxxx")
+      getWithCfpbHeaders(path.toString) ~> institutionsRoutes ~> check {
         status mustBe StatusCodes.NotFound
-        responseAs[ErrorResponse] mustBe ErrorResponse(404, "Institution xxxxx not found", "/institutions/xxxxx")
+        responseAs[ErrorResponse] mustBe ErrorResponse(404, "Institution xxxxx not found", path)
       }
     }
 

--- a/api/src/test/scala/hmda/api/http/institutions/SubmissionPathsSpec.scala
+++ b/api/src/test/scala/hmda/api/http/institutions/SubmissionPathsSpec.scala
@@ -3,6 +3,7 @@ package hmda.api.http.institutions
 import akka.actor.ActorRef
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.Uri.Path
 import akka.http.scaladsl.server.MethodRejection
 import akka.pattern.ask
 import hmda.api.http.InstitutionHttpApiSpec
@@ -33,9 +34,10 @@ class SubmissionPathsSpec extends InstitutionHttpApiSpec {
     }
 
     "return not found when looking for a latest submission for non existent institution" in {
-      getWithCfpbHeaders("/institutions/xxxxx/filings/2017/submissions/latest") ~> institutionsRoutes ~> check {
+      val path = Path("/institutions/xxxxx/filings/2017/submissions/latest")
+      getWithCfpbHeaders(path.toString) ~> institutionsRoutes ~> check {
         status mustBe StatusCodes.NotFound
-        val error = ErrorResponse(404, "No submission found for xxxxx for 2017", "/institutions/xxxxx/filings/2017/submissions/latest")
+        val error = ErrorResponse(404, "No submission found for xxxxx for 2017", path)
         responseAs[ErrorResponse] mustBe error
       }
 
@@ -50,16 +52,18 @@ class SubmissionPathsSpec extends InstitutionHttpApiSpec {
     }
 
     "fail creating a new submission for a non existent institution" in {
-      postWithCfpbHeaders("/institutions/xxxxx/filings/2017/submissions") ~> institutionsRoutes ~> check {
+      val path: Path = Path("/institutions/xxxxx/filings/2017/submissions")
+      postWithCfpbHeaders(path.toString) ~> institutionsRoutes ~> check {
         status mustBe StatusCodes.NotFound
-        responseAs[ErrorResponse] mustBe ErrorResponse(404, "Institution xxxxx not found", "/institutions/xxxxx/filings/2017/submissions")
+        responseAs[ErrorResponse] mustBe ErrorResponse(404, "Institution xxxxx not found", path)
       }
     }
 
     "fail creating a new submission for a non existent filing period" in {
-      postWithCfpbHeaders("/institutions/0/filings/2001/submissions") ~> institutionsRoutes ~> check {
+      val path = Path("/institutions/0/filings/2001/submissions")
+      postWithCfpbHeaders(path.toString) ~> institutionsRoutes ~> check {
         status mustBe StatusCodes.NotFound
-        responseAs[ErrorResponse] mustBe ErrorResponse(404, "2001 filing not found for institution 0", "/institutions/0/filings/2001/submissions")
+        responseAs[ErrorResponse] mustBe ErrorResponse(404, "2001 filing not found for institution 0", path)
       }
     }
   }

--- a/api/src/test/scala/hmda/api/http/institutions/SubmissionPathsSpec.scala
+++ b/api/src/test/scala/hmda/api/http/institutions/SubmissionPathsSpec.scala
@@ -35,7 +35,7 @@ class SubmissionPathsSpec extends InstitutionHttpApiSpec {
     "return not found when looking for a latest submission for non existent institution" in {
       getWithCfpbHeaders("/institutions/xxxxx/filings/2017/submissions/latest") ~> institutionsRoutes ~> check {
         status mustBe StatusCodes.NotFound
-        val error = ErrorResponse(404, "No submission found for xxxxx for 2017", "institutions/xxxxx/filings/2017/submissions/latest")
+        val error = ErrorResponse(404, "No submission found for xxxxx for 2017", "/institutions/xxxxx/filings/2017/submissions/latest")
         responseAs[ErrorResponse] mustBe error
       }
 
@@ -52,14 +52,14 @@ class SubmissionPathsSpec extends InstitutionHttpApiSpec {
     "fail creating a new submission for a non existent institution" in {
       postWithCfpbHeaders("/institutions/xxxxx/filings/2017/submissions") ~> institutionsRoutes ~> check {
         status mustBe StatusCodes.NotFound
-        responseAs[ErrorResponse] mustBe ErrorResponse(404, "Institution xxxxx not found", "institutions/xxxxx/filings/2017/submissions")
+        responseAs[ErrorResponse] mustBe ErrorResponse(404, "Institution xxxxx not found", "/institutions/xxxxx/filings/2017/submissions")
       }
     }
 
     "fail creating a new submission for a non existent filing period" in {
       postWithCfpbHeaders("/institutions/0/filings/2001/submissions") ~> institutionsRoutes ~> check {
         status mustBe StatusCodes.NotFound
-        responseAs[ErrorResponse] mustBe ErrorResponse(404, "2001 filing not found for institution 0", "institutions/0/filings/2001/submissions")
+        responseAs[ErrorResponse] mustBe ErrorResponse(404, "2001 filing not found for institution 0", "/institutions/0/filings/2001/submissions")
       }
     }
   }

--- a/api/src/test/scala/hmda/api/http/institutions/UploadPathsSpec.scala
+++ b/api/src/test/scala/hmda/api/http/institutions/UploadPathsSpec.scala
@@ -4,6 +4,7 @@ import scala.concurrent.duration._
 import akka.actor.ActorRef
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+import akka.http.scaladsl.model.Uri.Path
 import hmda.api.http.InstitutionHttpApiSpec
 import hmda.api.model.ErrorResponse
 import hmda.model.fi.{ Signed, Submission, SubmissionId }
@@ -33,17 +34,15 @@ class UploadPathsSpec extends InstitutionHttpApiSpec with UploadPaths {
     }
 
     "return 400 when trying to upload the wrong file" in {
-      val badContent = "qdemd"
-      val file = multiPartFile(badContent, "sample.dat")
-      postWithCfpbHeaders("/institutions/0/filings/2017/submissions/1", file) ~> institutionsRoutes ~> check {
+      val file = multiPartFile("bad file content", "sample.dat")
+      val path = Path("/institutions/0/filings/2017/submissions/1")
+      postWithCfpbHeaders(path.toString, file) ~> institutionsRoutes ~> check {
         status mustBe StatusCodes.BadRequest
-        responseAs[ErrorResponse] mustBe ErrorResponse(400, "Invalid File Format", "institutions/0/filings/2017/submissions/1")
+        responseAs[ErrorResponse] mustBe ErrorResponse(400, "Invalid File Format", path)
       }
     }
 
     "return 400 when trying to upload to a completed submission" in {
-      val badContent = "qdemd"
-      val file = multiPartFile(badContent, "sample.txt")
       val supervisor = system.actorSelection("/user/supervisor")
       val fSubmissionsActor = (supervisor ? FindSubmissions(SubmissionPersistence.name, "0", "2017")).mapTo[ActorRef]
 
@@ -51,13 +50,14 @@ class UploadPathsSpec extends InstitutionHttpApiSpec with UploadPaths {
         s <- fSubmissionsActor
       } yield {
         s ! UpdateSubmissionStatus(SubmissionId("0", "2017", 1), Signed)
-
         val submission = Await.result((s ? GetSubmissionById(SubmissionId("0", "2017", 1))).mapTo[Submission], 5.seconds)
         submission.submissionStatus mustBe Signed
 
-        postWithCfpbHeaders("/institutions/0/filings/2017/submissions/1", file) ~> institutionsRoutes ~> check {
+        val file = multiPartFile("bad file content", "sample.txt")
+        val path = Path("/institutions/0/filings/2017/submissions/1")
+        postWithCfpbHeaders(path.toString, file) ~> institutionsRoutes ~> check {
           status mustBe StatusCodes.BadRequest
-          responseAs[ErrorResponse] mustBe ErrorResponse(400, "Submission already exists", "institutions/0/filings/2017/submissions/1")
+          responseAs[ErrorResponse] mustBe ErrorResponse(400, "Submission already exists", path)
         }
       }
     }

--- a/api/src/test/scala/hmda/api/model/ModelGenerators.scala
+++ b/api/src/test/scala/hmda/api/model/ModelGenerators.scala
@@ -1,6 +1,7 @@
 package hmda.api.model
 
 import java.util.Calendar
+import akka.http.scaladsl.model.Uri.Path
 import hmda.model.fi._
 import hmda.model.institution.InstitutionStatus.{ Active, Inactive }
 import hmda.model.institution._
@@ -116,7 +117,7 @@ trait ModelGenerators {
       status <- Gen.oneOf(200, 201, 400, 500)
       message <- Gen.alphaStr
       path <- Gen.alphaStr
-    } yield ErrorResponse(status, message, path)
+    } yield ErrorResponse(status, message, Path(path))
   }
 
   implicit def larEditResultGen: Gen[LarEditResult] = {


### PR DESCRIPTION
This PR has several updates: 

- In the upload path, use the same directive that the other endpoints do (`timedPost`). So now it only responds to `POST`, which matches the specification. Previously, it would respond to any HTTP verb (e.g. `PUT`, `PATCH`), not just `POST`. 
- Update the ErrorResponse object so that the `path` field uses a `Path` object, instead of a simple `String`. This makes error responses more type safe.
- Update the `completeWithInternalError` method to use a `Uri` object as a parameter, instead of the `path` string.
- Extract the uri of each request within its endpoint, rather than reconstructing a path string from path parameters. This allows us to use `Uri` and `Path` objects instead of `String`s in several places.