### PR TITLE
Fix compiler warning

### DIFF
--- a/api/src/main/scala/hmda/api/http/institutions/submissions/SubmissionEditPaths.scala
+++ b/api/src/main/scala/hmda/api/http/institutions/submissions/SubmissionEditPaths.scala
@@ -87,6 +87,8 @@ trait SubmissionEditPaths
               complete(ToResponseMarshallable(edits))
             case Success(edits: EditResults) =>
               complete(ToResponseMarshallable(edits))
+            case Success(_) =>
+              completeWithInternalError(uri, new IllegalStateException)
             case Failure(error) =>
               completeWithInternalError(uri, error)
           }


### PR DESCRIPTION
Closes #670 

Since Scala does pattern matching in sequence, the third `Success()` case here should never be reached, but it will mute the compiler warnings.