### PR TITLE
Remove any trailing newlines before parsing

### DIFF
--- a/parser/src/main/scala/hmda/parser/fi/lar/LarCsvParser.scala
+++ b/parser/src/main/scala/hmda/parser/fi/lar/LarCsvParser.scala
@@ -9,7 +9,7 @@ import scala.util.{ Failure, Success, Try }
 
 object LarCsvParser {
   def apply(s: String): Either[List[String], LoanApplicationRegister] = {
-    val values = s.split('|').map(_.trim)
+    val values = s.trim.split('|').map(_.trim)
     val parserResults = checkLar(values.toList)
     parserResults match {
       case scalaz.Success(convertedValues) => {

--- a/parser/src/main/scala/hmda/parser/fi/ts/TsCsvParser.scala
+++ b/parser/src/main/scala/hmda/parser/fi/ts/TsCsvParser.scala
@@ -8,7 +8,7 @@ import scala.util.{ Failure, Success, Try }
 
 object TsCsvParser {
   def apply(s: String): Either[List[String], TransmittalSheet] = {
-    val values = s.split('|').map(_.trim).toList
+    val values = s.trim.split('|').map(_.trim).toList
     if (values.length != 21) {
       return Left(List("Incorrect number of fields. found: " + values.length + ", expected: 21"))
     }


### PR DESCRIPTION
Previously, since lines are persisted with a newline character at the end, the TS parser could not remove extra fields (extra | characters) from the end of the TS CSV. This would cause valid Transmittal Sheets to fail parsing. Now, we remove any extra newline characters, and any extra | characters are removed when the line is split.

Also applied the change to LAR parser, so future users won't see the same bug.

Closes #594 
Now we should be able to smoke test with the test files in `parser/src/test/resources/txt/` without seeing erroneous parser errors.