### PR TITLE
Consolidate test config (event processor)

### DIFF
--- a/persistence/src/test/scala/hmda/persistence/processing/LocalHmdaEventProcessorSpec.scala
+++ b/persistence/src/test/scala/hmda/persistence/processing/LocalHmdaEventProcessorSpec.scala
@@ -25,16 +25,7 @@ class LocalHmdaEventProcessorSpec extends ActorSpec {
     ActorSystem(
       "test-system",
       ConfigFactory.parseString(
-        """
-          | akka.loggers = ["akka.testkit.TestEventListener"]
-          | akka.loglevel = DEBUG
-          | akka.stdout-loglevel = "OFF"
-          | akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
-          | akka.persistence.snapshot-store.plugin = "akka.persistence.snapshot-store.local"
-          | akka.persistence.snapshot-store.local.dir = "target/snapshots"
-          | akka.log.dead-letters = off
-          | akka.log-dead-letters-during-shutdown = off
-          | """.stripMargin
+        TestConfigOverride.config
       )
     )
 


### PR DESCRIPTION
Consolidates configuration with other actors in the `persistence` project. Might help with sporadic test failures in CI server (event stream log capture timeout is increased)