### PR TITLE
Move changing submission status to `uploading` to after additional checks have completed

### DIFF
--- a/api/src/main/scala/hmda/api/http/institutions/UploadPaths.scala
+++ b/api/src/main/scala/hmda/api/http/institutions/UploadPaths.scala
@@ -57,7 +57,6 @@ trait UploadPaths extends InstitutionProtocol with ApiErrorProtocol with HmdaCus
 
           onComplete(fUploadSubmission) {
             case Success((true, processingActor)) =>
-              processingActor ! StartUpload
               uploadFile(processingActor, uploadTimestamp, uri.path)
             case Success((false, _)) =>
               val errorResponse = ErrorResponse(400, s"Submission $seqNr not available for upload", uri.path)
@@ -77,6 +76,7 @@ trait UploadPaths extends InstitutionProtocol with ApiErrorProtocol with HmdaCus
   private def uploadFile(processingActor: ActorRef, uploadTimestamp: Long, path: Path): Route = {
     fileUpload("file") {
       case (metadata, byteSource) if (metadata.fileName.endsWith(".txt")) =>
+        processingActor ! StartUpload
         val uploadedF = byteSource
           .via(splitLines)
           .map(_.utf8String)


### PR DESCRIPTION
While doing research for #618 I noticed that if I sent a request to the upload endpoint with a request that included the header `Content-Type: application/json`, which provoked the API to return  `The request's Content-Type is not supported. Expected: multipart/form-data`, the submission that I was uploading to would still have its status changed to `Uploading`, which is a behavior that I was not expecting.

As such, I have moved the call to the `processingActor` to update the `SubmissionStatus` to after it has been confirmed that a file is being uploaded and that it is a .txt, or just before we start reading in the stream of data.