### PR TITLE
S270

### DIFF
--- a/validation/src/main/scala/hmda/validation/engine/lar/syntactical/LarSyntacticalEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/lar/syntactical/LarSyntacticalEngine.scala
@@ -15,7 +15,8 @@ trait LarSyntacticalEngine extends LarCommonEngine with ValidationApi {
       S010,
       S020,
       S025.inContext(ctx),
-      S205
+      S205,
+      S270.inContext(ctx)
     )
     val checks = checksToRun.map(check(_, lar, lar.loan.id, Syntactical))
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/syntactical/S270.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/syntactical/S270.scala
@@ -1,0 +1,23 @@
+package hmda.validation.rules.lar.syntactical
+
+import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.validation.context.ValidationContext
+import hmda.validation.dsl.PredicateCommon._
+import hmda.validation.dsl.PredicateSyntax.PredicateOps
+import hmda.validation.dsl.Result
+import hmda.validation.rules.{ EditCheck, IfYearPresentIn }
+
+object S270 {
+  def inContext(ctx: ValidationContext): EditCheck[LoanApplicationRegister] = {
+    IfYearPresentIn(ctx) { new S270(_) }
+  }
+}
+
+class S270 private (year: Int) extends EditCheck[LoanApplicationRegister] {
+  override def name: String = "S270"
+
+  override def apply(lar: LoanApplicationRegister): Result = {
+    val larYear = lar.actionTakenDate.toString.substring(0, 4).toInt
+    larYear is equalTo(year)
+  }
+}

--- a/validation/src/test/scala/hmda/validation/rules/lar/syntactical/S270Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/syntactical/S270Spec.scala
@@ -1,0 +1,51 @@
+package hmda.validation.rules.lar.syntactical
+
+import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.parser.fi.lar.LarGenerators
+import hmda.validation.context.ValidationContext
+import hmda.validation.dsl.{ Failure, Success }
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{ MustMatchers, PropSpec }
+
+class S270Spec extends PropSpec with PropertyChecks with MustMatchers with LarGenerators {
+  property("be named S270") {
+    val ctx = ValidationContext(None, Some(2017))
+
+    S270.inContext(ctx).name mustBe "S270"
+  }
+
+  def in2017(lar: LoanApplicationRegister): LoanApplicationRegister = {
+    val date = lar.actionTakenDate.toString
+    val monthAndDay = date.substring(4)
+    val newDate = ("2017" + monthAndDay).toInt
+    lar.copy(actionTakenDate = newDate)
+  }
+
+  property("succeed when the year of the LAR's Action Taken Date matches the filing year") {
+    val ctx = ValidationContext(None, Some(2017))
+
+    forAll(larGen) { l =>
+      val lar = in2017(l)
+      S270.inContext(ctx)(lar) mustBe Success()
+    }
+  }
+
+  property("fail when TS's activity year does not match the filing year") {
+    val ctx = ValidationContext(None, Some(2018))
+
+    forAll(larGen) { l =>
+      val lar = in2017(l)
+      S270.inContext(ctx)(lar) mustBe Failure()
+    }
+  }
+
+  property("succeed when there is no filing year") {
+    val ctx = ValidationContext(None, None)
+
+    forAll(larGen) { l =>
+      val lar = in2017(l)
+      S270.inContext(ctx)(lar) mustBe Success()
+    }
+  }
+
+}


### PR DESCRIPTION
Closes #131

I've implemented S270 to use the exact same pattern as S100 (TS). The activity year comes from the validation context. If the validation context doesn't provide a year, this edit is treated as optional and automatically passes.