### PR TITLE
Non-existent submission upload fix

### DIFF
--- a/api/src/main/scala/hmda/api/http/institutions/UploadPaths.scala
+++ b/api/src/main/scala/hmda/api/http/institutions/UploadPaths.scala
@@ -59,7 +59,7 @@ trait UploadPaths extends InstitutionProtocol with ApiErrorProtocol with HmdaCus
               processingActor ! StartUpload
               uploadFile(processingActor, uploadTimestamp, path)
             case Success((true, _)) =>
-              val errorResponse = ErrorResponse(404, s"Submission $seqNr not available for upload", path)
+              val errorResponse = ErrorResponse(400, s"Submission $seqNr not available for upload", path)
               complete(ToResponseMarshallable(StatusCodes.BadRequest -> errorResponse))
             case Failure(error) =>
               completeWithInternalError(path, error)

--- a/api/src/main/scala/hmda/api/http/institutions/UploadPaths.scala
+++ b/api/src/main/scala/hmda/api/http/institutions/UploadPaths.scala
@@ -59,7 +59,7 @@ trait UploadPaths extends InstitutionProtocol with ApiErrorProtocol with HmdaCus
               processingActor ! StartUpload
               uploadFile(processingActor, uploadTimestamp, path)
             case Success((true, _)) =>
-              val errorResponse = ErrorResponse(400, "Submission already exists", path)
+              val errorResponse = ErrorResponse(404, s"Submission $seqNr not available for upload", path)
               complete(ToResponseMarshallable(StatusCodes.BadRequest -> errorResponse))
             case Failure(error) =>
               completeWithInternalError(path, error)

--- a/api/src/main/scala/hmda/api/http/institutions/UploadPaths.scala
+++ b/api/src/main/scala/hmda/api/http/institutions/UploadPaths.scala
@@ -51,14 +51,14 @@ trait UploadPaths extends InstitutionProtocol with ApiErrorProtocol with HmdaCus
           val fUploadSubmission = for {
             p <- fProcessingActor
             s <- fSubmissionsActor
-            fIsSubmissionOverwrite <- checkSubmissionOverwrite(s, submissionId)
-          } yield (fIsSubmissionOverwrite, p)
+            fIsSubmissionCreated <- checkSubmissionIsCreated(s, submissionId)
+          } yield (fIsSubmissionCreated, p)
 
           onComplete(fUploadSubmission) {
-            case Success((false, processingActor)) =>
+            case Success((true, processingActor)) =>
               processingActor ! StartUpload
               uploadFile(processingActor, uploadTimestamp, path)
-            case Success((true, _)) =>
+            case Success((false, _)) =>
               val errorResponse = ErrorResponse(400, s"Submission $seqNr not available for upload", path)
               complete(ToResponseMarshallable(StatusCodes.BadRequest -> errorResponse))
             case Failure(error) =>
@@ -68,9 +68,9 @@ trait UploadPaths extends InstitutionProtocol with ApiErrorProtocol with HmdaCus
       }
     }
 
-  private def checkSubmissionOverwrite(submissionsActor: ActorRef, submissionId: SubmissionId)(implicit ec: ExecutionContext): Future[Boolean] = {
+  private def checkSubmissionIsCreated(submissionsActor: ActorRef, submissionId: SubmissionId)(implicit ec: ExecutionContext): Future[Boolean] = {
     val submission = (submissionsActor ? GetSubmissionById(submissionId)).mapTo[Submission]
-    submission.map(_.submissionStatus != Created)
+    submission.map(_.submissionStatus == Created)
   }
 
   private def uploadFile(processingActor: ActorRef, uploadTimestamp: Long, path: String): Route = {

--- a/api/src/test/scala/hmda/api/http/institutions/UploadPathsSpec.scala
+++ b/api/src/test/scala/hmda/api/http/institutions/UploadPathsSpec.scala
@@ -15,17 +15,18 @@ import akka.pattern.ask
 import scala.concurrent.Await
 
 class UploadPathsSpec extends InstitutionHttpApiSpec with UploadPaths {
+  val csv = "1|0123456789|9|201301171330|2013|99-9999999|900|MIKES SMALL BANK   XXXXXXXXXXX|1234 Main St       XXXXXXXXXXXXXXXXXXXXX|Sacramento         XXXXXX|CA|99999-9999|MIKES SMALL INC    XXXXXXXXXXX|1234 Kearney St    XXXXXXXXXXXXXXXXXXXXX|San Francisco      XXXXXX|CA|99999-1234|Mrs. Krabappel     XXXXXXXXXXX|916-999-9999|999-753-9999|krabappel@gmail.comXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\n" +
+    "2|0123456789|9|ABCDEFGHIJKLMNOPQRSTUVWXY|20130117|4|3|2|1|10000|1|5|20130119|06920|06|034|0100.01|4|5|7|4|3|2|1|8|7|6|5|4|1|2|9000|0|9|8|7|01.05|2|4\n" +
+    "2|0123456789|9|ABCDEFGHIJKLMNOPQRSTUVWXY|20130117|4|3|2|1|10000|1|5|20130119|06920|06|034|0100.01|4|5|7|4|3|2|1|8|7|6|5|4|1|2|9000|0|9|8|7|01.05|2|4\n" +
+    "2|0123456789|9|ABCDEFGHIJKLMNOPQRSTUVWXY|20130117|4|3|2|1|10000|1|5|20130119|06920|06|034|0100.01|4|5|7|4|3|2|1|8|7|6|5|4|1|2|9000|0|9|8|7|01.05|2|4"
+  val file = multiPartFile(csv, "sample.txt")
+
+  val badContent = "qdemd"
+  val badFile = multiPartFile(badContent, "sample.dat")
 
   "Upload Paths" must {
 
     "return proper response when uploading a HMDA file" in {
-      val csv = "1|0123456789|9|201301171330|2013|99-9999999|900|MIKES SMALL BANK   XXXXXXXXXXX|1234 Main St       XXXXXXXXXXXXXXXXXXXXX|Sacramento         XXXXXX|CA|99999-9999|MIKES SMALL INC    XXXXXXXXXXX|1234 Kearney St    XXXXXXXXXXXXXXXXXXXXX|San Francisco      XXXXXX|CA|99999-1234|Mrs. Krabappel     XXXXXXXXXXX|916-999-9999|999-753-9999|krabappel@gmail.comXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\n" +
-        "2|0123456789|9|ABCDEFGHIJKLMNOPQRSTUVWXY|20130117|4|3|2|1|10000|1|5|20130119|06920|06|034|0100.01|4|5|7|4|3|2|1|8|7|6|5|4|1|2|9000|0|9|8|7|01.05|2|4\n" +
-        "2|0123456789|9|ABCDEFGHIJKLMNOPQRSTUVWXY|20130117|4|3|2|1|10000|1|5|20130119|06920|06|034|0100.01|4|5|7|4|3|2|1|8|7|6|5|4|1|2|9000|0|9|8|7|01.05|2|4\n" +
-        "2|0123456789|9|ABCDEFGHIJKLMNOPQRSTUVWXY|20130117|4|3|2|1|10000|1|5|20130119|06920|06|034|0100.01|4|5|7|4|3|2|1|8|7|6|5|4|1|2|9000|0|9|8|7|01.05|2|4"
-
-      val file = multiPartFile(csv, "sample.txt")
-
       postWithCfpbHeaders("/institutions/0/filings/2017/submissions/1", file) ~> institutionsRoutes ~> check {
         status mustBe StatusCodes.Accepted
         responseAs[String] mustBe "uploaded"
@@ -33,17 +34,20 @@ class UploadPathsSpec extends InstitutionHttpApiSpec with UploadPaths {
     }
 
     "return 400 when trying to upload the wrong file" in {
-      val badContent = "qdemd"
-      val file = multiPartFile(badContent, "sample.dat")
-      postWithCfpbHeaders("/institutions/0/filings/2017/submissions/1", file) ~> institutionsRoutes ~> check {
+      postWithCfpbHeaders("/institutions/0/filings/2017/submissions/1", badFile) ~> institutionsRoutes ~> check {
         status mustBe StatusCodes.BadRequest
         responseAs[ErrorResponse] mustBe ErrorResponse(400, "Invalid File Format", "institutions/0/filings/2017/submissions/1")
       }
     }
 
-    "return 400 when trying to upload to a completed submission" in {
-      val badContent = "qdemd"
-      val file = multiPartFile(badContent, "sample.txt")
+    "return a 404 when trying to upload to a non-existant submission" in {
+      postWithCfpbHeaders("/institutions/0/filings/2017/submissions/987654321", file) ~> institutionsRoutes ~> check {
+        status mustBe StatusCodes.BadRequest
+        responseAs[ErrorResponse] mustBe ErrorResponse(404, "Submission 987654321 not available for upload", "institutions/0/filings/2017/submissions/987654321")
+      }
+    }
+
+    "return 404 when trying to upload to a completed submission" in {
       val supervisor = system.actorSelection("/user/supervisor")
       val fSubmissionsActor = (supervisor ? FindSubmissions(SubmissionPersistence.name, "0", "2017")).mapTo[ActorRef]
 
@@ -57,7 +61,7 @@ class UploadPathsSpec extends InstitutionHttpApiSpec with UploadPaths {
 
         postWithCfpbHeaders("/institutions/0/filings/2017/submissions/1", file) ~> institutionsRoutes ~> check {
           status mustBe StatusCodes.BadRequest
-          responseAs[ErrorResponse] mustBe ErrorResponse(400, "Submission already exists", "institutions/0/filings/2017/submissions/1")
+          responseAs[ErrorResponse] mustBe ErrorResponse(404, "Submission 1 not available for upload", "institutions/0/filings/2017/submissions/1")
         }
       }
     }

--- a/api/src/test/scala/hmda/api/http/institutions/UploadPathsSpec.scala
+++ b/api/src/test/scala/hmda/api/http/institutions/UploadPathsSpec.scala
@@ -40,14 +40,14 @@ class UploadPathsSpec extends InstitutionHttpApiSpec with UploadPaths {
       }
     }
 
-    "return a 404 when trying to upload to a non-existant submission" in {
+    "return a 400 when trying to upload to a non-existant submission" in {
       postWithCfpbHeaders("/institutions/0/filings/2017/submissions/987654321", file) ~> institutionsRoutes ~> check {
         status mustBe StatusCodes.BadRequest
         responseAs[ErrorResponse] mustBe ErrorResponse(400, "Submission 987654321 not available for upload", "institutions/0/filings/2017/submissions/987654321")
       }
     }
 
-    "return 404 when trying to upload to a completed submission" in {
+    "return 400 when trying to upload to a completed submission" in {
       val supervisor = system.actorSelection("/user/supervisor")
       val fSubmissionsActor = (supervisor ? FindSubmissions(SubmissionPersistence.name, "0", "2017")).mapTo[ActorRef]
 

--- a/api/src/test/scala/hmda/api/http/institutions/UploadPathsSpec.scala
+++ b/api/src/test/scala/hmda/api/http/institutions/UploadPathsSpec.scala
@@ -43,7 +43,7 @@ class UploadPathsSpec extends InstitutionHttpApiSpec with UploadPaths {
     "return a 404 when trying to upload to a non-existant submission" in {
       postWithCfpbHeaders("/institutions/0/filings/2017/submissions/987654321", file) ~> institutionsRoutes ~> check {
         status mustBe StatusCodes.BadRequest
-        responseAs[ErrorResponse] mustBe ErrorResponse(404, "Submission 987654321 not available for upload", "institutions/0/filings/2017/submissions/987654321")
+        responseAs[ErrorResponse] mustBe ErrorResponse(400, "Submission 987654321 not available for upload", "institutions/0/filings/2017/submissions/987654321")
       }
     }
 
@@ -61,7 +61,7 @@ class UploadPathsSpec extends InstitutionHttpApiSpec with UploadPaths {
 
         postWithCfpbHeaders("/institutions/0/filings/2017/submissions/1", file) ~> institutionsRoutes ~> check {
           status mustBe StatusCodes.BadRequest
-          responseAs[ErrorResponse] mustBe ErrorResponse(404, "Submission 1 not available for upload", "institutions/0/filings/2017/submissions/1")
+          responseAs[ErrorResponse] mustBe ErrorResponse(400, "Submission 1 not available for upload", "institutions/0/filings/2017/submissions/1")
         }
       }
     }

--- a/persistence/src/main/scala/hmda/persistence/institutions/SubmissionPersistence.scala
+++ b/persistence/src/main/scala/hmda/persistence/institutions/SubmissionPersistence.scala
@@ -1,7 +1,7 @@
 package hmda.persistence.institutions
 
 import akka.actor.{ ActorRef, ActorSystem, Props }
-import hmda.model.fi.{ Created, Submission, SubmissionId, SubmissionStatus }
+import hmda.model.fi._
 import hmda.persistence.CommonMessages.{ Command, Event, GetState }
 import hmda.persistence.HmdaPersistentActor
 import hmda.persistence.institutions.SubmissionPersistence._
@@ -69,11 +69,11 @@ class SubmissionPersistence(institutionId: String, period: String) extends HmdaP
       }
 
     case GetSubmissionById(id) =>
-      val submission = state.submissions.find(s => s.id == id).getOrElse(Submission())
+      val submission = state.submissions.find(s => s.id == id).getOrElse(Submission(SubmissionId(), Failed("No submission found")))
       sender() ! submission
 
     case GetLatestSubmission =>
-      val latest = state.submissions.headOption.getOrElse(Submission())
+      val latest = state.submissions.headOption.getOrElse(Submission(SubmissionId(), Failed("No submission found")))
       sender() ! latest
 
     case GetState =>


### PR DESCRIPTION
The `SubmissionPersistence` actor was returning a `Submission` with the `Created` status when it failed to find a submission.  This behavior is changed so that it now returns a `Submission` object with a `Failed` status.

If anyone feels like this overloads the `Failed` status message, I can create a new status (something like `Not Found`).

Closes #592