### PR TITLE
InstitutionStatus in JSON responses

### DIFF
--- a/Documents/API.md
+++ b/Documents/API.md
@@ -32,12 +32,18 @@ All endpoints in the `/institutions` namespace require two headers (see "Authori
         {
           "id": "12345",
           "name": "First Bank",
-          "status": "active"
+          "status": {
+            "code": 1,
+            "message": "active"
+          }
         },
         {
           "id": "123456",
           "name": "Second Bank",
-          "status": "inactive"
+          "status": {
+            "code": 0,
+            "message": "inactive"
+          }
         }
       ]
     }
@@ -53,7 +59,10 @@ All endpoints in the `/institutions` namespace require two headers (see "Authori
       "institution": {
       "id": "12345",
       "name": "First Bank",
-      "status": "active"
+      "status": {
+        "code": 0,
+        "message": "inactive"
+      }
     },
       "filings": [
         {

--- a/Documents/institution-status.md
+++ b/Documents/institution-status.md
@@ -10,7 +10,10 @@ For example:
 "institution": {
     "id": "12345",
     "name": "First Bank",
-    "status": "active"
+    "status": {
+        "code": 1,
+        "message": "active"
+    }
 }
 ```
 

--- a/Documents/institution-status.md
+++ b/Documents/institution-status.md
@@ -2,7 +2,12 @@
 
 Every institution will store a `InstitutionStatus` object with the following structure:
 
-* `status`: `String`
+```
+"status": {
+    "code": Int,
+    "message": String
+}
+```
 
 For example:
 

--- a/api/src/main/scala/hmda/api/protocol/processing/InstitutionProtocol.scala
+++ b/api/src/main/scala/hmda/api/protocol/processing/InstitutionProtocol.scala
@@ -1,10 +1,8 @@
 package hmda.api.protocol.processing
 
 import hmda.api.model.{ InstitutionDetail, InstitutionWrapper, Institutions }
-import hmda.model.institution.DepositoryType.{ Depository, NonDepository }
-import hmda.model.institution.{ Agency, DepositoryType, Institution, InstitutionStatus }
-import hmda.model.institution.InstitutionStatus.{ Active, Inactive }
-import spray.json.{ DefaultJsonProtocol, DeserializationException, JsNumber, JsObject, JsString, JsValue, RootJsonFormat }
+import hmda.model.institution.{ InstitutionStatus, Active, Inactive }
+import spray.json.{ DefaultJsonProtocol, DeserializationException, JsString, JsValue, RootJsonFormat }
 
 trait InstitutionProtocol extends DefaultJsonProtocol with FilingProtocol {
   implicit object InstitutionStatusJsonFormat extends RootJsonFormat[InstitutionStatus] {

--- a/api/src/main/scala/hmda/api/protocol/processing/InstitutionProtocol.scala
+++ b/api/src/main/scala/hmda/api/protocol/processing/InstitutionProtocol.scala
@@ -1,27 +1,31 @@
 package hmda.api.protocol.processing
 
 import hmda.api.model.{ InstitutionDetail, InstitutionWrapper, Institutions }
-import hmda.model.institution.{ InstitutionStatus, Active, Inactive }
-import spray.json.{ DefaultJsonProtocol, DeserializationException, JsString, JsValue, RootJsonFormat }
+import hmda.model.institution.{ Active, Inactive, InstitutionStatus }
+import hmda.model.institution.InstitutionStatusMessage._
+import spray.json.{ DefaultJsonProtocol, DeserializationException, JsNumber, JsObject, JsString, JsValue, RootJsonFormat }
 
 trait InstitutionProtocol extends DefaultJsonProtocol with FilingProtocol {
   implicit object InstitutionStatusJsonFormat extends RootJsonFormat[InstitutionStatus] {
+
     override def write(status: InstitutionStatus): JsValue = {
-      status match {
-        case Active => JsString("active")
-        case Inactive => JsString("inactive")
-      }
+      JsObject(
+        ("code", JsNumber(status.code)),
+        ("message", JsString(status.message))
+      )
     }
 
     override def read(json: JsValue): InstitutionStatus = {
-      json match {
+      json.asJsObject.getFields("message").head match {
         case JsString(s) => s match {
-          case "active" => Active
-          case "inactive" => Inactive
+          case `activeMsg` => Active
+          case `inactiveMsg` => Inactive
+          case _ => throw new DeserializationException("Institution Status expected")
         }
-        case _ => throw new DeserializationException("Institution Status expected")
+        case _ => throw new DeserializationException("Unable to deserialize")
       }
     }
+
   }
 
   implicit val institutionWrapperFormat = jsonFormat3(InstitutionWrapper.apply)

--- a/api/src/test/scala/hmda/api/http/InstitutionsAuthSpec.scala
+++ b/api/src/test/scala/hmda/api/http/InstitutionsAuthSpec.scala
@@ -9,7 +9,7 @@ import akka.stream.ActorMaterializer
 import hmda.model.institution.Agency.FDIC
 import hmda.model.institution.ExternalIdType.RssdId
 import hmda.model.institution.{ ExternalId, Institution }
-import hmda.model.institution.InstitutionStatus.Active
+import hmda.model.institution.Active
 import hmda.model.institution.InstitutionType.Bank
 import hmda.persistence.HmdaSupervisor
 import hmda.persistence.HmdaSupervisor.FindActorByName

--- a/api/src/test/scala/hmda/api/model/ModelGenerators.scala
+++ b/api/src/test/scala/hmda/api/model/ModelGenerators.scala
@@ -3,7 +3,6 @@ package hmda.api.model
 import java.util.Calendar
 import akka.http.scaladsl.model.Uri.Path
 import hmda.model.fi._
-import hmda.model.institution.InstitutionStatus.{ Active, Inactive }
 import hmda.model.institution._
 import hmda.validation.engine._
 import org.scalacheck.Gen

--- a/api/src/test/scala/hmda/api/protocol/processing/InstitutionProtocolSpec.scala
+++ b/api/src/test/scala/hmda/api/protocol/processing/InstitutionProtocolSpec.scala
@@ -17,7 +17,14 @@ class InstitutionProtocolSpec extends PropSpec with PropertyChecks with MustMatc
   property("An Institution must convert to a JSON wrapper") {
     forAll(institutionGen) { i =>
       InstitutionWrapper(i.id.toString, i.name, i.status).toJson mustBe
-        JsObject(("id", JsString(i.id.toString)), ("name", JsString(i.name)), ("status", JsString(i.status.message)))
+        JsObject(
+          ("id", JsString(i.id.toString)),
+          ("name", JsString(i.name)),
+          ("status", JsObject(
+            ("code", JsNumber(i.status.code)),
+            ("message", JsString(i.status.message))
+          ))
+        )
     }
   }
 

--- a/api/src/test/scala/hmda/api/protocol/processing/InstitutionProtocolSpec.scala
+++ b/api/src/test/scala/hmda/api/protocol/processing/InstitutionProtocolSpec.scala
@@ -1,7 +1,7 @@
 package hmda.api.protocol.processing
 
 import hmda.api.model.{ InstitutionWrapper, ModelGenerators }
-import hmda.model.institution.{ Institution, InstitutionStatus }
+import hmda.model.institution.{ InstitutionStatus }
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{ MustMatchers, PropSpec }
 import spray.json._
@@ -17,7 +17,7 @@ class InstitutionProtocolSpec extends PropSpec with PropertyChecks with MustMatc
   property("An Institution must convert to a JSON wrapper") {
     forAll(institutionGen) { i =>
       InstitutionWrapper(i.id.toString, i.name, i.status).toJson mustBe
-        JsObject(("id", JsString(i.id.toString)), ("name", JsString(i.name)), ("status", JsString(i.status.entryName)))
+        JsObject(("id", JsString(i.id.toString)), ("name", JsString(i.name)), ("status", JsString(i.status.message)))
     }
   }
 

--- a/model/src/main/scala/hmda/model/institution/Institution.scala
+++ b/model/src/main/scala/hmda/model/institution/Institution.scala
@@ -11,7 +11,7 @@ case class Institution(
     institutionType: InstitutionType,
     hasParent: Boolean,
     cra: Boolean = false, // TODO do we have this info when creating the institution? if so, then don't default here.
-    status: InstitutionStatus = InstitutionStatus.Active
+    status: InstitutionStatus = Active
 ) extends Serializable {
 
   private val extIdsByType: Map[ExternalIdType, ExternalId] = externalIds.map(extId => (extId.idType, extId)).toMap

--- a/model/src/main/scala/hmda/model/institution/InstitutionStatus.scala
+++ b/model/src/main/scala/hmda/model/institution/InstitutionStatus.scala
@@ -1,17 +1,20 @@
 package hmda.model.institution
 
-import enumeratum.{ Enum, EnumEntry }
+import InstitutionStatusMessage._
 
 /**
  * The status of a financial institution
  */
-sealed abstract class InstitutionStatus(override val entryName: String) extends EnumEntry with Serializable
+sealed trait InstitutionStatus {
+  def code: Int
+  def message: String
+}
 
-object InstitutionStatus extends Enum[InstitutionStatus] {
-
-  val values = findValues
-
-  case object Active extends InstitutionStatus("active")
-  case object Inactive extends InstitutionStatus("inactive")
-
+case object Active extends InstitutionStatus {
+  override def code: Int = 1
+  override def message: String = activeMsg
+}
+case object Inactive extends InstitutionStatus {
+  override def code: Int = 2
+  override def message: String = inactiveMsg
 }

--- a/model/src/main/scala/hmda/model/institution/InstitutionStatusMessage.scala
+++ b/model/src/main/scala/hmda/model/institution/InstitutionStatusMessage.scala
@@ -1,0 +1,6 @@
+package hmda.model.institution
+
+object InstitutionStatusMessage {
+  val activeMsg = "active"
+  val inactiveMsg = "inactive"
+}

--- a/model/src/test/scala/hmda/model/institution/InMemoryInstitutionRepositorySpec.scala
+++ b/model/src/test/scala/hmda/model/institution/InMemoryInstitutionRepositorySpec.scala
@@ -2,7 +2,6 @@ package hmda.model.institution
 
 import hmda.model.institution.Agency.{ CFPB, FDIC, OCC }
 import hmda.model.institution.ExternalIdType.{ FdicCertNo, FederalTaxId, OccCharterId, RssdId }
-import hmda.model.institution.InstitutionStatus.{ Active, Inactive }
 import hmda.model.institution.InstitutionType.{ Bank, SavingsAndLoan }
 import org.scalatest.{ MustMatchers, WordSpec }
 

--- a/model/src/test/scala/hmda/model/institution/InstitutionSpec.scala
+++ b/model/src/test/scala/hmda/model/institution/InstitutionSpec.scala
@@ -3,7 +3,6 @@ package hmda.model.institution
 import hmda.model.institution.Agency._
 import hmda.model.institution.DepositoryType.Depository
 import hmda.model.institution.ExternalIdType._
-import hmda.model.institution.InstitutionStatus.Active
 import hmda.model.institution.InstitutionType._
 import org.scalatest.{ MustMatchers, WordSpec }
 

--- a/persistence/src/main/scala/hmda/persistence/demo/DemoData.scala
+++ b/persistence/src/main/scala/hmda/persistence/demo/DemoData.scala
@@ -5,7 +5,7 @@ import akka.util.Timeout
 import hmda.model.fi._
 import hmda.model.institution.Agency.{ CFPB, FDIC, HUD, OCC }
 import hmda.model.institution.ExternalIdType.{ FdicCertNo, FederalTaxId, OccCharterId, RssdId }
-import hmda.model.institution.InstitutionStatus.{ Active, Inactive }
+import hmda.model.institution.{ Active, Inactive }
 import hmda.model.institution.InstitutionType.{ Bank, CreditUnion }
 import hmda.model.institution.{ ExternalId, Institution }
 import hmda.persistence.CommonMessages._

--- a/persistence/src/main/scala/hmda/persistence/demo/DemoInstitutions.scala
+++ b/persistence/src/main/scala/hmda/persistence/demo/DemoInstitutions.scala
@@ -46,7 +46,10 @@ object DemoInstitutions extends ResourceUtils {
   }
 
   def toStatus(text: String): InstitutionStatus = {
-    InstitutionStatus.values.filter(status => status.entryName == text).head
+    text match {
+      case "active" => Active
+      case "inactive" => Inactive
+    }
   }
 
 }

--- a/persistence/src/main/scala/hmda/persistence/institutions/InstitutionPersistence.scala
+++ b/persistence/src/main/scala/hmda/persistence/institutions/InstitutionPersistence.scala
@@ -3,7 +3,7 @@ package hmda.persistence.institutions
 import akka.actor.{ ActorRef, ActorSystem, Props }
 import hmda.model.institution.Agency.CFPB
 import hmda.model.institution.Institution
-import hmda.model.institution.InstitutionStatus.Inactive
+import hmda.model.institution.Inactive
 import hmda.model.institution.InstitutionType.Bank
 import hmda.persistence.CommonMessages._
 import hmda.persistence.HmdaPersistentActor

--- a/persistence/src/test/scala/hmda/persistence/institutions/InstitutionPersistenceSpec.scala
+++ b/persistence/src/test/scala/hmda/persistence/institutions/InstitutionPersistenceSpec.scala
@@ -5,7 +5,7 @@ import hmda.actor.test.ActorSpec
 import hmda.model.institution.Agency.{ CFPB, FDIC }
 import hmda.model.institution.ExternalIdType.{ FdicCertNo, FederalTaxId, RssdId }
 import hmda.model.institution.{ ExternalId, Institution }
-import hmda.model.institution.InstitutionStatus.Active
+import hmda.model.institution.Active
 import hmda.model.institution.InstitutionType.Bank
 import hmda.persistence.CommonMessages.GetState
 import hmda.persistence.demo.DemoData

--- a/validation/src/test/scala/hmda/validation/rules/ts/syntactical/S025Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/ts/syntactical/S025Spec.scala
@@ -4,7 +4,6 @@ import hmda.model.fi.lar._
 import hmda.model.fi.ts.{ Contact, Parent, Respondent, TransmittalSheet }
 import hmda.model.institution.Agency.CFPB
 import hmda.model.institution.ExternalIdType.{ FdicCertNo, FederalTaxId, RssdId }
-import hmda.model.institution.InstitutionStatus.Active
 import hmda.model.institution.InstitutionType.Bank
 import hmda.model.institution.{ ExternalId, Institution }
 import hmda.validation.context.ValidationContext


### PR DESCRIPTION
Closes #601 

1. Changes `InstitutionStatus` model to have a `code` and `message` field. `InstitutionStatus` is now modeled exactly like `SubmissionStatus`. This requires some updates, especially of test code and imports.
2. Adds institution status to JSON representation in all endpoints that return institution data (I believe just `/institutions` and `/institutions/<id>`).