### PR TITLE
Q047

### DIFF
--- a/validation/src/main/resources/application.conf
+++ b/validation/src/main/resources/application.conf
@@ -78,4 +78,7 @@ hmda.validation.macro {
   Q008 {
     numOfLarsMultiplier = 0.30
   }
+  Q047 {
+    numOfLarsMultiplier = 0.10
+  }
 }

--- a/validation/src/main/scala/hmda/validation/engine/lar/macro/LarMacroEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/lar/macro/LarMacroEngine.scala
@@ -8,7 +8,7 @@ import hmda.validation.engine.lar.LarCommonEngine
 import hmda.validation.engine.{ Macro, ValidationErrorType }
 import hmda.validation.rules.AggregateEditCheck
 import hmda.validation.rules.lar.`macro`.MacroEditTypes.LoanApplicationRegisterSource
-import hmda.validation.rules.lar.`macro`.{ Q007, Q008 }
+import hmda.validation.rules.lar.`macro`.{ Q007, Q008, Q047 }
 
 import scala.concurrent.{ ExecutionContext, Future }
 
@@ -18,7 +18,8 @@ trait LarMacroEngine extends LarCommonEngine with ValidationApi {
     Future.sequence(
       List(
         Q007,
-        Q008
+        Q008,
+        Q047
       ).map(checkAggregate(_, larSource, "", Macro))
     )
       .map(checks => validateAll(checks, larSource))

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q047.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q047.scala
@@ -1,0 +1,37 @@
+package hmda.validation.rules.lar.`macro`
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import com.typesafe.config.ConfigFactory
+import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.validation.dsl.Result
+import hmda.validation.rules.AggregateEditCheck
+import hmda.validation.dsl.PredicateCommon._
+import hmda.validation.dsl.PredicateSyntax._
+import hmda.validation.rules.lar.`macro`.MacroEditTypes._
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+object Q047 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplicationRegister] {
+
+  val config = ConfigFactory.load()
+  val multiplier = config.getDouble("hmda.validation.macro.Q047.numOfLarsMultiplier")
+
+  override def name = "Q047"
+
+  override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
+
+    val singleFamilyWithdrawn =
+      count(lars.filter(lar => lar.actionTakenType == 4 && lar.preapprovals == 1))
+
+    val total = count(lars)
+
+    for {
+      a <- singleFamilyWithdrawn
+      t <- total
+    } yield {
+      a.toDouble is lessThanOrEqual(t * multiplier)
+    }
+
+  }
+}

--- a/validation/src/test/scala/hmda/validation/rules/lar/macro/MacroSpec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/macro/MacroSpec.scala
@@ -27,10 +27,10 @@ abstract class MacroSpec extends SummaryEditCheckSpec with BeforeAndAfterAll wit
     system.terminate()
   }
 
-  protected def newLarSource(lars: List[LoanApplicationRegister], numOfGoodLars: Int, validDef: LoanApplicationRegister => LoanApplicationRegister, invalidDef: LoanApplicationRegister => LoanApplicationRegister) = {
-    val validLars = lars.map(lar => validDef(lar)).take(numOfGoodLars)
-    val invalidLars = lars.map(lar => invalidDef(lar)).drop(numOfGoodLars)
-    val newLars = validLars ::: invalidLars
+  protected def newLarSource(lars: List[LoanApplicationRegister], numOfRelevantLars: Int, relevantDef: LoanApplicationRegister => LoanApplicationRegister, irrelevantDef: LoanApplicationRegister => LoanApplicationRegister) = {
+    val relevantLars = lars.map(lar => relevantDef(lar)).take(numOfRelevantLars)
+    val irrelevantLars = lars.map(lar => irrelevantDef(lar)).drop(numOfRelevantLars)
+    val newLars = relevantLars ::: irrelevantLars
     Source.fromIterator(() => newLars.toIterator)
   }
 

--- a/validation/src/test/scala/hmda/validation/rules/lar/macro/MacroSpec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/macro/MacroSpec.scala
@@ -27,10 +27,10 @@ abstract class MacroSpec extends SummaryEditCheckSpec with BeforeAndAfterAll wit
     system.terminate()
   }
 
-  protected def newActionTakenTypeSource(lars: List[LoanApplicationRegister], numOfGoodLars: Int, goodActionTakenType: Int, badActionTakenType: Int) = {
-    val goodLars = lars.map(lar => lar.copy(actionTakenType = goodActionTakenType)).take(numOfGoodLars)
-    val badLars = lars.map(lar => lar.copy(actionTakenType = badActionTakenType)).drop(numOfGoodLars)
-    val newLars = goodLars ::: badLars
+  protected def newLarSource(lars: List[LoanApplicationRegister], numOfGoodLars: Int, validDef: LoanApplicationRegister => LoanApplicationRegister, invalidDef: LoanApplicationRegister => LoanApplicationRegister) = {
+    val validLars = lars.map(lar => validDef(lar)).take(numOfGoodLars)
+    val invalidLars = lars.map(lar => invalidDef(lar)).drop(numOfGoodLars)
+    val newLars = validLars ::: invalidLars
     Source.fromIterator(() => newLars.toIterator)
   }
 

--- a/validation/src/test/scala/hmda/validation/rules/lar/macro/Q007Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/macro/Q007Spec.scala
@@ -12,23 +12,25 @@ class Q007Spec extends MacroSpec {
 
   val testLars = lar100ListGen.sample.getOrElse(Nil)
   val sampleSize = testLars.size
+  def validLar(lar: LoanApplicationRegister) = lar.copy(actionTakenType = 4)
+  def invalidLar(lar: LoanApplicationRegister) = lar.copy(actionTakenType = 2)
 
   property(s"be valid if not accepted < $multiplier * total") {
-    val numOfGoodLars = (sampleSize * multiplier).toInt - 1
-    val newLarSource = newActionTakenTypeSource(testLars, numOfGoodLars, 2, 4)
-    newLarSource.mustPass
+    val numOfGoodLars = (sampleSize * (1.0 - multiplier)).toInt + 1
+    val validLarSource = newLarSource(testLars, numOfGoodLars, validLar(_), invalidLar(_))
+    validLarSource.mustPass
   }
 
   property(s"be valid if not accepted = $multiplier * total") {
-    val numOfGoodLars = (sampleSize * multiplier).toInt
-    val newLarSource = newActionTakenTypeSource(testLars, numOfGoodLars, 2, 4)
-    newLarSource.mustPass
+    val numOfGoodLars = (sampleSize * (1.0 - multiplier)).toInt
+    val validLarSource = newLarSource(testLars, numOfGoodLars, validLar(_), invalidLar(_))
+    validLarSource.mustPass
   }
 
   property(s"be invalid if not accepted > $multiplier * total") {
-    val numOfGoodLars = (sampleSize * multiplier).toInt + 1
-    val newLarSource = newActionTakenTypeSource(testLars, numOfGoodLars, 2, 4)
-    newLarSource.mustFail
+    val numOfGoodLars = (sampleSize * (1.0 - multiplier)).toInt - 1
+    val invalidLarSource = newLarSource(testLars, numOfGoodLars, validLar(_), invalidLar(_))
+    invalidLarSource.mustFail
   }
 
   override def check: AggregateEditCheck[LoanApplicationRegisterSource, LoanApplicationRegister] = Q007

--- a/validation/src/test/scala/hmda/validation/rules/lar/macro/Q007Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/macro/Q007Spec.scala
@@ -12,24 +12,24 @@ class Q007Spec extends MacroSpec {
 
   val testLars = lar100ListGen.sample.getOrElse(Nil)
   val sampleSize = testLars.size
-  def validLar(lar: LoanApplicationRegister) = lar.copy(actionTakenType = 4)
-  def invalidLar(lar: LoanApplicationRegister) = lar.copy(actionTakenType = 2)
+  def relevantLar(lar: LoanApplicationRegister) = lar.copy(actionTakenType = 4)
+  def irrelevantLar(lar: LoanApplicationRegister) = lar.copy(actionTakenType = 2)
 
   property(s"be valid if not accepted < $multiplier * total") {
     val numOfRelevantLars = (sampleSize * (1.0 - multiplier)).toInt + 1
-    val validLarSource = newLarSource(testLars, numOfRelevantLars, validLar(_), invalidLar(_))
+    val validLarSource = newLarSource(testLars, numOfRelevantLars, relevantLar, irrelevantLar)
     validLarSource.mustPass
   }
 
   property(s"be valid if not accepted = $multiplier * total") {
     val numOfRelevantLars = (sampleSize * (1.0 - multiplier)).toInt
-    val validLarSource = newLarSource(testLars, numOfRelevantLars, validLar(_), invalidLar(_))
+    val validLarSource = newLarSource(testLars, numOfRelevantLars, relevantLar, irrelevantLar)
     validLarSource.mustPass
   }
 
   property(s"be invalid if not accepted > $multiplier * total") {
     val numOfRelevantLars = (sampleSize * (1.0 - multiplier)).toInt - 1
-    val invalidLarSource = newLarSource(testLars, numOfRelevantLars, validLar(_), invalidLar(_))
+    val invalidLarSource = newLarSource(testLars, numOfRelevantLars, relevantLar, irrelevantLar)
     invalidLarSource.mustFail
   }
 

--- a/validation/src/test/scala/hmda/validation/rules/lar/macro/Q007Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/macro/Q007Spec.scala
@@ -16,20 +16,20 @@ class Q007Spec extends MacroSpec {
   def invalidLar(lar: LoanApplicationRegister) = lar.copy(actionTakenType = 2)
 
   property(s"be valid if not accepted < $multiplier * total") {
-    val numOfGoodLars = (sampleSize * (1.0 - multiplier)).toInt + 1
-    val validLarSource = newLarSource(testLars, numOfGoodLars, validLar(_), invalidLar(_))
+    val numOfRelevantLars = (sampleSize * (1.0 - multiplier)).toInt + 1
+    val validLarSource = newLarSource(testLars, numOfRelevantLars, validLar(_), invalidLar(_))
     validLarSource.mustPass
   }
 
   property(s"be valid if not accepted = $multiplier * total") {
-    val numOfGoodLars = (sampleSize * (1.0 - multiplier)).toInt
-    val validLarSource = newLarSource(testLars, numOfGoodLars, validLar(_), invalidLar(_))
+    val numOfRelevantLars = (sampleSize * (1.0 - multiplier)).toInt
+    val validLarSource = newLarSource(testLars, numOfRelevantLars, validLar(_), invalidLar(_))
     validLarSource.mustPass
   }
 
   property(s"be invalid if not accepted > $multiplier * total") {
-    val numOfGoodLars = (sampleSize * (1.0 - multiplier)).toInt - 1
-    val invalidLarSource = newLarSource(testLars, numOfGoodLars, validLar(_), invalidLar(_))
+    val numOfRelevantLars = (sampleSize * (1.0 - multiplier)).toInt - 1
+    val invalidLarSource = newLarSource(testLars, numOfRelevantLars, validLar(_), invalidLar(_))
     invalidLarSource.mustFail
   }
 

--- a/validation/src/test/scala/hmda/validation/rules/lar/macro/Q007Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/macro/Q007Spec.scala
@@ -12,23 +12,23 @@ class Q007Spec extends MacroSpec {
 
   val testLars = lar100ListGen.sample.getOrElse(Nil)
   val sampleSize = testLars.size
-  def relevantLar(lar: LoanApplicationRegister) = lar.copy(actionTakenType = 4)
-  def irrelevantLar(lar: LoanApplicationRegister) = lar.copy(actionTakenType = 2)
+  def irrelevantLar(lar: LoanApplicationRegister) = lar.copy(actionTakenType = 4)
+  def relevantLar(lar: LoanApplicationRegister) = lar.copy(actionTakenType = 2)
 
   property(s"be valid if not accepted < $multiplier * total") {
-    val numOfRelevantLars = (sampleSize * (1.0 - multiplier)).toInt + 1
+    val numOfRelevantLars = (sampleSize * multiplier).toInt - 1
     val validLarSource = newLarSource(testLars, numOfRelevantLars, relevantLar, irrelevantLar)
     validLarSource.mustPass
   }
 
   property(s"be valid if not accepted = $multiplier * total") {
-    val numOfRelevantLars = (sampleSize * (1.0 - multiplier)).toInt
+    val numOfRelevantLars = (sampleSize * multiplier).toInt
     val validLarSource = newLarSource(testLars, numOfRelevantLars, relevantLar, irrelevantLar)
     validLarSource.mustPass
   }
 
   property(s"be invalid if not accepted > $multiplier * total") {
-    val numOfRelevantLars = (sampleSize * (1.0 - multiplier)).toInt - 1
+    val numOfRelevantLars = (sampleSize * multiplier).toInt + 1
     val invalidLarSource = newLarSource(testLars, numOfRelevantLars, relevantLar, irrelevantLar)
     invalidLarSource.mustFail
   }

--- a/validation/src/test/scala/hmda/validation/rules/lar/macro/Q008Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/macro/Q008Spec.scala
@@ -15,20 +15,20 @@ class Q008Spec extends MacroSpec {
   def invalidLar(lar: LoanApplicationRegister) = lar.copy(actionTakenType = 4)
 
   property(s"be valid if withdrawn < $multiplier * total") {
-    val numOfGoodLars = (sampleSize * (1.0 - multiplier)).toInt + 1
-    val validLarSource = newLarSource(testLars, numOfGoodLars, validLar(_), invalidLar(_))
+    val numOfRelevantLars = (sampleSize * (1.0 - multiplier)).toInt + 1
+    val validLarSource = newLarSource(testLars, numOfRelevantLars, validLar(_), invalidLar(_))
     validLarSource.mustPass
   }
 
   property(s"be valid if withdrawn = $multiplier * total") {
-    val numOfGoodLars = (sampleSize * (1.0 - multiplier)).toInt
-    val validLarSource = newLarSource(testLars, numOfGoodLars, validLar(_), invalidLar(_))
+    val numOfRelevantLars = (sampleSize * (1.0 - multiplier)).toInt
+    val validLarSource = newLarSource(testLars, numOfRelevantLars, validLar(_), invalidLar(_))
     validLarSource.mustPass
   }
 
   property(s"be invalid if withdrawn > $multiplier * total") {
-    val numOfGoodLars = (sampleSize * (1.0 - multiplier)).toInt - 1
-    val invalidLarSource = newLarSource(testLars, numOfGoodLars, validLar(_), invalidLar(_))
+    val numOfRelevantLars = (sampleSize * (1.0 - multiplier)).toInt - 1
+    val invalidLarSource = newLarSource(testLars, numOfRelevantLars, validLar(_), invalidLar(_))
     invalidLarSource.mustFail
   }
 

--- a/validation/src/test/scala/hmda/validation/rules/lar/macro/Q008Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/macro/Q008Spec.scala
@@ -11,23 +11,23 @@ class Q008Spec extends MacroSpec {
 
   val testLars = lar100ListGen.sample.getOrElse(Nil)
   val sampleSize = testLars.size
-  def relevantLar(lar: LoanApplicationRegister) = lar.copy(actionTakenType = 2)
-  def irrelevantLar(lar: LoanApplicationRegister) = lar.copy(actionTakenType = 4)
+  def irrelevantLar(lar: LoanApplicationRegister) = lar.copy(actionTakenType = 2)
+  def relevantLar(lar: LoanApplicationRegister) = lar.copy(actionTakenType = 4)
 
   property(s"be valid if withdrawn < $multiplier * total") {
-    val numOfRelevantLars = (sampleSize * (1.0 - multiplier)).toInt + 1
+    val numOfRelevantLars = (sampleSize * multiplier).toInt - 1
     val validLarSource = newLarSource(testLars, numOfRelevantLars, relevantLar, irrelevantLar)
     validLarSource.mustPass
   }
 
   property(s"be valid if withdrawn = $multiplier * total") {
-    val numOfRelevantLars = (sampleSize * (1.0 - multiplier)).toInt
+    val numOfRelevantLars = (sampleSize * multiplier).toInt
     val validLarSource = newLarSource(testLars, numOfRelevantLars, relevantLar, irrelevantLar)
     validLarSource.mustPass
   }
 
   property(s"be invalid if withdrawn > $multiplier * total") {
-    val numOfRelevantLars = (sampleSize * (1.0 - multiplier)).toInt - 1
+    val numOfRelevantLars = (sampleSize * multiplier).toInt + 1
     val invalidLarSource = newLarSource(testLars, numOfRelevantLars, relevantLar, irrelevantLar)
     invalidLarSource.mustFail
   }

--- a/validation/src/test/scala/hmda/validation/rules/lar/macro/Q008Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/macro/Q008Spec.scala
@@ -11,23 +11,25 @@ class Q008Spec extends MacroSpec {
 
   val testLars = lar100ListGen.sample.getOrElse(Nil)
   val sampleSize = testLars.size
+  def validLar(lar: LoanApplicationRegister) = lar.copy(actionTakenType = 2)
+  def invalidLar(lar: LoanApplicationRegister) = lar.copy(actionTakenType = 4)
 
   property(s"be valid if withdrawn < $multiplier * total") {
-    val numOfGoodLars = (sampleSize * multiplier).toInt - 1
-    val newLarSource = newActionTakenTypeSource(testLars, numOfGoodLars, 4, 2)
-    newLarSource.mustPass
+    val numOfGoodLars = (sampleSize * (1.0 - multiplier)).toInt + 1
+    val validLarSource = newLarSource(testLars, numOfGoodLars, validLar(_), invalidLar(_))
+    validLarSource.mustPass
   }
 
   property(s"be valid if withdrawn = $multiplier * total") {
-    val numOfGoodLars = (sampleSize * multiplier).toInt
-    val newLarSource = newActionTakenTypeSource(testLars, numOfGoodLars, 4, 2)
-    newLarSource.mustPass
+    val numOfGoodLars = (sampleSize * (1.0 - multiplier)).toInt
+    val validLarSource = newLarSource(testLars, numOfGoodLars, validLar(_), invalidLar(_))
+    validLarSource.mustPass
   }
 
   property(s"be invalid if withdrawn > $multiplier * total") {
-    val numOfGoodLars = (sampleSize * multiplier).toInt + 1
-    val newLarSource = newActionTakenTypeSource(testLars, numOfGoodLars, 4, 2)
-    newLarSource.mustFail
+    val numOfGoodLars = (sampleSize * (1.0 - multiplier)).toInt - 1
+    val invalidLarSource = newLarSource(testLars, numOfGoodLars, validLar(_), invalidLar(_))
+    invalidLarSource.mustFail
   }
 
   override def check: AggregateEditCheck[LoanApplicationRegisterSource, LoanApplicationRegister] = Q008

--- a/validation/src/test/scala/hmda/validation/rules/lar/macro/Q008Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/macro/Q008Spec.scala
@@ -11,24 +11,24 @@ class Q008Spec extends MacroSpec {
 
   val testLars = lar100ListGen.sample.getOrElse(Nil)
   val sampleSize = testLars.size
-  def validLar(lar: LoanApplicationRegister) = lar.copy(actionTakenType = 2)
-  def invalidLar(lar: LoanApplicationRegister) = lar.copy(actionTakenType = 4)
+  def relevantLar(lar: LoanApplicationRegister) = lar.copy(actionTakenType = 2)
+  def irrelevantLar(lar: LoanApplicationRegister) = lar.copy(actionTakenType = 4)
 
   property(s"be valid if withdrawn < $multiplier * total") {
     val numOfRelevantLars = (sampleSize * (1.0 - multiplier)).toInt + 1
-    val validLarSource = newLarSource(testLars, numOfRelevantLars, validLar(_), invalidLar(_))
+    val validLarSource = newLarSource(testLars, numOfRelevantLars, relevantLar, irrelevantLar)
     validLarSource.mustPass
   }
 
   property(s"be valid if withdrawn = $multiplier * total") {
     val numOfRelevantLars = (sampleSize * (1.0 - multiplier)).toInt
-    val validLarSource = newLarSource(testLars, numOfRelevantLars, validLar(_), invalidLar(_))
+    val validLarSource = newLarSource(testLars, numOfRelevantLars, relevantLar, irrelevantLar)
     validLarSource.mustPass
   }
 
   property(s"be invalid if withdrawn > $multiplier * total") {
     val numOfRelevantLars = (sampleSize * (1.0 - multiplier)).toInt - 1
-    val invalidLarSource = newLarSource(testLars, numOfRelevantLars, validLar(_), invalidLar(_))
+    val invalidLarSource = newLarSource(testLars, numOfRelevantLars, relevantLar, irrelevantLar)
     invalidLarSource.mustFail
   }
 

--- a/validation/src/test/scala/hmda/validation/rules/lar/macro/Q047Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/macro/Q047Spec.scala
@@ -17,20 +17,20 @@ class Q047Spec extends MacroSpec {
   }
 
   property(s"be valid if single family and withdrawn < $multiplier * total") {
-    val numOfGoodLars = (sampleSize * (1.0 - multiplier)).toInt + 1
-    val validLarSource = newLarSource(testLars, numOfGoodLars, validLar(_), invalidLar(_))
+    val numOfRelevantLars = (sampleSize * (1.0 - multiplier)).toInt + 1
+    val validLarSource = newLarSource(testLars, numOfRelevantLars, validLar(_), invalidLar(_))
     validLarSource.mustPass
   }
 
   property(s"be valid if single family and withdrawn = $multiplier * total") {
-    val numOfGoodLars = (sampleSize * (1.0 - multiplier)).toInt
-    val validLarSource = newLarSource(testLars, numOfGoodLars, validLar(_), invalidLar(_))
+    val numOfRelevantLars = (sampleSize * (1.0 - multiplier)).toInt
+    val validLarSource = newLarSource(testLars, numOfRelevantLars, validLar(_), invalidLar(_))
     validLarSource.mustPass
   }
 
   property(s"be invalid if single family and withdrawn > $multiplier * total") {
-    val numOfGoodLars = (sampleSize * (1.0 - multiplier)).toInt - 1
-    val invalidLarSource = newLarSource(testLars, numOfGoodLars, validLar(_), invalidLar(_))
+    val numOfRelevantLars = (sampleSize * (1.0 - multiplier)).toInt - 1
+    val invalidLarSource = newLarSource(testLars, numOfRelevantLars, validLar(_), invalidLar(_))
     invalidLarSource.mustFail
   }
 

--- a/validation/src/test/scala/hmda/validation/rules/lar/macro/Q047Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/macro/Q047Spec.scala
@@ -1,0 +1,38 @@
+package hmda.validation.rules.lar.`macro`
+import com.typesafe.config.ConfigFactory
+import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.validation.rules.AggregateEditCheck
+import hmda.validation.rules.lar.`macro`.MacroEditTypes.LoanApplicationRegisterSource
+
+class Q047Spec extends MacroSpec {
+
+  val config = ConfigFactory.load()
+  val multiplier = config.getDouble("hmda.validation.macro.Q047.numOfLarsMultiplier")
+
+  val testLars = lar100ListGen.sample.getOrElse(Nil)
+  val sampleSize = testLars.size
+  def validLar(lar: LoanApplicationRegister) = lar.copy(actionTakenType = 2)
+  def invalidLar(lar: LoanApplicationRegister) = {
+    lar.copy(actionTakenType = 4).copy(preapprovals = 1)
+  }
+
+  property(s"be valid if single family and withdrawn < $multiplier * total") {
+    val numOfGoodLars = (sampleSize * (1.0 - multiplier)).toInt + 1
+    val validLarSource = newLarSource(testLars, numOfGoodLars, validLar(_), invalidLar(_))
+    validLarSource.mustPass
+  }
+
+  property(s"be valid if single family and withdrawn = $multiplier * total") {
+    val numOfGoodLars = (sampleSize * (1.0 - multiplier)).toInt
+    val validLarSource = newLarSource(testLars, numOfGoodLars, validLar(_), invalidLar(_))
+    validLarSource.mustPass
+  }
+
+  property(s"be invalid if single family and withdrawn > $multiplier * total") {
+    val numOfGoodLars = (sampleSize * (1.0 - multiplier)).toInt - 1
+    val invalidLarSource = newLarSource(testLars, numOfGoodLars, validLar(_), invalidLar(_))
+    invalidLarSource.mustFail
+  }
+
+  override def check: AggregateEditCheck[LoanApplicationRegisterSource, LoanApplicationRegister] = Q047
+}

--- a/validation/src/test/scala/hmda/validation/rules/lar/macro/Q047Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/macro/Q047Spec.scala
@@ -11,25 +11,25 @@ class Q047Spec extends MacroSpec {
 
   val testLars = lar100ListGen.sample.getOrElse(Nil)
   val sampleSize = testLars.size
-  def relevantLar(lar: LoanApplicationRegister) = lar.copy(actionTakenType = 2)
-  def irrelevantLar(lar: LoanApplicationRegister) = {
+  def irrelevantLar(lar: LoanApplicationRegister) = lar.copy(actionTakenType = 2)
+  def relevantLar(lar: LoanApplicationRegister) = {
     lar.copy(actionTakenType = 4).copy(preapprovals = 1)
   }
 
-  property(s"be valid if single family and withdrawn < $multiplier * total") {
-    val numOfRelevantLars = (sampleSize * (1.0 - multiplier)).toInt + 1
+  property(s"be valid if preaproval accepted and application withdrawn < $multiplier * total") {
+    val numOfRelevantLars = (sampleSize * multiplier).toInt - 1
     val validLarSource = newLarSource(testLars, numOfRelevantLars, relevantLar, irrelevantLar)
     validLarSource.mustPass
   }
 
-  property(s"be valid if single family and withdrawn = $multiplier * total") {
-    val numOfRelevantLars = (sampleSize * (1.0 - multiplier)).toInt
+  property(s"be valid if preaproval accepted and application withdrawn = $multiplier * total") {
+    val numOfRelevantLars = (sampleSize * multiplier).toInt
     val validLarSource = newLarSource(testLars, numOfRelevantLars, relevantLar, irrelevantLar)
     validLarSource.mustPass
   }
 
-  property(s"be invalid if single family and withdrawn > $multiplier * total") {
-    val numOfRelevantLars = (sampleSize * (1.0 - multiplier)).toInt - 1
+  property(s"be invalid if preaproval accepted and application withdrawn > $multiplier * total") {
+    val numOfRelevantLars = (sampleSize * multiplier).toInt + 1
     val invalidLarSource = newLarSource(testLars, numOfRelevantLars, relevantLar, irrelevantLar)
     invalidLarSource.mustFail
   }

--- a/validation/src/test/scala/hmda/validation/rules/lar/macro/Q047Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/macro/Q047Spec.scala
@@ -11,26 +11,26 @@ class Q047Spec extends MacroSpec {
 
   val testLars = lar100ListGen.sample.getOrElse(Nil)
   val sampleSize = testLars.size
-  def validLar(lar: LoanApplicationRegister) = lar.copy(actionTakenType = 2)
-  def invalidLar(lar: LoanApplicationRegister) = {
+  def relevantLar(lar: LoanApplicationRegister) = lar.copy(actionTakenType = 2)
+  def irrelevantLar(lar: LoanApplicationRegister) = {
     lar.copy(actionTakenType = 4).copy(preapprovals = 1)
   }
 
   property(s"be valid if single family and withdrawn < $multiplier * total") {
     val numOfRelevantLars = (sampleSize * (1.0 - multiplier)).toInt + 1
-    val validLarSource = newLarSource(testLars, numOfRelevantLars, validLar(_), invalidLar(_))
+    val validLarSource = newLarSource(testLars, numOfRelevantLars, relevantLar, irrelevantLar)
     validLarSource.mustPass
   }
 
   property(s"be valid if single family and withdrawn = $multiplier * total") {
     val numOfRelevantLars = (sampleSize * (1.0 - multiplier)).toInt
-    val validLarSource = newLarSource(testLars, numOfRelevantLars, validLar(_), invalidLar(_))
+    val validLarSource = newLarSource(testLars, numOfRelevantLars, relevantLar, irrelevantLar)
     validLarSource.mustPass
   }
 
   property(s"be invalid if single family and withdrawn > $multiplier * total") {
     val numOfRelevantLars = (sampleSize * (1.0 - multiplier)).toInt - 1
-    val invalidLarSource = newLarSource(testLars, numOfRelevantLars, validLar(_), invalidLar(_))
+    val invalidLarSource = newLarSource(testLars, numOfRelevantLars, relevantLar, irrelevantLar)
     invalidLarSource.mustFail
   }
 


### PR DESCRIPTION
Add Q047 and refactor `newActionTakenTypeSource` into `newLarSource` which takes two functions as arguments that define how a lar is transformed to create a valid or invalid lar.

Closes #217 
