### PR TITLE
Test that Submission Statuses get Updated

### DIFF
--- a/persistence/src/test/scala/hmda/persistence/processing/LocalHmdaEventProcessorSpec.scala
+++ b/persistence/src/test/scala/hmda/persistence/processing/LocalHmdaEventProcessorSpec.scala
@@ -79,6 +79,7 @@ class LocalHmdaEventProcessorSpec extends ActorSpec {
     "process ParsingStarted message from event stream" in {
       val msg = s"Parsing started for submission $submissionId"
       checkEventStreamMessage(msg, ParsingStarted(submissionId))
+      checkSubmissionStatus(Parsing)
     }
 
     "process ParsingCompleted message from event stream" in {
@@ -90,19 +91,19 @@ class LocalHmdaEventProcessorSpec extends ActorSpec {
     "process ParsingCompletedWithErrors message from event stream" in {
       val msg = s"Parsing completed with errors for submission $submissionId"
       checkEventStreamMessage(msg, ParsingCompletedWithErrors(submissionId))
-      //checkSubmissionStatus(ParsedWithErrors)
-      // TODO: improve checkSubmissionStatus so that this test passes consistently
-      //   and we can add checkSubmissionStatus to all specs in this file
+      checkSubmissionStatus(ParsedWithErrors)
     }
 
     "process ValidationStarted message from event stream" in {
       val msg = s"Validation started for $submissionId"
       checkEventStreamMessage(msg, ValidationStarted(submissionId))
+      checkSubmissionStatus(Validating)
     }
 
     "process ValidationCompletedWithErrors from event stream" in {
       val msg = s"validation completed with errors for submission $submissionId"
       checkEventStreamMessage(msg, ValidationCompletedWithErrors(submissionId))
+      checkSubmissionStatus(ValidatedWithErrors)
     }
 
     "process ValidationCompleted from event stream" in {

--- a/persistence/src/test/scala/hmda/persistence/processing/LocalHmdaEventProcessorSpec.scala
+++ b/persistence/src/test/scala/hmda/persistence/processing/LocalHmdaEventProcessorSpec.scala
@@ -62,32 +62,32 @@ class LocalHmdaEventProcessorSpec extends ActorSpec {
 
   "Event processor" must {
 
-    "process upload start message from event stream" in {
+    "process UploadStarted message from event stream" in {
       val msg = s"Upload started for submission $submissionId"
       val status = UploadStarted(submissionId)
       checkEventStreamMessage(msg, status)
       checkSubmissionStatus(Uploading)
     }
 
-    "process upload completed message from event stream" in {
+    "process UploadCompleted message from event stream" in {
       val submissionId = SubmissionId("testUploadComp", "2017", 1)
       val size = 10
       val msg = s"$size lines uploaded for submission $submissionId"
       checkEventStreamMessage(msg, UploadCompleted(size, submissionId))
     }
 
-    "process parse started message from event stream" in {
+    "process ParsingStarted message from event stream" in {
       val msg = s"Parsing started for submission $submissionId"
       checkEventStreamMessage(msg, ParsingStarted(submissionId))
     }
 
-    "process parse completed message from event stream" in {
+    "process ParsingCompleted message from event stream" in {
       val submissionId = SubmissionId("testParseComp", "2017", 1)
       val msg = s"Parsing completed for $submissionId"
       checkEventStreamMessage(msg, ParsingCompleted(submissionId))
     }
 
-    "process 'parsingCompletedWithErrors' message from event stream" in {
+    "process ParsingCompletedWithErrors message from event stream" in {
       val msg = s"Parsing completed with errors for submission $submissionId"
       checkEventStreamMessage(msg, ParsingCompletedWithErrors(submissionId))
       //checkSubmissionStatus(ParsedWithErrors)
@@ -95,17 +95,17 @@ class LocalHmdaEventProcessorSpec extends ActorSpec {
       //   and we can add checkSubmissionStatus to all specs in this file
     }
 
-    "process validation started message from event stream" in {
+    "process ValidationStarted message from event stream" in {
       val msg = s"Validation started for $submissionId"
       checkEventStreamMessage(msg, ValidationStarted(submissionId))
     }
 
-    "process validation completed with errors from event stream" in {
+    "process ValidationCompletedWithErrors from event stream" in {
       val msg = s"validation completed with errors for submission $submissionId"
       checkEventStreamMessage(msg, ValidationCompletedWithErrors(submissionId))
     }
 
-    "process validation completed from event stream" in {
+    "process ValidationCompleted from event stream" in {
       val msg = s"Validation completed for submission $submissionId"
       checkEventStreamMessage(msg, ValidationCompleted(submissionId))
       checkSubmissionStatus(Validated)

--- a/persistence/src/test/scala/hmda/persistence/processing/LocalHmdaEventProcessorSpec.scala
+++ b/persistence/src/test/scala/hmda/persistence/processing/LocalHmdaEventProcessorSpec.scala
@@ -113,7 +113,7 @@ class LocalHmdaEventProcessorSpec extends ActorSpec {
     }
   }
 
-  def checkSubmissionStatus(status: SubmissionStatus): Assertion = {
+  private def checkSubmissionStatus(status: SubmissionStatus): Assertion = {
     val fSubmissions = (supervisor ? FindSubmissions(SubmissionPersistence.name, submissionId.institutionId, submissionId.period)).mapTo[ActorRef]
     val subActor = Await.result(fSubmissions, 5.seconds)
     val submissionSeq = Await.result((subActor ? GetState).mapTo[Seq[Submission]], 5.seconds)


### PR DESCRIPTION
Closes #582 

Thanks to @nickgrippin (he fixed `checkSubmissionStatus` in #586), I just needed to check that submission statuses get updated properly in several specs.