### PR TITLE
WIP: Add lar level fields

### DIFF
--- a/Documents/API.md
+++ b/Documents/API.md
@@ -249,17 +249,34 @@ All endpoints in the `/institutions` namespace require two headers (see "Authori
                         "description": "None"
                       }
                     ],
-            "ts": true,
             "lars": [
+               {
+                "larId": "Transmittal Sheet",
+                "fields": [
+                  {
+                    "name": "None",
+                    "value": ""
+                  }
+                ]
+               },
               {
-                "lar": {"loanId": "s1"}
-              },
-              {
-                "lar": {"loanId": "s2"}
-              },
-              {
-                "lar": {"loanId": "s3"}
-              }
+                          "larId": "ABCDE12345ABCDE12345ABCDE",
+                          "fields": [
+                            {
+                              "name": "None",
+                              "value": ""
+                            }
+                          ]
+                        },
+                        {
+                          "larId": "ABCDE12345ABCDE12345ABCDE",
+                          "fields": [
+                            {
+                              "name": "None",
+                              "value": ""
+                            }
+                          ]
+                        }
             ]
           },
           {
@@ -274,11 +291,23 @@ All endpoints in the `/institutions` namespace require two headers (see "Authori
             "ts": false,
             "lars": [
               {
-                "lar": {"loanId": "s4"}
-              },
-              {
-                "lar": {"loanId": "s5"}
-              }
+                          "larId": "ABCDE12345ABCDE12345ABCDE",
+                          "fields": [
+                            {
+                              "name": "None",
+                              "value": ""
+                            }
+                          ]
+                        },
+                        {
+                          "larId": "ABCDE12345ABCDE12345ABCDE",
+                          "fields": [
+                            {
+                              "name": "None",
+                              "value": ""
+                            }
+                          ]
+                        }
             ]
           }
         ]
@@ -328,10 +357,14 @@ All endpoints in the `/institutions` namespace require two headers (see "Authori
               ],
       "lars": [
         {
-          "lar": {
-            "loanId": "4977566612"
-          }
-        }
+                     "larId": "ABCDE12345ABCDE12345ABCDE",
+                     "fields": [
+                       {
+                         "name": "None",
+                         "value": ""
+                       }
+                     ]
+                   }
       ]
     },
     {
@@ -346,9 +379,17 @@ All endpoints in the `/institutions` namespace require two headers (see "Authori
               ],
       "lars": [
         {
-          "lar": {
-            "loanId": "4977566612"
-          }
+          "lar": [
+            {
+                        "larId": "ABCDE12345ABCDE12345ABCDE",
+                        "fields": [
+                          {
+                            "name": "None",
+                            "value": ""
+                          }
+                        ]
+                      }
+          ]
         }
       ]
     }

--- a/Documents/API.md
+++ b/Documents/API.md
@@ -242,6 +242,7 @@ All endpoints in the `/institutions` namespace require two headers (see "Authori
         "edits": [
           {
             "edit": "S025",
+            "description": "Description of S025",
             "ts": true,
             "lars": [
               {
@@ -257,6 +258,7 @@ All endpoints in the `/institutions` namespace require two headers (see "Authori
           },
           {
             "edit": "S010",
+            "description": "Description of S010",
             "ts": false,
             "lars": [
               {
@@ -275,7 +277,8 @@ All endpoints in the `/institutions` namespace require two headers (see "Authori
         {
             "edits": [
                 {
-                   "edit": "q007",
+                   "edit": "Q007",
+                   "description: "Description of Q007",
                    "justifications": [
                      {
                        "value": "don't worry",
@@ -303,6 +306,7 @@ All endpoints in the `/institutions` namespace require two headers (see "Authori
   "edits": [
     {
       "edit": "V555",
+      "description: "Description of V555",
       "ts": false,
       "lars": [
         {
@@ -314,6 +318,7 @@ All endpoints in the `/institutions` namespace require two headers (see "Authori
     },
     {
       "edit": "V550",
+      "description: "Description of V550",
       "ts": false,
       "lars": [
         {

--- a/Documents/API.md
+++ b/Documents/API.md
@@ -243,6 +243,12 @@ All endpoints in the `/institutions` namespace require two headers (see "Authori
           {
             "edit": "S025",
             "description": "Description of S025",
+            "fields": [
+                      {
+                        "name": "None",
+                        "description": "None"
+                      }
+                    ],
             "ts": true,
             "lars": [
               {
@@ -259,6 +265,12 @@ All endpoints in the `/institutions` namespace require two headers (see "Authori
           {
             "edit": "S010",
             "description": "Description of S010",
+            "fields": [
+                      {
+                        "name": "None",
+                        "description": "None"
+                      }
+                    ],
             "ts": false,
             "lars": [
               {
@@ -308,6 +320,12 @@ All endpoints in the `/institutions` namespace require two headers (see "Authori
       "edit": "V555",
       "description: "Description of V555",
       "ts": false,
+      "fields": [
+                {
+                  "name": "None",
+                  "description": "None"
+                }
+              ],
       "lars": [
         {
           "lar": {
@@ -320,6 +338,12 @@ All endpoints in the `/institutions` namespace require two headers (see "Authori
       "edit": "V550",
       "description: "Description of V550",
       "ts": false,
+      "fields": [
+                {
+                  "name": "None",
+                  "description": "None"
+                }
+              ],
       "lars": [
         {
           "lar": {

--- a/api/src/main/scala/hmda/api/http/LarHttpApi.scala
+++ b/api/src/main/scala/hmda/api/http/LarHttpApi.scala
@@ -98,7 +98,7 @@ trait LarHttpApi extends LarProtocol with ValidationResultProtocol with HmdaCust
   def aggregateErrors(validationErrors: ValidationErrors): SingleValidationErrorResult = {
     val errors = validationErrors.errors.groupBy(_.errorType)
     def allOfType(errorType: ValidationErrorType): Seq[String] = {
-      errors.getOrElse(errorType, List()).map(e => e.name)
+      errors.getOrElse(errorType, List()).map(e => e.metaData.name)
     }
 
     SingleValidationErrorResult(

--- a/api/src/main/scala/hmda/api/http/ValidationErrorConverter.scala
+++ b/api/src/main/scala/hmda/api/http/ValidationErrorConverter.scala
@@ -16,7 +16,7 @@ trait ValidationErrorConverter {
     val tsEditResults: Seq[EditResult] = tsUniqueErrors.map(x => EditResult(x.name, x.description, x.fields.toList.map(y => y._1), ts = true, Nil))
 
     val larEditResults: Map[ValidationErrorType, Map[ValidationErrorMetaData, Seq[LarEditResult]]] =
-      editValues.mapValues(x => x.mapValues(y => y.map(_.errorId).map(z => LarEditResult(LarId(z)))))
+      editValues.mapValues(x => x.mapValues(y => y.map(z => LarEditResult(z.errorId, z.metaData.fields.map(a => LarEditField(a._1.name, a._2)).toList))))
 
     val mapResults = larEditResults.getOrElse(validationErrorType, Map.empty[ValidationErrorMetaData, Seq[LarEditResult]])
     EditResults(

--- a/api/src/main/scala/hmda/api/http/ValidationErrorConverter.scala
+++ b/api/src/main/scala/hmda/api/http/ValidationErrorConverter.scala
@@ -13,7 +13,7 @@ trait ValidationErrorConverter {
 
     val tsNamedErrors: Seq[ValidationErrorMetaData] = tsErrors.map(_.metaData)
     val tsUniqueErrors: Seq[ValidationErrorMetaData] = tsNamedErrors.diff(larErrors.map(_.metaData))
-    val tsEditResults: Seq[EditResult] = tsUniqueErrors.map(x => EditResult(x.name, x.description, ts = true, Nil))
+    val tsEditResults: Seq[EditResult] = tsUniqueErrors.map(x => EditResult(x.name, x.description, x.fields.toList.map(y => y._1), ts = true, Nil))
 
     val larEditResults: Map[ValidationErrorType, Map[ValidationErrorMetaData, Seq[LarEditResult]]] =
       editValues.mapValues(x => x.mapValues(y => y.map(_.errorId).map(z => LarEditResult(LarId(z)))))
@@ -22,7 +22,7 @@ trait ValidationErrorConverter {
     EditResults(
       mapResults
         .toList
-        .map(x => EditResult(x._1.name, x._1.description, tsNamedErrors.contains(x._1), x._2))
+        .map(x => EditResult(x._1.name, x._1.description, x._1.fields.toList.map(y => y._1), tsNamedErrors.contains(x._1), x._2))
         .union(tsEditResults)
     )
 

--- a/api/src/main/scala/hmda/api/http/ValidationErrorConverter.scala
+++ b/api/src/main/scala/hmda/api/http/ValidationErrorConverter.scala
@@ -5,26 +5,41 @@ import hmda.validation.engine._
 
 trait ValidationErrorConverter {
 
-  def validationErrorsToEditResults(tsErrors: Seq[ValidationError], larErrors: Seq[ValidationError], validationErrorType: ValidationErrorType) = {
-    val errorsByType: Map[ValidationErrorType, Seq[ValidationError]] = larErrors.groupBy(_.errorType)
+  def validationErrorsToEditResults(tsErrors: Seq[ValidationError], larErrors: Seq[ValidationError], validationErrorType: ValidationErrorType): EditResults = {
 
-    val editValues: Map[ValidationErrorType, Map[ValidationErrorMetaData, Seq[ValidationError]]] =
-      errorsByType.mapValues(x => x.groupBy(y => y.metaData))
+    def singleTypeValidationErrorsToEditResults(errors: Seq[ValidationError], validationErrorType: ValidationErrorType): Seq[EditResult] = {
+      val errorsByType: Map[ValidationErrorType, Seq[ValidationError]] = errors.groupBy(_.errorType)
 
-    val tsNamedErrors: Seq[ValidationErrorMetaData] = tsErrors.map(_.metaData)
-    val tsUniqueErrors: Seq[ValidationErrorMetaData] = tsNamedErrors.diff(larErrors.map(_.metaData))
-    val tsEditResults: Seq[EditResult] = tsUniqueErrors.map(x => EditResult(x.name, x.description, x.fields.toList.map(y => y._1), ts = true, Nil))
+      val editValues: Map[ValidationErrorType, Map[ValidationErrorMetaData, Seq[ValidationError]]] =
+        errorsByType.mapValues(x => x.groupBy(y => y.metaData))
 
-    val larEditResults: Map[ValidationErrorType, Map[ValidationErrorMetaData, Seq[LarEditResult]]] =
-      editValues.mapValues(x => x.mapValues(y => y.map(z => LarEditResult(z.errorId, z.metaData.fields.map(a => LarEditField(a._1.name, a._2)).toList))))
+      val larEditResults: Map[ValidationErrorType, Map[ValidationErrorMetaData, Seq[LarEditResult]]] =
+        editValues.mapValues(x => x.mapValues(y => y.map(z => LarEditResult(z.errorId, z.metaData.fields.map(a => LarEditField(a._1.name, a._2)).toList))))
 
-    val mapResults = larEditResults.getOrElse(validationErrorType, Map.empty[ValidationErrorMetaData, Seq[LarEditResult]])
-    EditResults(
+      val mapResults = larEditResults.getOrElse(validationErrorType, Map.empty[ValidationErrorMetaData, Seq[LarEditResult]])
       mapResults
         .toList
-        .map(x => EditResult(x._1.name, x._1.description, x._1.fields.toList.map(y => y._1), tsNamedErrors.contains(x._1), x._2))
-        .union(tsEditResults)
-    )
+        .map(x => EditResult(x._1.name, x._1.description, x._1.fields.toList.map(y => y._1), x._2))
+    }
+
+    val tsErrorsRenamed: Seq[ValidationError] = {
+      tsErrors.map(x => {
+        x.copy(errorId = "Transmittal Sheet")
+      })
+    }
+
+    val tsEdits = singleTypeValidationErrorsToEditResults(tsErrorsRenamed, validationErrorType)
+    val larEdits = singleTypeValidationErrorsToEditResults(larErrors, validationErrorType)
+    val larEditNames = larEdits.map(_.edit)
+
+    val tsUnique = tsEdits.filter(x => !larEditNames.contains(x.edit))
+    val tsDup = tsEdits.diff(tsUnique)
+
+    EditResults(larEdits.map(x => {
+      val ts = tsDup.filter(y => x.edit == y.edit)
+      if (ts.length == 1) x.copy(lars = x.lars ++ ts.head.lars)
+      else x
+    }) ++ tsUnique)
 
   }
 

--- a/api/src/main/scala/hmda/api/model/EditResults.scala
+++ b/api/src/main/scala/hmda/api/model/EditResults.scala
@@ -4,7 +4,7 @@ import hmda.model.fi.RecordField
 
 case class LarEditField(name: String, value: String)
 case class LarEditResult(larId: String, fields: List[LarEditField])
-case class EditResult(edit: String, description: String, fields: List[RecordField], ts: Boolean, lars: Seq[LarEditResult])
+case class EditResult(edit: String, description: String, fields: List[RecordField], lars: Seq[LarEditResult])
 case class EditResults(edits: Seq[EditResult])
 case object EditResults {
   def empty: EditResults = EditResults(Nil)

--- a/api/src/main/scala/hmda/api/model/EditResults.scala
+++ b/api/src/main/scala/hmda/api/model/EditResults.scala
@@ -2,7 +2,7 @@ package hmda.api.model
 
 case class LarId(loanId: String)
 case class LarEditResult(lar: LarId)
-case class EditResult(edit: String, ts: Boolean, lars: Seq[LarEditResult])
+case class EditResult(edit: String, description: String, ts: Boolean, lars: Seq[LarEditResult])
 case class EditResults(edits: Seq[EditResult])
 case object EditResults {
   def empty: EditResults = EditResults(Nil)

--- a/api/src/main/scala/hmda/api/model/EditResults.scala
+++ b/api/src/main/scala/hmda/api/model/EditResults.scala
@@ -2,8 +2,8 @@ package hmda.api.model
 
 import hmda.model.fi.RecordField
 
-case class LarId(loanId: String)
-case class LarEditResult(lar: LarId)
+case class LarEditField(name: String, value: String)
+case class LarEditResult(larId: String, fields: List[LarEditField])
 case class EditResult(edit: String, description: String, fields: List[RecordField], ts: Boolean, lars: Seq[LarEditResult])
 case class EditResults(edits: Seq[EditResult])
 case object EditResults {

--- a/api/src/main/scala/hmda/api/model/EditResults.scala
+++ b/api/src/main/scala/hmda/api/model/EditResults.scala
@@ -1,8 +1,10 @@
 package hmda.api.model
 
+import hmda.model.fi.RecordField
+
 case class LarId(loanId: String)
 case class LarEditResult(lar: LarId)
-case class EditResult(edit: String, description: String, ts: Boolean, lars: Seq[LarEditResult])
+case class EditResult(edit: String, description: String, fields: List[RecordField], ts: Boolean, lars: Seq[LarEditResult])
 case class EditResults(edits: Seq[EditResult])
 case object EditResults {
   def empty: EditResults = EditResults(Nil)

--- a/api/src/main/scala/hmda/api/protocol/processing/EditResultsProtocol.scala
+++ b/api/src/main/scala/hmda/api/protocol/processing/EditResultsProtocol.scala
@@ -1,12 +1,14 @@
 package hmda.api.protocol.processing
 
 import hmda.api.model._
+import hmda.model.fi.RecordField
 import spray.json.DefaultJsonProtocol
 
 trait EditResultsProtocol extends DefaultJsonProtocol {
+  implicit val larFieldFormat = jsonFormat2(RecordField.apply)
   implicit val larIdFormat = jsonFormat1(LarId.apply)
   implicit val larEditResultFormat = jsonFormat1(LarEditResult.apply)
-  implicit val editResultFormat = jsonFormat4(EditResult.apply)
+  implicit val editResultFormat = jsonFormat5(EditResult.apply)
   implicit val editResultsFormat = jsonFormat1(EditResults.apply)
   implicit val justificationFormat = jsonFormat2(Justification.apply)
   implicit val macroResultFormat = jsonFormat2(MacroResult.apply)

--- a/api/src/main/scala/hmda/api/protocol/processing/EditResultsProtocol.scala
+++ b/api/src/main/scala/hmda/api/protocol/processing/EditResultsProtocol.scala
@@ -6,8 +6,8 @@ import spray.json.DefaultJsonProtocol
 
 trait EditResultsProtocol extends DefaultJsonProtocol {
   implicit val larFieldFormat = jsonFormat2(RecordField.apply)
-  implicit val larIdFormat = jsonFormat1(LarId.apply)
-  implicit val larEditResultFormat = jsonFormat1(LarEditResult.apply)
+  implicit val larEditFieldFormat = jsonFormat2(LarEditField.apply)
+  implicit val larEditResultFormat = jsonFormat2(LarEditResult.apply)
   implicit val editResultFormat = jsonFormat5(EditResult.apply)
   implicit val editResultsFormat = jsonFormat1(EditResults.apply)
   implicit val justificationFormat = jsonFormat2(Justification.apply)

--- a/api/src/main/scala/hmda/api/protocol/processing/EditResultsProtocol.scala
+++ b/api/src/main/scala/hmda/api/protocol/processing/EditResultsProtocol.scala
@@ -8,7 +8,7 @@ trait EditResultsProtocol extends DefaultJsonProtocol {
   implicit val larFieldFormat = jsonFormat2(RecordField.apply)
   implicit val larEditFieldFormat = jsonFormat2(LarEditField.apply)
   implicit val larEditResultFormat = jsonFormat2(LarEditResult.apply)
-  implicit val editResultFormat = jsonFormat5(EditResult.apply)
+  implicit val editResultFormat = jsonFormat4(EditResult.apply)
   implicit val editResultsFormat = jsonFormat1(EditResults.apply)
   implicit val justificationFormat = jsonFormat2(Justification.apply)
   implicit val macroResultFormat = jsonFormat2(MacroResult.apply)

--- a/api/src/main/scala/hmda/api/protocol/processing/EditResultsProtocol.scala
+++ b/api/src/main/scala/hmda/api/protocol/processing/EditResultsProtocol.scala
@@ -6,7 +6,7 @@ import spray.json.DefaultJsonProtocol
 trait EditResultsProtocol extends DefaultJsonProtocol {
   implicit val larIdFormat = jsonFormat1(LarId.apply)
   implicit val larEditResultFormat = jsonFormat1(LarEditResult.apply)
-  implicit val editResultFormat = jsonFormat3(EditResult.apply)
+  implicit val editResultFormat = jsonFormat4(EditResult.apply)
   implicit val editResultsFormat = jsonFormat1(EditResults.apply)
   implicit val justificationFormat = jsonFormat2(Justification.apply)
   implicit val macroResultFormat = jsonFormat2(MacroResult.apply)

--- a/api/src/main/scala/hmda/api/protocol/validation/ValidationResultProtocol.scala
+++ b/api/src/main/scala/hmda/api/protocol/validation/ValidationResultProtocol.scala
@@ -27,6 +27,7 @@ trait ValidationResultProtocol extends DefaultJsonProtocol {
     }
   }
 
+  implicit val validationErrorMetaDataFormat = jsonFormat2(ValidationErrorMetaData.apply)
   implicit val validationErrorFormat = jsonFormat3(ValidationError.apply)
   implicit val larValidationErrorsFormat = jsonFormat1(LarValidationErrors.apply)
   implicit val tsValidationErrorsFormat = jsonFormat1(TsValidationErrors.apply)

--- a/api/src/test/scala/hmda/api/http/ValidationErrorConverterSpec.scala
+++ b/api/src/test/scala/hmda/api/http/ValidationErrorConverterSpec.scala
@@ -33,8 +33,8 @@ class ValidationErrorConverterSpec extends WordSpec with MustMatchers with Valid
         validationErrorsToMacroResults(larErrors)
       val summaryEditResults = SummaryEditResults(syntacticalEditResults, validityEditResults, qualityEditResults, macroEditResults)
 
-      val s020 = EditResult("S020", "", List(noField), ts = true, Seq(LarEditResult(LarId("8299422144")), LarEditResult(LarId("2185751599"))))
-      val s010 = EditResult("S010", "", List(noField), ts = false, Seq(LarEditResult(LarId("2185751599"))))
+      val s020 = EditResult("S020", "", List(noField), ts = true, Seq(LarEditResult("8299422144", List(LarEditField("None", ""))), LarEditResult("2185751599", List(LarEditField("None", "")))))
+      val s010 = EditResult("S010", "", List(noField), ts = false, Seq(LarEditResult("2185751599", List(LarEditField("None", "")))))
       summaryEditResults.syntactical.edits.head mustBe s010
       summaryEditResults.syntactical.edits.tail.contains(s020) mustBe true
       summaryEditResults.validity.edits.size mustBe 3

--- a/api/src/test/scala/hmda/api/http/ValidationErrorConverterSpec.scala
+++ b/api/src/test/scala/hmda/api/http/ValidationErrorConverterSpec.scala
@@ -13,6 +13,8 @@ import hmda.validation.engine.lar.LarEngine
 import hmda.validation.engine.ts.TsEngine
 import org.scalatest.{ MustMatchers, WordSpec }
 
+import scala.collection.mutable
+
 class ValidationErrorConverterSpec extends WordSpec with MustMatchers with ValidationErrorConverter with LarEngine {
 
   "Validation errors" must {
@@ -33,8 +35,8 @@ class ValidationErrorConverterSpec extends WordSpec with MustMatchers with Valid
         validationErrorsToMacroResults(larErrors)
       val summaryEditResults = SummaryEditResults(syntacticalEditResults, validityEditResults, qualityEditResults, macroEditResults)
 
-      val s020 = EditResult("S020", "", List(noField), ts = true, Seq(LarEditResult("8299422144", List(LarEditField("None", ""))), LarEditResult("2185751599", List(LarEditField("None", "")))))
-      val s010 = EditResult("S010", "", List(noField), ts = false, Seq(LarEditResult("2185751599", List(LarEditField("None", "")))))
+      val s020 = EditResult("S020", "", List(noField), Seq(LarEditResult("8299422144", List(LarEditField("None", ""))), LarEditResult("2185751599", List(LarEditField("None", ""))), LarEditResult("Transmittal Sheet", List(LarEditField("None", "")))))
+      val s010 = EditResult("S010", "", List(noField), Seq(LarEditResult("2185751599", List(LarEditField("None", "")))))
       summaryEditResults.syntactical.edits.head mustBe s010
       summaryEditResults.syntactical.edits.tail.contains(s020) mustBe true
       summaryEditResults.validity.edits.size mustBe 3

--- a/api/src/test/scala/hmda/api/http/ValidationErrorConverterSpec.scala
+++ b/api/src/test/scala/hmda/api/http/ValidationErrorConverterSpec.scala
@@ -20,7 +20,7 @@ class ValidationErrorConverterSpec extends WordSpec with MustMatchers with Valid
       val ctx = ValidationContext(None, Some(2017))
       val larErrors = badLars.flatMap(lar => validationErrors(lar, ctx, validateLar).errors)
 
-      val tsErrors = Seq(ValidationError("8299422144", "S020", Syntactical))
+      val tsErrors = Seq(ValidationError("8299422144", ValidationErrorMetaData("S020", ""), Syntactical))
 
       val syntacticalEditResults =
         validationErrorsToEditResults(tsErrors, larErrors, Syntactical)
@@ -32,8 +32,8 @@ class ValidationErrorConverterSpec extends WordSpec with MustMatchers with Valid
         validationErrorsToMacroResults(larErrors)
       val summaryEditResults = SummaryEditResults(syntacticalEditResults, validityEditResults, qualityEditResults, macroEditResults)
 
-      val s020 = EditResult("S020", ts = true, Seq(LarEditResult(LarId("8299422144")), LarEditResult(LarId("2185751599"))))
-      val s010 = EditResult("S010", ts = false, Seq(LarEditResult(LarId("2185751599"))))
+      val s020 = EditResult("S020", "", ts = true, Seq(LarEditResult(LarId("8299422144")), LarEditResult(LarId("2185751599"))))
+      val s010 = EditResult("S010", "", ts = false, Seq(LarEditResult(LarId("2185751599"))))
       summaryEditResults.syntactical.edits.head mustBe s020
       summaryEditResults.syntactical.edits.tail.contains(s010) mustBe true
       summaryEditResults.validity.edits.size mustBe 3

--- a/api/src/test/scala/hmda/api/http/ValidationErrorConverterSpec.scala
+++ b/api/src/test/scala/hmda/api/http/ValidationErrorConverterSpec.scala
@@ -2,6 +2,7 @@ package hmda.api.http
 
 import hmda.api.model._
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.model.fi.ts.TransmittalSheet
 import hmda.model.util.FITestData._
 import hmda.parser.fi.lar.LarCsvParser
@@ -20,7 +21,7 @@ class ValidationErrorConverterSpec extends WordSpec with MustMatchers with Valid
       val ctx = ValidationContext(None, Some(2017))
       val larErrors = badLars.flatMap(lar => validationErrors(lar, ctx, validateLar).errors)
 
-      val tsErrors = Seq(ValidationError("8299422144", ValidationErrorMetaData("S020", ""), Syntactical))
+      val tsErrors = Seq(ValidationError("8299422144", ValidationErrorMetaData("S020", "", Map(noField -> "")), Syntactical))
 
       val syntacticalEditResults =
         validationErrorsToEditResults(tsErrors, larErrors, Syntactical)
@@ -32,10 +33,10 @@ class ValidationErrorConverterSpec extends WordSpec with MustMatchers with Valid
         validationErrorsToMacroResults(larErrors)
       val summaryEditResults = SummaryEditResults(syntacticalEditResults, validityEditResults, qualityEditResults, macroEditResults)
 
-      val s020 = EditResult("S020", "", ts = true, Seq(LarEditResult(LarId("8299422144")), LarEditResult(LarId("2185751599"))))
-      val s010 = EditResult("S010", "", ts = false, Seq(LarEditResult(LarId("2185751599"))))
-      summaryEditResults.syntactical.edits.head mustBe s020
-      summaryEditResults.syntactical.edits.tail.contains(s010) mustBe true
+      val s020 = EditResult("S020", "", List(noField), ts = true, Seq(LarEditResult(LarId("8299422144")), LarEditResult(LarId("2185751599"))))
+      val s010 = EditResult("S010", "", List(noField), ts = false, Seq(LarEditResult(LarId("2185751599"))))
+      summaryEditResults.syntactical.edits.head mustBe s010
+      summaryEditResults.syntactical.edits.tail.contains(s020) mustBe true
       summaryEditResults.validity.edits.size mustBe 3
       summaryEditResults.quality mustBe EditResults(Nil)
       summaryEditResults.`macro` mustBe MacroResults(Nil)

--- a/api/src/test/scala/hmda/api/http/institutions/submissions/SubmissionEditPathsSpec.scala
+++ b/api/src/test/scala/hmda/api/http/institutions/submissions/SubmissionEditPathsSpec.scala
@@ -27,14 +27,14 @@ class SubmissionEditPathsSpec extends InstitutionHttpApiSpec {
     val expectedSummary = SummaryEditResults(
       EditResults(
         List(
-          EditResult("S010", "", List(noField), ts = false, List(LarEditResult(LarId("loan1")))),
-          EditResult("S020", "", List(noField), ts = true, List(LarEditResult(LarId("loan1"))))
+          EditResult("S010", "", List(noField), ts = false, Seq(LarEditResult("loan1", List(LarEditField("None", ""))))),
+          EditResult("S020", "", List(noField), ts = true, Seq(LarEditResult("loan1", List(LarEditField("None", "")))))
         )
       ),
       EditResults(
         List(
-          EditResult("V285", "", List(noField), ts = false, List(LarEditResult(LarId("loan2")), LarEditResult(LarId("loan3")))),
-          EditResult("V280", "", List(noField), ts = false, List(LarEditResult(LarId("loan1"))))
+          EditResult("V285", "", List(noField), ts = false, Seq(LarEditResult("loan2", List(LarEditField("None", ""))), LarEditResult("loan3", List(LarEditField("None", ""))))),
+          EditResult("V280", "", List(noField), ts = false, Seq(LarEditResult("loan1", List(LarEditField("None", "")))))
         )
       ),
       EditResults.empty,
@@ -51,8 +51,8 @@ class SubmissionEditPathsSpec extends InstitutionHttpApiSpec {
     val expectedEdits =
       EditResults(
         List(
-          EditResult("V285", "", List(noField), ts = false, List(LarEditResult(LarId("loan2")), LarEditResult(LarId("loan3")))),
-          EditResult("V280", "", List(noField), ts = false, List(LarEditResult(LarId("loan1"))))
+          EditResult("V285", "", List(noField), ts = false, Seq(LarEditResult("loan2", List(LarEditField("None", ""))), LarEditResult("loan3", List(LarEditField("None", ""))))),
+          EditResult("V280", "", List(noField), ts = false, Seq(LarEditResult("loan1", List(LarEditField("None", "")))))
         )
       )
 

--- a/api/src/test/scala/hmda/api/http/institutions/submissions/SubmissionEditPathsSpec.scala
+++ b/api/src/test/scala/hmda/api/http/institutions/submissions/SubmissionEditPathsSpec.scala
@@ -7,6 +7,7 @@ import akka.pattern.ask
 import hmda.api.http.InstitutionHttpApiSpec
 import hmda.api.model._
 import hmda.model.fi._
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.persistence.HmdaSupervisor.FindProcessingActor
 import hmda.persistence.processing.HmdaFileValidator
 import hmda.validation.engine._
@@ -26,14 +27,14 @@ class SubmissionEditPathsSpec extends InstitutionHttpApiSpec {
     val expectedSummary = SummaryEditResults(
       EditResults(
         List(
-          EditResult("S020", "", ts = true, List(LarEditResult(LarId("loan1")))),
-          EditResult("S010", "", ts = false, List(LarEditResult(LarId("loan1"))))
+          EditResult("S010", "", List(noField), ts = false, List(LarEditResult(LarId("loan1")))),
+          EditResult("S020", "", List(noField), ts = true, List(LarEditResult(LarId("loan1"))))
         )
       ),
       EditResults(
         List(
-          EditResult("V285", "", ts = false, List(LarEditResult(LarId("loan2")), LarEditResult(LarId("loan3")))),
-          EditResult("V280", "", ts = false, List(LarEditResult(LarId("loan1"))))
+          EditResult("V285", "", List(noField), ts = false, List(LarEditResult(LarId("loan2")), LarEditResult(LarId("loan3")))),
+          EditResult("V280", "", List(noField), ts = false, List(LarEditResult(LarId("loan1"))))
         )
       ),
       EditResults.empty,
@@ -50,8 +51,8 @@ class SubmissionEditPathsSpec extends InstitutionHttpApiSpec {
     val expectedEdits =
       EditResults(
         List(
-          EditResult("V285", "", ts = false, List(LarEditResult(LarId("loan2")), LarEditResult(LarId("loan3")))),
-          EditResult("V280", "", ts = false, List(LarEditResult(LarId("loan1"))))
+          EditResult("V285", "", List(noField), ts = false, List(LarEditResult(LarId("loan2")), LarEditResult(LarId("loan3")))),
+          EditResult("V280", "", List(noField), ts = false, List(LarEditResult(LarId("loan1"))))
         )
       )
 
@@ -112,12 +113,12 @@ class SubmissionEditPathsSpec extends InstitutionHttpApiSpec {
     val submissionId = SubmissionId(id, period, seqNr)
     val fHmdaValidator = (supervisor ? FindProcessingActor(HmdaFileValidator.name, submissionId)).mapTo[ActorRef]
 
-    val s1 = ValidationError("loan1", ValidationErrorMetaData("S010", ""), Syntactical)
-    val s2 = ValidationError("loan1", ValidationErrorMetaData("S020", ""), Syntactical)
-    val v1 = ValidationError("loan1", ValidationErrorMetaData("V280", ""), Validity)
-    val v2 = ValidationError("loan2", ValidationErrorMetaData("V285", ""), Validity)
-    val v3 = ValidationError("loan3", ValidationErrorMetaData("V285", ""), Validity)
-    val m1 = ValidationError("", ValidationErrorMetaData("Q007", ""), Macro)
+    val s1 = ValidationError("loan1", ValidationErrorMetaData("S010", "", Map(noField -> "")), Syntactical)
+    val s2 = ValidationError("loan1", ValidationErrorMetaData("S020", "", Map(noField -> "")), Syntactical)
+    val v1 = ValidationError("loan1", ValidationErrorMetaData("V280", "", Map(noField -> "")), Validity)
+    val v2 = ValidationError("loan2", ValidationErrorMetaData("V285", "", Map(noField -> "")), Validity)
+    val v3 = ValidationError("loan3", ValidationErrorMetaData("V285", "", Map(noField -> "")), Validity)
+    val m1 = ValidationError("", ValidationErrorMetaData("Q007", "", Map(noField -> "")), Macro)
     val larValidationErrors = LarValidationErrors(Seq(s1, s2, v1, v2, v3, m1))
 
     val tsValidationErrors = TsValidationErrors(Seq(s2))

--- a/api/src/test/scala/hmda/api/http/institutions/submissions/SubmissionEditPathsSpec.scala
+++ b/api/src/test/scala/hmda/api/http/institutions/submissions/SubmissionEditPathsSpec.scala
@@ -26,14 +26,14 @@ class SubmissionEditPathsSpec extends InstitutionHttpApiSpec {
     val expectedSummary = SummaryEditResults(
       EditResults(
         List(
-          EditResult("S020", ts = true, List(LarEditResult(LarId("loan1")))),
-          EditResult("S010", ts = false, List(LarEditResult(LarId("loan1"))))
+          EditResult("S020", "", ts = true, List(LarEditResult(LarId("loan1")))),
+          EditResult("S010", "", ts = false, List(LarEditResult(LarId("loan1"))))
         )
       ),
       EditResults(
         List(
-          EditResult("V285", ts = false, List(LarEditResult(LarId("loan2")), LarEditResult(LarId("loan3")))),
-          EditResult("V280", ts = false, List(LarEditResult(LarId("loan1"))))
+          EditResult("V285", "", ts = false, List(LarEditResult(LarId("loan2")), LarEditResult(LarId("loan3")))),
+          EditResult("V280", "", ts = false, List(LarEditResult(LarId("loan1"))))
         )
       ),
       EditResults.empty,
@@ -50,8 +50,8 @@ class SubmissionEditPathsSpec extends InstitutionHttpApiSpec {
     val expectedEdits =
       EditResults(
         List(
-          EditResult("V285", ts = false, List(LarEditResult(LarId("loan2")), LarEditResult(LarId("loan3")))),
-          EditResult("V280", ts = false, List(LarEditResult(LarId("loan1"))))
+          EditResult("V285", "", ts = false, List(LarEditResult(LarId("loan2")), LarEditResult(LarId("loan3")))),
+          EditResult("V280", "", ts = false, List(LarEditResult(LarId("loan1"))))
         )
       )
 
@@ -112,12 +112,12 @@ class SubmissionEditPathsSpec extends InstitutionHttpApiSpec {
     val submissionId = SubmissionId(id, period, seqNr)
     val fHmdaValidator = (supervisor ? FindProcessingActor(HmdaFileValidator.name, submissionId)).mapTo[ActorRef]
 
-    val s1 = ValidationError("loan1", "S010", Syntactical)
-    val s2 = ValidationError("loan1", "S020", Syntactical)
-    val v1 = ValidationError("loan1", "V280", Validity)
-    val v2 = ValidationError("loan2", "V285", Validity)
-    val v3 = ValidationError("loan3", "V285", Validity)
-    val m1 = ValidationError("", "Q007", Macro)
+    val s1 = ValidationError("loan1", ValidationErrorMetaData("S010", ""), Syntactical)
+    val s2 = ValidationError("loan1", ValidationErrorMetaData("S020", ""), Syntactical)
+    val v1 = ValidationError("loan1", ValidationErrorMetaData("V280", ""), Validity)
+    val v2 = ValidationError("loan2", ValidationErrorMetaData("V285", ""), Validity)
+    val v3 = ValidationError("loan3", ValidationErrorMetaData("V285", ""), Validity)
+    val m1 = ValidationError("", ValidationErrorMetaData("Q007", ""), Macro)
     val larValidationErrors = LarValidationErrors(Seq(s1, s2, v1, v2, v3, m1))
 
     val tsValidationErrors = TsValidationErrors(Seq(s2))

--- a/api/src/test/scala/hmda/api/http/institutions/submissions/SubmissionEditPathsSpec.scala
+++ b/api/src/test/scala/hmda/api/http/institutions/submissions/SubmissionEditPathsSpec.scala
@@ -5,7 +5,7 @@ import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.StatusCodes
 import akka.pattern.ask
 import hmda.api.http.InstitutionHttpApiSpec
-import hmda.api.model._
+import hmda.api.model.{ LarEditResult, _ }
 import hmda.model.fi._
 import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.persistence.HmdaSupervisor.FindProcessingActor
@@ -27,14 +27,14 @@ class SubmissionEditPathsSpec extends InstitutionHttpApiSpec {
     val expectedSummary = SummaryEditResults(
       EditResults(
         List(
-          EditResult("S010", "", List(noField), ts = false, Seq(LarEditResult("loan1", List(LarEditField("None", ""))))),
-          EditResult("S020", "", List(noField), ts = true, Seq(LarEditResult("loan1", List(LarEditField("None", "")))))
+          EditResult("S010", "", List(noField), Seq(LarEditResult("loan1", List(LarEditField("None", ""))))),
+          EditResult("S020", "", List(noField), Seq(LarEditResult("loan1", List(LarEditField("None", ""))), LarEditResult("Transmittal Sheet", List(LarEditField("None", "")))))
         )
       ),
       EditResults(
         List(
-          EditResult("V285", "", List(noField), ts = false, Seq(LarEditResult("loan2", List(LarEditField("None", ""))), LarEditResult("loan3", List(LarEditField("None", ""))))),
-          EditResult("V280", "", List(noField), ts = false, Seq(LarEditResult("loan1", List(LarEditField("None", "")))))
+          EditResult("V285", "", List(noField), Seq(LarEditResult("loan2", List(LarEditField("None", ""))), LarEditResult("loan3", List(LarEditField("None", ""))))),
+          EditResult("V280", "", List(noField), Seq(LarEditResult("loan1", List(LarEditField("None", "")))))
         )
       ),
       EditResults.empty,
@@ -51,8 +51,8 @@ class SubmissionEditPathsSpec extends InstitutionHttpApiSpec {
     val expectedEdits =
       EditResults(
         List(
-          EditResult("V285", "", List(noField), ts = false, Seq(LarEditResult("loan2", List(LarEditField("None", ""))), LarEditResult("loan3", List(LarEditField("None", ""))))),
-          EditResult("V280", "", List(noField), ts = false, Seq(LarEditResult("loan1", List(LarEditField("None", "")))))
+          EditResult("V285", "", List(noField), Seq(LarEditResult("loan2", List(LarEditField("None", ""))), LarEditResult("loan3", List(LarEditField("None", ""))))),
+          EditResult("V280", "", List(noField), Seq(LarEditResult("loan1", List(LarEditField("None", "")))))
         )
       )
 

--- a/api/src/test/scala/hmda/api/model/ModelGenerators.scala
+++ b/api/src/test/scala/hmda/api/model/ModelGenerators.scala
@@ -5,6 +5,11 @@ import akka.http.scaladsl.model.Uri.Path
 import hmda.model.fi._
 import hmda.validation.engine._
 import org.scalacheck.Gen
+import hmda.model.fi.lar.fields.LarTopLevelFields._
+import hmda.model.fi.lar.fields.LarApplicantFields._
+import hmda.model.fi.lar.fields.LarDenialFields._
+import hmda.model.fi.lar.fields.LarGeographyFields._
+import hmda.model.fi.lar.fields.LarLoanFields._
 
 trait ModelGenerators {
 
@@ -45,6 +50,50 @@ trait ModelGenerators {
       IRSGenerated,
       IRSVerified,
       Signed
+    )
+  }
+
+  implicit def fieldGen: Gen[RecordField] = {
+    Gen.oneOf(
+      noField,
+      respondentId,
+      agencyCode,
+      preaprovals,
+      actionTakenType,
+      actionTakenDate,
+      purchaserType,
+      rateSpread,
+      heopaStatus,
+      lienStatus,
+      ethnicity,
+      coEthnicity,
+      race1,
+      race2,
+      race3,
+      race4,
+      race5,
+      coRace1,
+      coRace2,
+      coRace3,
+      coRace4,
+      coRace5,
+      sex,
+      coSex,
+      income,
+      reason1,
+      reason2,
+      reason3,
+      msa,
+      state,
+      county,
+      tract,
+      id,
+      applicationDate,
+      loanType,
+      propertyType,
+      purpose,
+      occupancy,
+      amount
     )
   }
 
@@ -90,9 +139,10 @@ trait ModelGenerators {
     for {
       edit <- Gen.alphaStr
       description <- Gen.alphaStr
+      fields <- fieldGen
       ts <- Gen.oneOf(true, false)
       lars <- Gen.listOf(larEditResultGen)
-    } yield EditResult(edit, description, ts, lars)
+    } yield EditResult(edit, description, List(fields), ts, lars)
   }
 
   implicit def editResultsGen: Gen[EditResults] = {
@@ -125,9 +175,11 @@ trait ModelGenerators {
     for {
       id <- Gen.alphaStr
       name <- Gen.alphaStr
+      field <- fieldGen
+      fieldDescription <- Gen.alphaStr
       description <- Gen.alphaStr
       errorType <- validationErrorTypeGen
-    } yield ValidationError(id, ValidationErrorMetaData(name, description), errorType)
+    } yield ValidationError(id, ValidationErrorMetaData(name, description, Map(field -> fieldDescription)), errorType)
   }
 
   implicit def summaryEditResultsGen: Gen[SummaryEditResults] = {

--- a/api/src/test/scala/hmda/api/model/ModelGenerators.scala
+++ b/api/src/test/scala/hmda/api/model/ModelGenerators.scala
@@ -12,7 +12,7 @@ trait ModelGenerators {
     for {
       status <- Gen.oneOf("OK", "SERVICE_UNAVAILABLE")
       service = "hmda-api"
-      time = Calendar.getInstance().getTime().toString
+      time = Calendar.getInstance().getTime.toString
       host = "localhost"
     } yield Status(status, service, time, host)
   }
@@ -89,9 +89,10 @@ trait ModelGenerators {
   implicit def editResultGen: Gen[EditResult] = {
     for {
       edit <- Gen.alphaStr
+      description <- Gen.alphaStr
       ts <- Gen.oneOf(true, false)
       lars <- Gen.listOf(larEditResultGen)
-    } yield EditResult(edit, ts, lars)
+    } yield EditResult(edit, description, ts, lars)
   }
 
   implicit def editResultsGen: Gen[EditResults] = {
@@ -124,8 +125,9 @@ trait ModelGenerators {
     for {
       id <- Gen.alphaStr
       name <- Gen.alphaStr
+      description <- Gen.alphaStr
       errorType <- validationErrorTypeGen
-    } yield ValidationError(id, name, errorType)
+    } yield ValidationError(id, ValidationErrorMetaData(name, description), errorType)
   }
 
   implicit def summaryEditResultsGen: Gen[SummaryEditResults] = {

--- a/api/src/test/scala/hmda/api/model/ModelGenerators.scala
+++ b/api/src/test/scala/hmda/api/model/ModelGenerators.scala
@@ -148,9 +148,8 @@ trait ModelGenerators {
       edit <- Gen.alphaStr
       description <- Gen.alphaStr
       fields <- fieldGen
-      ts <- Gen.oneOf(true, false)
       lars <- Gen.listOf(larEditResultGen)
-    } yield EditResult(edit, description, List(fields), ts, lars)
+    } yield EditResult(edit, description, List(fields), lars)
   }
 
   implicit def editResultsGen: Gen[EditResults] = {

--- a/api/src/test/scala/hmda/api/model/ModelGenerators.scala
+++ b/api/src/test/scala/hmda/api/model/ModelGenerators.scala
@@ -129,10 +129,18 @@ trait ModelGenerators {
     } yield ErrorResponse(status, message, Path(path))
   }
 
+  implicit def larEditFieldGen: Gen[LarEditField] = {
+    for {
+      fieldName <- Gen.alphaStr
+      value <- Gen.alphaStr
+    } yield LarEditField(fieldName, value)
+  }
+
   implicit def larEditResultGen: Gen[LarEditResult] = {
     for {
       loanId <- Gen.alphaStr
-    } yield LarEditResult(LarId(loanId))
+      larEditField <- Gen.listOf(larEditFieldGen)
+    } yield LarEditResult(loanId, larEditField)
   }
 
   implicit def editResultGen: Gen[EditResult] = {

--- a/model/shared/src/main/scala/hmda/model/fi/RecordField.scala
+++ b/model/shared/src/main/scala/hmda/model/fi/RecordField.scala
@@ -1,0 +1,3 @@
+package hmda.model.fi
+
+case class RecordField(name: String, description: String)

--- a/model/shared/src/main/scala/hmda/model/fi/lar/fields/LarApplicantFields.scala
+++ b/model/shared/src/main/scala/hmda/model/fi/lar/fields/LarApplicantFields.scala
@@ -1,91 +1,37 @@
 package hmda.model.fi.lar.fields
 
-case object Ethnicity extends LarField {
-  override def name = "Applicant Ethnicity"
+import hmda.model.fi.RecordField
 
-  override def description = ""
-}
+object LarApplicantFields {
 
-case object CoEthnicity extends LarField {
-  override def name = "Co-applicant Ethnicity"
+  val ethnicity = RecordField("Applicant Ethnicity", "")
 
-  override def description = ""
-}
+  val coEthnicity = RecordField("Co-applicant Ethnicity", "")
 
-case object Race1 extends LarField {
-  override def name = "Applicant Race: 1"
+  val race1 = RecordField("Applicant Race: 1", "")
 
-  override def description = ""
-}
+  val race2 = RecordField("Applicant Race: 2", "")
 
-case object Race2 extends LarField {
-  override def name = "Applicant Race: 2"
+  val race3 = RecordField("Applicant Race: 3", "")
 
-  override def description = ""
-}
+  val race4 = RecordField("Applicant Race: 4", "")
 
-case object Race3 extends LarField {
-  override def name = "Applicant Race: 3"
+  val race5 = RecordField("Applicant Race: 5", "")
 
-  override def description = ""
-}
+  val coRace1 = RecordField("Co-applicant Race: 1", "")
 
-case object Race4 extends LarField {
-  override def name = "Applicant Race: 4"
+  val coRace2 = RecordField("Co-applicant Race: 2", "")
 
-  override def description = ""
-}
+  val coRace3 = RecordField("Co-applicant Race: 3", "")
 
-case object Race5 extends LarField {
-  override def name = "Applicant Race: 5"
+  val coRace4 = RecordField("Co-applicant Race: 4", "")
 
-  override def description = ""
-}
+  val coRace5 = RecordField("Co-applicant Race: 5", "")
 
-case object CoRace1 extends LarField {
-  override def name = "Co-applicant Race: 1"
+  val sex = RecordField("Applicant Sex", "")
 
-  override def description = ""
-}
+  val coSex = RecordField("Co-applicant Sex", "")
 
-case object CoRace2 extends LarField {
-  override def name = "Co-applicant Race: 2"
+  val income = RecordField("Applicant Income", "")
 
-  override def description = ""
-}
-
-case object CoRace3 extends LarField {
-  override def name = "Co-applicant Race: 3"
-
-  override def description = ""
-}
-
-case object CoRace4 extends LarField {
-  override def name = "Co-applicant Race: 4"
-
-  override def description = ""
-}
-
-case object CoRace5 extends LarField {
-  override def name = "Co-applicant Race: 5"
-
-  override def description = ""
-}
-
-case object Sex extends LarField {
-  override def name = "Applicant Sex"
-
-  override def description = ""
-}
-
-case object CoSex extends LarField {
-  override def name = "Co-applicant Sex"
-
-  override def description = ""
-}
-
-case object Income extends LarField {
-  override def name = "Applicant Income"
-
-  override def description = ""
 }

--- a/model/shared/src/main/scala/hmda/model/fi/lar/fields/LarApplicantFields.scala
+++ b/model/shared/src/main/scala/hmda/model/fi/lar/fields/LarApplicantFields.scala
@@ -1,0 +1,91 @@
+package hmda.model.fi.lar.fields
+
+case object Ethnicity extends LarField {
+  override def name = "Applicant Ethnicity"
+
+  override def description = ""
+}
+
+case object CoEthnicity extends LarField {
+  override def name = "Co-applicant Ethnicity"
+
+  override def description = ""
+}
+
+case object Race1 extends LarField {
+  override def name = "Applicant Race: 1"
+
+  override def description = ""
+}
+
+case object Race2 extends LarField {
+  override def name = "Applicant Race: 2"
+
+  override def description = ""
+}
+
+case object Race3 extends LarField {
+  override def name = "Applicant Race: 3"
+
+  override def description = ""
+}
+
+case object Race4 extends LarField {
+  override def name = "Applicant Race: 4"
+
+  override def description = ""
+}
+
+case object Race5 extends LarField {
+  override def name = "Applicant Race: 5"
+
+  override def description = ""
+}
+
+case object CoRace1 extends LarField {
+  override def name = "Co-applicant Race: 1"
+
+  override def description = ""
+}
+
+case object CoRace2 extends LarField {
+  override def name = "Co-applicant Race: 2"
+
+  override def description = ""
+}
+
+case object CoRace3 extends LarField {
+  override def name = "Co-applicant Race: 3"
+
+  override def description = ""
+}
+
+case object CoRace4 extends LarField {
+  override def name = "Co-applicant Race: 4"
+
+  override def description = ""
+}
+
+case object CoRace5 extends LarField {
+  override def name = "Co-applicant Race: 5"
+
+  override def description = ""
+}
+
+case object Sex extends LarField {
+  override def name = "Applicant Sex"
+
+  override def description = ""
+}
+
+case object CoSex extends LarField {
+  override def name = "Co-applicant Sex"
+
+  override def description = ""
+}
+
+case object Income extends LarField {
+  override def name = "Applicant Income"
+
+  override def description = ""
+}

--- a/model/shared/src/main/scala/hmda/model/fi/lar/fields/LarDenialFields.scala
+++ b/model/shared/src/main/scala/hmda/model/fi/lar/fields/LarDenialFields.scala
@@ -1,0 +1,19 @@
+package hmda.model.fi.lar.fields
+
+case object Reason1 extends LarField {
+  override def name = "Denial Reason: 1"
+
+  override def description = ""
+}
+
+case object Reason2 extends LarField {
+  override def name = "Denial Reason: 2"
+
+  override def description = ""
+}
+
+case object Reason3 extends LarField {
+  override def name = "Denial Reason: 3"
+
+  override def description = ""
+}

--- a/model/shared/src/main/scala/hmda/model/fi/lar/fields/LarDenialFields.scala
+++ b/model/shared/src/main/scala/hmda/model/fi/lar/fields/LarDenialFields.scala
@@ -1,19 +1,11 @@
 package hmda.model.fi.lar.fields
 
-case object Reason1 extends LarField {
-  override def name = "Denial Reason: 1"
+import hmda.model.fi.RecordField
 
-  override def description = ""
-}
+object LarDenialFields {
+  val reason1 = RecordField("Denial Reason: 1", "")
 
-case object Reason2 extends LarField {
-  override def name = "Denial Reason: 2"
+  val reason2 = RecordField("Denial Reason: 2", "")
 
-  override def description = ""
-}
-
-case object Reason3 extends LarField {
-  override def name = "Denial Reason: 3"
-
-  override def description = ""
+  val reason3 = RecordField("Denial Reason: 3", "")
 }

--- a/model/shared/src/main/scala/hmda/model/fi/lar/fields/LarField.scala
+++ b/model/shared/src/main/scala/hmda/model/fi/lar/fields/LarField.scala
@@ -1,9 +1,0 @@
-package hmda.model.fi.lar.fields
-
-abstract class LarField {
-
-  def name: String
-
-  def description: String
-
-}

--- a/model/shared/src/main/scala/hmda/model/fi/lar/fields/LarField.scala
+++ b/model/shared/src/main/scala/hmda/model/fi/lar/fields/LarField.scala
@@ -1,0 +1,9 @@
+package hmda.model.fi.lar.fields
+
+abstract class LarField {
+
+  def name: String
+
+  def description: String
+
+}

--- a/model/shared/src/main/scala/hmda/model/fi/lar/fields/LarGeographyFields.scala
+++ b/model/shared/src/main/scala/hmda/model/fi/lar/fields/LarGeographyFields.scala
@@ -1,0 +1,25 @@
+package hmda.model.fi.lar.fields
+
+case object Msa extends LarField {
+  override def name = "Metropolitan Statistical Area / Metropolitan Division"
+
+  override def description = ""
+}
+
+case object State extends LarField {
+  override def name = "State Code"
+
+  override def description = ""
+}
+
+case object County extends LarField {
+  override def name = "County Code"
+
+  override def description = ""
+}
+
+case object Tract extends LarField {
+  override def name = "Census Tract"
+
+  override def description = ""
+}

--- a/model/shared/src/main/scala/hmda/model/fi/lar/fields/LarGeographyFields.scala
+++ b/model/shared/src/main/scala/hmda/model/fi/lar/fields/LarGeographyFields.scala
@@ -1,25 +1,13 @@
 package hmda.model.fi.lar.fields
 
-case object Msa extends LarField {
-  override def name = "Metropolitan Statistical Area / Metropolitan Division"
+import hmda.model.fi.RecordField
 
-  override def description = ""
-}
+object LarGeographyFields {
+  val msa = RecordField("Metropolitan Statistical Area / Metropolitan Division", "")
 
-case object State extends LarField {
-  override def name = "State Code"
+  val state = RecordField("State Code", "")
 
-  override def description = ""
-}
+  val county = RecordField("County Code", "")
 
-case object County extends LarField {
-  override def name = "County Code"
-
-  override def description = ""
-}
-
-case object Tract extends LarField {
-  override def name = "Census Tract"
-
-  override def description = ""
+  val tract = RecordField("Census Tract", "")
 }

--- a/model/shared/src/main/scala/hmda/model/fi/lar/fields/LarLoanFields.scala
+++ b/model/shared/src/main/scala/hmda/model/fi/lar/fields/LarLoanFields.scala
@@ -1,43 +1,20 @@
 package hmda.model.fi.lar.fields
 
-case object Id extends LarField {
-  override def name = "Loan/Application Number"
+import hmda.model.fi.RecordField
 
-  override def description = ""
-}
+object LarLoanFields {
 
-case object ApplicationDate extends LarField {
-  override def name = "Date Application Received"
+  val id = RecordField("Loan/Application Number", "")
 
-  override def description = ""
-}
+  val applicationDate = RecordField("Date Application Received", "")
 
-case object LoanType extends LarField {
-  override def name = "Loan Type"
+  val loanType = RecordField("Loan Type", "")
 
-  override def description = ""
-}
+  val propertyType = RecordField("Property Type", "")
 
-case object PropertyType extends LarField {
-  override def name = "Property Type"
+  val purpose = RecordField("Loan Purpose", "")
 
-  override def description = ""
-}
+  val occupancy = RecordField("Owner Occupancy", "")
 
-case object Purpose extends LarField {
-  override def name = "Loan Purpose"
-
-  override def description = ""
-}
-
-case object Occupancy extends LarField {
-  override def name = "Owner Occupancy"
-
-  override def description = ""
-}
-
-case object Amount extends LarField {
-  override def name = "Loan Amount"
-
-  override def description = ""
+  val amount = RecordField("Loan Amount", "")
 }

--- a/model/shared/src/main/scala/hmda/model/fi/lar/fields/LarLoanFields.scala
+++ b/model/shared/src/main/scala/hmda/model/fi/lar/fields/LarLoanFields.scala
@@ -1,0 +1,43 @@
+package hmda.model.fi.lar.fields
+
+case object Id extends LarField {
+  override def name = "Loan/Application Number"
+
+  override def description = ""
+}
+
+case object ApplicationDate extends LarField {
+  override def name = "Date Application Received"
+
+  override def description = ""
+}
+
+case object LoanType extends LarField {
+  override def name = "Loan Type"
+
+  override def description = ""
+}
+
+case object PropertyType extends LarField {
+  override def name = "Property Type"
+
+  override def description = ""
+}
+
+case object Purpose extends LarField {
+  override def name = "Loan Purpose"
+
+  override def description = ""
+}
+
+case object Occupancy extends LarField {
+  override def name = "Owner Occupancy"
+
+  override def description = ""
+}
+
+case object Amount extends LarField {
+  override def name = "Loan Amount"
+
+  override def description = ""
+}

--- a/model/shared/src/main/scala/hmda/model/fi/lar/fields/LarTopLevelFields.scala
+++ b/model/shared/src/main/scala/hmda/model/fi/lar/fields/LarTopLevelFields.scala
@@ -1,0 +1,56 @@
+package hmda.model.fi.lar.fields
+
+
+case object RespondentId extends LarField {
+  override def name = "Respondent-ID"
+
+  override def description = ""
+}
+
+case object AgencyCode extends LarField {
+  override def name = "Agency Code"
+
+  override def description = ""
+}
+
+case object Preaprovals extends LarField {
+  override def name = "Preapprovals"
+
+  override def description = ""
+}
+
+case object ActionTakenType extends LarField {
+  override def name = "Type of Action Taken"
+
+  override def description = ""
+}
+
+case object ActionTakenDate extends LarField {
+  override def name = "Date of Action"
+
+  override def description = ""
+}
+
+case object PurchaserType extends LarField {
+  override def name = "Type of Purchaser"
+
+  override def description = ""
+}
+
+case object RateSpread extends LarField {
+  override def name = "Rate Spread"
+
+  override def description = ""
+}
+
+case object HeopaStatus extends LarField {
+  override def name = "HOEPA Status"
+
+  override def description = ""
+}
+
+case object LienStatus extends LarField {
+  override def name = "Lien Status"
+
+  override def description = ""
+}

--- a/model/shared/src/main/scala/hmda/model/fi/lar/fields/LarTopLevelFields.scala
+++ b/model/shared/src/main/scala/hmda/model/fi/lar/fields/LarTopLevelFields.scala
@@ -1,56 +1,27 @@
 package hmda.model.fi.lar.fields
 
+import hmda.model.fi.RecordField
 
-case object RespondentId extends LarField {
-  override def name = "Respondent-ID"
+object LarTopLevelFields {
 
-  override def description = ""
+  val noField = RecordField("None", "None")
+
+  val respondentId = RecordField("Respondent-ID", "")
+
+  val agencyCode = RecordField("Agency Code", "")
+
+  val preaprovals = RecordField("Preapprovals", "")
+
+  val actionTakenType = RecordField("Type of Action Taken", "")
+
+  val actionTakenDate = RecordField("Date of Action", "")
+
+  val purchaserType = RecordField("Type of Purchaser", "")
+
+  val rateSpread = RecordField("Rate Spread", "")
+
+  val heopaStatus = RecordField("HOEPA Status", "")
+
+  val lienStatus = RecordField("Lien Status", "")
 }
 
-case object AgencyCode extends LarField {
-  override def name = "Agency Code"
-
-  override def description = ""
-}
-
-case object Preaprovals extends LarField {
-  override def name = "Preapprovals"
-
-  override def description = ""
-}
-
-case object ActionTakenType extends LarField {
-  override def name = "Type of Action Taken"
-
-  override def description = ""
-}
-
-case object ActionTakenDate extends LarField {
-  override def name = "Date of Action"
-
-  override def description = ""
-}
-
-case object PurchaserType extends LarField {
-  override def name = "Type of Purchaser"
-
-  override def description = ""
-}
-
-case object RateSpread extends LarField {
-  override def name = "Rate Spread"
-
-  override def description = ""
-}
-
-case object HeopaStatus extends LarField {
-  override def name = "HOEPA Status"
-
-  override def description = ""
-}
-
-case object LienStatus extends LarField {
-  override def name = "Lien Status"
-
-  override def description = ""
-}

--- a/persistence/src/test/scala/hmda/persistence/processing/HmdaFileValidatorSpec.scala
+++ b/persistence/src/test/scala/hmda/persistence/processing/HmdaFileValidatorSpec.scala
@@ -53,10 +53,10 @@ class HmdaFileValidatorSpec extends ActorSpec with BeforeAndAfterEach with HmdaF
     }
 
     "persist validation errors" in {
-      val e1 = ValidationError("1", "S999", Syntactical)
-      val e2 = ValidationError("1", "V999", Validity)
-      val e3 = ValidationError("1", "Q999", Quality)
-      val e4 = ValidationError("1", "Q007", Macro)
+      val e1 = ValidationError("1", ValidationErrorMetaData("S999", ""), Syntactical)
+      val e2 = ValidationError("1", ValidationErrorMetaData("V999", ""), Validity)
+      val e3 = ValidationError("1", ValidationErrorMetaData("Q999", ""), Quality)
+      val e4 = ValidationError("1", ValidationErrorMetaData("Q007", ""), Macro)
       val larErrors = LarValidationErrors(Seq(e1, e2, e3, e4))
       val tsErrors = TsValidationErrors(Seq(e1, e2, e3))
       probe.send(hmdaFileValidator, larErrors)
@@ -93,10 +93,10 @@ class HmdaFileValidatorSpec extends ActorSpec with BeforeAndAfterEach with HmdaF
         Nil,
         Nil,
         Nil,
-        List(ValidationError("8299422144", "S020", Syntactical), ValidationError("2185751599", "S010", Syntactical), ValidationError("2185751599", "S020", Syntactical)),
-        List(ValidationError("4977566612", "V550", Validity), ValidationError("4977566612", "V555", Validity), ValidationError("4977566612", "V560", Validity)),
+        List(ValidationError("8299422144", ValidationErrorMetaData("S020", ""), Syntactical), ValidationError("2185751599", ValidationErrorMetaData("S010", ""), Syntactical), ValidationError("2185751599", ValidationErrorMetaData("S020", ""), Syntactical)),
+        List(ValidationError("4977566612", ValidationErrorMetaData("V550", ""), Validity), ValidationError("4977566612", ValidationErrorMetaData("V555", ""), Validity), ValidationError("4977566612", ValidationErrorMetaData("V560", ""), Validity)),
         Nil,
-        List(ValidationError("", "Q008", Macro), ValidationError("", "Q010", Macro), ValidationError("", "Q016", Macro), ValidationError("", "Q023", Macro))
+        List(ValidationError("", ValidationErrorMetaData("Q008", ""), Macro), ValidationError("", ValidationErrorMetaData("Q010", ""), Macro), ValidationError("", ValidationErrorMetaData("Q016", ""), Macro), ValidationError("", ValidationErrorMetaData("Q023", ""), Macro))
       ))
 
     }

--- a/persistence/src/test/scala/hmda/persistence/processing/HmdaFileValidatorSpec.scala
+++ b/persistence/src/test/scala/hmda/persistence/processing/HmdaFileValidatorSpec.scala
@@ -14,6 +14,7 @@ import hmda.persistence.processing.ProcessingMessages.{ BeginValidation, Validat
 import hmda.persistence.processing.SingleLarValidation._
 import hmda.validation.engine._
 import org.scalatest.BeforeAndAfterEach
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 
 class HmdaFileValidatorSpec extends ActorSpec with BeforeAndAfterEach with HmdaFileParserSpecUtils {
   import hmda.model.util.FITestData._
@@ -53,10 +54,10 @@ class HmdaFileValidatorSpec extends ActorSpec with BeforeAndAfterEach with HmdaF
     }
 
     "persist validation errors" in {
-      val e1 = ValidationError("1", ValidationErrorMetaData("S999", ""), Syntactical)
-      val e2 = ValidationError("1", ValidationErrorMetaData("V999", ""), Validity)
-      val e3 = ValidationError("1", ValidationErrorMetaData("Q999", ""), Quality)
-      val e4 = ValidationError("1", ValidationErrorMetaData("Q007", ""), Macro)
+      val e1 = ValidationError("1", ValidationErrorMetaData("S999", "", Map(noField -> "")), Syntactical)
+      val e2 = ValidationError("1", ValidationErrorMetaData("V999", "", Map(noField -> "")), Validity)
+      val e3 = ValidationError("1", ValidationErrorMetaData("Q999", "", Map(noField -> "")), Quality)
+      val e4 = ValidationError("1", ValidationErrorMetaData("Q007", "", Map(noField -> "")), Macro)
       val larErrors = LarValidationErrors(Seq(e1, e2, e3, e4))
       val tsErrors = TsValidationErrors(Seq(e1, e2, e3))
       probe.send(hmdaFileValidator, larErrors)
@@ -93,10 +94,10 @@ class HmdaFileValidatorSpec extends ActorSpec with BeforeAndAfterEach with HmdaF
         Nil,
         Nil,
         Nil,
-        List(ValidationError("8299422144", ValidationErrorMetaData("S020", ""), Syntactical), ValidationError("2185751599", ValidationErrorMetaData("S010", ""), Syntactical), ValidationError("2185751599", ValidationErrorMetaData("S020", ""), Syntactical)),
-        List(ValidationError("4977566612", ValidationErrorMetaData("V550", ""), Validity), ValidationError("4977566612", ValidationErrorMetaData("V555", ""), Validity), ValidationError("4977566612", ValidationErrorMetaData("V560", ""), Validity)),
+        List(ValidationError("8299422144", ValidationErrorMetaData("S020", "", Map(noField -> "")), Syntactical), ValidationError("2185751599", ValidationErrorMetaData("S010", "", Map(noField -> "")), Syntactical), ValidationError("2185751599", ValidationErrorMetaData("S020", "", Map(noField -> "")), Syntactical)),
+        List(ValidationError("4977566612", ValidationErrorMetaData("V550", "", Map(noField -> "")), Validity), ValidationError("4977566612", ValidationErrorMetaData("V555", "", Map(noField -> "")), Validity), ValidationError("4977566612", ValidationErrorMetaData("V560", "", Map(noField -> "")), Validity)),
         Nil,
-        List(ValidationError("", ValidationErrorMetaData("Q008", ""), Macro), ValidationError("", ValidationErrorMetaData("Q010", ""), Macro), ValidationError("", ValidationErrorMetaData("Q016", ""), Macro), ValidationError("", ValidationErrorMetaData("Q023", ""), Macro))
+        List(ValidationError("", ValidationErrorMetaData("Q008", "", Map(noField -> "")), Macro), ValidationError("", ValidationErrorMetaData("Q010", "", Map(noField -> "")), Macro), ValidationError("", ValidationErrorMetaData("Q016", "", Map(noField -> "")), Macro), ValidationError("", ValidationErrorMetaData("Q023", "", Map(noField -> "")), Macro))
       ))
 
     }

--- a/validation/src/main/scala/hmda/validation/api/ValidationApi.scala
+++ b/validation/src/main/scala/hmda/validation/api/ValidationApi.scala
@@ -1,7 +1,7 @@
 package hmda.validation.api
 
 import hmda.validation.dsl.{ Failure, Result, Success }
-import hmda.validation.engine.{ ValidationError, ValidationErrorType }
+import hmda.validation.engine.{ ValidationError, ValidationErrorMetaData, ValidationErrorType }
 import hmda.validation.rules.EditCheck
 
 import scalaz._
@@ -10,13 +10,13 @@ import scalaz.Scalaz._
 trait ValidationApi {
 
   def check[T](editCheck: EditCheck[T], input: T, inputId: String, errorType: ValidationErrorType): ValidationNel[ValidationError, T] = {
-    convertResult(input, editCheck(input), editCheck.name, inputId, errorType)
+    convertResult(input, editCheck(input), editCheck.name, inputId, errorType, editCheck.description)
   }
 
-  def convertResult[T](input: T, result: Result, ruleName: String, inputId: String, errorType: ValidationErrorType): ValidationNel[ValidationError, T] = {
+  def convertResult[T](input: T, result: Result, ruleName: String, inputId: String, errorType: ValidationErrorType, description: String): ValidationNel[ValidationError, T] = {
     result match {
       case Success() => input.success
-      case Failure() => ValidationError(inputId, ruleName, errorType).failure.toValidationNel
+      case Failure() => ValidationError(inputId, ValidationErrorMetaData(ruleName, description), errorType).failure.toValidationNel
     }
   }
 

--- a/validation/src/main/scala/hmda/validation/api/ValidationApi.scala
+++ b/validation/src/main/scala/hmda/validation/api/ValidationApi.scala
@@ -1,5 +1,6 @@
 package hmda.validation.api
 
+import hmda.model.fi.RecordField
 import hmda.validation.dsl.{ Failure, Result, Success }
 import hmda.validation.engine.{ ValidationError, ValidationErrorMetaData, ValidationErrorType }
 import hmda.validation.rules.EditCheck
@@ -10,13 +11,13 @@ import scalaz.Scalaz._
 trait ValidationApi {
 
   def check[T](editCheck: EditCheck[T], input: T, inputId: String, errorType: ValidationErrorType): ValidationNel[ValidationError, T] = {
-    convertResult(input, editCheck(input), editCheck.name, inputId, errorType, editCheck.description)
+    convertResult(input, editCheck(input), editCheck.name, inputId, errorType, editCheck.description, editCheck.fields(input))
   }
 
-  def convertResult[T](input: T, result: Result, ruleName: String, inputId: String, errorType: ValidationErrorType, description: String): ValidationNel[ValidationError, T] = {
+  def convertResult[T](input: T, result: Result, ruleName: String, inputId: String, errorType: ValidationErrorType, description: String, fields: Map[RecordField, String]): ValidationNel[ValidationError, T] = {
     result match {
       case Success() => input.success
-      case Failure() => ValidationError(inputId, ValidationErrorMetaData(ruleName, description), errorType).failure.toValidationNel
+      case Failure() => ValidationError(inputId, ValidationErrorMetaData(ruleName, description, fields), errorType).failure.toValidationNel
     }
   }
 

--- a/validation/src/main/scala/hmda/validation/engine/ValidationError.scala
+++ b/validation/src/main/scala/hmda/validation/engine/ValidationError.scala
@@ -1,5 +1,7 @@
 package hmda.validation.engine
 
+import hmda.model.fi.RecordField
+
 sealed trait ValidationErrorType
 case object Syntactical extends ValidationErrorType
 case object Validity extends ValidationErrorType
@@ -8,7 +10,7 @@ case object Macro extends ValidationErrorType
 
 // errorID = Loan ID (LAR) or Agency Code + Respondent ID (TS)
 case class ValidationError(errorId: String, metaData: ValidationErrorMetaData, errorType: ValidationErrorType)
-case class ValidationErrorMetaData(name: String, description: String)
+case class ValidationErrorMetaData(name: String, description: String, fields: Map[RecordField, String])
 abstract class ValidationErrors {
   def errors: Seq[ValidationError]
 }

--- a/validation/src/main/scala/hmda/validation/engine/ValidationError.scala
+++ b/validation/src/main/scala/hmda/validation/engine/ValidationError.scala
@@ -7,7 +7,8 @@ case object Quality extends ValidationErrorType
 case object Macro extends ValidationErrorType
 
 // errorID = Loan ID (LAR) or Agency Code + Respondent ID (TS)
-case class ValidationError(errorId: String, name: String, errorType: ValidationErrorType)
+case class ValidationError(errorId: String, metaData: ValidationErrorMetaData, errorType: ValidationErrorType)
+case class ValidationErrorMetaData(name: String, description: String)
 abstract class ValidationErrors {
   def errors: Seq[ValidationError]
 }

--- a/validation/src/main/scala/hmda/validation/engine/lar/macro/LarMacroEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/lar/macro/LarMacroEngine.scala
@@ -59,7 +59,7 @@ trait LarMacroEngine extends LarCommonEngine with ValidationApi {
     for {
       result <- fResult
     } yield {
-      convertResult(input, result, editCheck.name, inputId, errorType, editCheck.description)
+      convertResult(input, result, editCheck.name, inputId, errorType, editCheck.description, editCheck.fields(input))
     }
   }
 

--- a/validation/src/main/scala/hmda/validation/engine/lar/macro/LarMacroEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/lar/macro/LarMacroEngine.scala
@@ -59,7 +59,7 @@ trait LarMacroEngine extends LarCommonEngine with ValidationApi {
     for {
       result <- fResult
     } yield {
-      convertResult(input, result, editCheck.name, inputId, errorType)
+      convertResult(input, result, editCheck.name, inputId, errorType, editCheck.description)
     }
   }
 

--- a/validation/src/main/scala/hmda/validation/engine/lar/quality/LarQualityEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/lar/quality/LarQualityEngine.scala
@@ -10,7 +10,7 @@ import hmda.validation.rules.lar.quality._
 trait LarQualityEngine extends LarCommonEngine with ValidationApi {
 
   private def q022(lar: LoanApplicationRegister): LarValidation = {
-    convertResult(lar, Q022(lar, 2017), "Q022", lar.loan.id, Quality, Q022.description)
+    convertResult(lar, Q022(lar, 2017), "Q022", lar.loan.id, Quality, Q022.description, Q022.fields(lar))
   }
 
   def checkQuality(lar: LoanApplicationRegister, ctx: ValidationContext): LarValidation = {

--- a/validation/src/main/scala/hmda/validation/engine/lar/quality/LarQualityEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/lar/quality/LarQualityEngine.scala
@@ -10,7 +10,7 @@ import hmda.validation.rules.lar.quality._
 trait LarQualityEngine extends LarCommonEngine with ValidationApi {
 
   private def q022(lar: LoanApplicationRegister): LarValidation = {
-    convertResult(lar, Q022(lar, 2017), "Q022", lar.loan.id, Quality)
+    convertResult(lar, Q022(lar, 2017), "Q022", lar.loan.id, Quality, Q022.description)
   }
 
   def checkQuality(lar: LoanApplicationRegister, ctx: ValidationContext): LarValidation = {

--- a/validation/src/main/scala/hmda/validation/rules/AggregateEditCheck.scala
+++ b/validation/src/main/scala/hmda/validation/rules/AggregateEditCheck.scala
@@ -4,6 +4,7 @@ import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{ Sink, Source }
+import hmda.model.fi.RecordField
 import hmda.validation.dsl.Result
 
 import scala.concurrent.{ ExecutionContext, Future }
@@ -13,6 +14,8 @@ abstract class AggregateEditCheck[A <: Source[T, NotUsed], T] extends SourceUtil
   def name: String
 
   def description: String
+
+  def fields(input: A): Map[RecordField, String]
 
   def apply(input: A)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result]
 

--- a/validation/src/main/scala/hmda/validation/rules/AggregateEditCheck.scala
+++ b/validation/src/main/scala/hmda/validation/rules/AggregateEditCheck.scala
@@ -12,6 +12,8 @@ abstract class AggregateEditCheck[A <: Source[T, NotUsed], T] extends SourceUtil
 
   def name: String
 
+  def description: String
+
   def apply(input: A)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result]
 
 }

--- a/validation/src/main/scala/hmda/validation/rules/EditCheck.scala
+++ b/validation/src/main/scala/hmda/validation/rules/EditCheck.scala
@@ -1,5 +1,6 @@
 package hmda.validation.rules
 
+import hmda.model.fi.RecordField
 import hmda.validation.dsl.Result
 
 abstract class EditCheck[-T] {
@@ -7,6 +8,8 @@ abstract class EditCheck[-T] {
   def name: String
 
   def description: String
+
+  def fields(input: T): Map[RecordField, String]
 
   def apply(input: T): Result
 }

--- a/validation/src/main/scala/hmda/validation/rules/EditCheck.scala
+++ b/validation/src/main/scala/hmda/validation/rules/EditCheck.scala
@@ -6,5 +6,7 @@ abstract class EditCheck[-T] {
 
   def name: String
 
+  def description: String
+
   def apply(input: T): Result
 }

--- a/validation/src/main/scala/hmda/validation/rules/EmptyEditCheck.scala
+++ b/validation/src/main/scala/hmda/validation/rules/EmptyEditCheck.scala
@@ -4,5 +4,6 @@ import hmda.validation.dsl.{ Result, Success }
 
 class EmptyEditCheck[T] extends EditCheck[T] {
   def name = "empty"
+  def description = "empty"
   def apply(input: T): Result = Success()
 }

--- a/validation/src/main/scala/hmda/validation/rules/EmptyEditCheck.scala
+++ b/validation/src/main/scala/hmda/validation/rules/EmptyEditCheck.scala
@@ -1,9 +1,11 @@
 package hmda.validation.rules
 
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.{ Result, Success }
 
 class EmptyEditCheck[T] extends EditCheck[T] {
   def name = "empty"
   def description = "empty"
+  def fields(input: T) = Map(noField -> "empty")
   def apply(input: T): Result = Success()
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q006.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q006.scala
@@ -9,6 +9,7 @@ import hmda.validation.rules.AggregateEditCheck
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 
 import scala.concurrent.{ ExecutionContext, Future }
 
@@ -21,6 +22,8 @@ object Q006 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
   override def name = "Q006"
 
   override def description = ""
+
+  override def fields(lars: LoanApplicationRegisterSource) = Map(noField -> "")
 
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q006.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q006.scala
@@ -20,6 +20,8 @@ object Q006 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q006"
 
+  override def description = ""
+
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 
     val originatedHomePurchase =

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q007.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q007.scala
@@ -19,6 +19,8 @@ object Q007 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q007"
 
+  override def description = ""
+
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 
     val approvedButNotAccepted =

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q007.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q007.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.AggregateEditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -20,6 +21,8 @@ object Q007 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
   override def name = "Q007"
 
   override def description = ""
+
+  override def fields(lars: LoanApplicationRegisterSource) = Map(noField -> "")
 
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q008.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q008.scala
@@ -19,6 +19,8 @@ object Q008 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q008"
 
+  override def description = ""
+
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, mat: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 
     val applicationWithdrawn =

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q008.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q008.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
@@ -20,6 +21,8 @@ object Q008 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
   override def name = "Q008"
 
   override def description = ""
+
+  override def fields(lars: LoanApplicationRegisterSource) = Map(noField -> "")
 
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, mat: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q009.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q009.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
@@ -20,6 +21,8 @@ object Q009 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
   override def name = "Q009"
 
   override def description = ""
+
+  override def fields(lars: LoanApplicationRegisterSource) = Map(noField -> "")
 
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q009.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q009.scala
@@ -19,6 +19,8 @@ object Q009 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q009"
 
+  override def description = ""
+
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 
     val incomplete = count(lars.filter(lar => lar.actionTakenType == 5))

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q010.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q010.scala
@@ -19,6 +19,8 @@ object Q010 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q010"
 
+  override def description = ""
+
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 
     val originated = count(lars.filter(lar => lar.actionTakenType == 1))

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q010.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q010.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
@@ -20,6 +21,8 @@ object Q010 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
   override def name = "Q010"
 
   override def description = ""
+
+  override def fields(lars: LoanApplicationRegisterSource) = Map(noField -> "")
 
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q015.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q015.scala
@@ -20,6 +20,8 @@ object Q015 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q015"
 
+  override def description = ""
+
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 
     def findAmount(lar: LoanApplicationRegister) = lar.loan.amount

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q015.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q015.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.AggregateEditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -21,6 +22,8 @@ object Q015 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
   override def name = "Q015"
 
   override def description = ""
+
+  override def fields(lars: LoanApplicationRegisterSource) = Map(noField -> "")
 
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q016.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q016.scala
@@ -20,6 +20,8 @@ object Q016 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q016"
 
+  override def description = ""
+
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 
     val belowIncomeThreshold = count(lars.filter(lar => lar.loan.amount < incomeCap))

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q016.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q016.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
@@ -21,6 +22,8 @@ object Q016 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
   override def name = "Q016"
 
   override def description = ""
+
+  override def fields(lars: LoanApplicationRegisterSource) = Map(noField -> "")
 
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q023.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q023.scala
@@ -19,6 +19,8 @@ object Q023 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q023"
 
+  override def description = ""
+
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 
     val noMsa = count(lars.filter(lar => lar.geography.msa == "NA"))

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q023.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q023.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
@@ -20,6 +21,8 @@ object Q023 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
   override def name = "Q023"
 
   override def description = ""
+
+  override def fields(lars: LoanApplicationRegisterSource) = Map(noField -> "")
 
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q031.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q031.scala
@@ -20,6 +20,8 @@ object Q031 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q031"
 
+  override def description = ""
+
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 
     val multifamily =

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q031.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q031.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.AggregateEditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -21,6 +22,8 @@ object Q031 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
   override def name = "Q031"
 
   override def description = ""
+
+  override def fields(lars: LoanApplicationRegisterSource) = Map(noField -> "")
 
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q047.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q047.scala
@@ -19,6 +19,8 @@ object Q047 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q047"
 
+  override def description = ""
+
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 
     val singleFamilyWithdrawn =

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q047.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q047.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.AggregateEditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -20,6 +21,8 @@ object Q047 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
   override def name = "Q047"
 
   override def description = ""
+
+  override def fields(lars: LoanApplicationRegisterSource) = Map(noField -> "")
 
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q048.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q048.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.AggregateEditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -20,6 +21,8 @@ object Q048 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
   override def name = "Q048"
 
   override def description = ""
+
+  override def fields(lars: LoanApplicationRegisterSource) = Map(noField -> "")
 
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q048.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q048.scala
@@ -19,6 +19,8 @@ object Q048 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q048"
 
+  override def description = ""
+
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 
     val incompletePreapprovalRequest =

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q053.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q053.scala
@@ -19,6 +19,8 @@ object Q053 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q053"
 
+  override def description = ""
+
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 
     val hoepaLoans =

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q053.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q053.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
@@ -20,6 +21,8 @@ object Q053 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
   override def name = "Q053"
 
   override def description = ""
+
+  override def fields(lars: LoanApplicationRegisterSource) = Map(noField -> "")
 
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q054.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q054.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
@@ -20,6 +21,8 @@ object Q054 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
   override def name = "Q054"
 
   override def description = ""
+
+  override def fields(lars: LoanApplicationRegisterSource) = Map(noField -> "")
 
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q054.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q054.scala
@@ -19,6 +19,8 @@ object Q054 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q054"
 
+  override def description = ""
+
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 
     val hoepaLoans =

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q055.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q055.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.AggregateEditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -20,6 +21,8 @@ object Q055 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
   override def name = "Q055"
 
   override def description = ""
+
+  override def fields(lars: LoanApplicationRegisterSource) = Map(noField -> "")
 
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q055.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q055.scala
@@ -19,6 +19,8 @@ object Q055 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q055"
 
+  override def description = ""
+
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 
     val hoepaLoans =

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q056.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q056.scala
@@ -20,6 +20,8 @@ object Q056 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q056"
 
+  override def description = ""
+
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 
     val denied =

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q056.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q056.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.AggregateEditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -21,6 +22,8 @@ object Q056 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
   override def name = "Q056"
 
   override def description = ""
+
+  override def fields(lars: LoanApplicationRegisterSource) = Map(noField -> "")
 
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q057.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q057.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.AggregateEditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -20,6 +21,8 @@ object Q057 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
   override def name = "Q057"
 
   override def description = ""
+
+  override def fields(lars: LoanApplicationRegisterSource) = Map(noField -> "")
 
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q057.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q057.scala
@@ -19,6 +19,8 @@ object Q057 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q057"
 
+  override def description = ""
+
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 
     val denied =

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q058.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q058.scala
@@ -19,6 +19,8 @@ object Q058 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q058"
 
+  override def description = ""
+
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 
     val preapprovalRequested =

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q058.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q058.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.AggregateEditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -20,6 +21,8 @@ object Q058 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
   override def name = "Q058"
 
   override def description = ""
+
+  override def fields(lars: LoanApplicationRegisterSource) = Map(noField -> "")
 
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q061.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q061.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.AggregateEditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -20,6 +21,8 @@ object Q061 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
   override def name = "Q061"
 
   override def description = ""
+
+  override def fields(lars: LoanApplicationRegisterSource) = Map(noField -> "")
 
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q061.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q061.scala
@@ -19,6 +19,8 @@ object Q061 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q061"
 
+  override def description = ""
+
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 
     val firstLienHoepaLoans =

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q062.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q062.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
@@ -20,6 +21,8 @@ object Q062 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
   override def name: String = "Q062"
 
   override def description = ""
+
+  override def fields(lars: LoanApplicationRegisterSource) = Map(noField -> "")
 
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q062.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q062.scala
@@ -19,6 +19,8 @@ object Q062 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name: String = "Q062"
 
+  override def description = ""
+
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 
     val fannieHoepaLoans =

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q063.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q063.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
@@ -20,6 +21,8 @@ object Q063 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
   override def name: String = "Q063"
 
   override def description = ""
+
+  override def fields(lars: LoanApplicationRegisterSource) = Map(noField -> "")
 
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
     val freddieHoepaLoans =

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q063.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q063.scala
@@ -19,6 +19,8 @@ object Q063 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name: String = "Q063"
 
+  override def description = ""
+
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
     val freddieHoepaLoans =
       count(lars.filter(

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q073.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q073.scala
@@ -20,6 +20,8 @@ object Q073 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q073"
 
+  override def description = ""
+
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
     val applicableLoans = lars.filter(lar =>
       lar.loan.purpose == 1

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q073.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q073.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
@@ -21,6 +22,8 @@ object Q073 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
   override def name = "Q073"
 
   override def description = ""
+
+  override def fields(lars: LoanApplicationRegisterSource) = Map(noField -> "")
 
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
     val applicableLoans = lars.filter(lar =>

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q074.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q074.scala
@@ -20,6 +20,8 @@ object Q074 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q074"
 
+  override def description = ""
+
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
     val applicableLoans = lars.filter(lar =>
       lar.loan.purpose == 3

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q074.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q074.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
@@ -21,6 +22,8 @@ object Q074 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
   override def name = "Q074"
 
   override def description = ""
+
+  override def fields(lars: LoanApplicationRegisterSource) = Map(noField -> "")
 
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
     val applicableLoans = lars.filter(lar =>

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q080.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q080.scala
@@ -19,6 +19,8 @@ object Q080 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q080"
 
+  override def description = ""
+
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 
     val relevantLars =

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q080.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q080.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
@@ -20,6 +21,8 @@ object Q080 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
   override def name = "Q080"
 
   override def description = ""
+
+  override def fields(lars: LoanApplicationRegisterSource) = Map(noField -> "")
 
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q081.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q081.scala
@@ -19,6 +19,8 @@ object Q081 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q081"
 
+  override def description = ""
+
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 
     val relevantLars =

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q081.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q081.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
@@ -20,6 +21,8 @@ object Q081 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
   override def name = "Q081"
 
   override def description = ""
+
+  override def fields(lars: LoanApplicationRegisterSource) = Map(noField -> "")
 
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q082.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q082.scala
@@ -19,6 +19,8 @@ object Q082 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q082"
 
+  override def description = ""
+
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 
     val relevantLars =

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q082.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q082.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
@@ -20,6 +21,8 @@ object Q082 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
   override def name = "Q082"
 
   override def description = ""
+
+  override def fields(lars: LoanApplicationRegisterSource) = Map(noField -> "")
 
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q083.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q083.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
@@ -20,6 +21,8 @@ object Q083 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
   override def name = "Q083"
 
   override def description = ""
+
+  override def fields(lars: LoanApplicationRegisterSource) = Map(noField -> "")
 
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q083.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q083.scala
@@ -19,6 +19,8 @@ object Q083 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q083"
 
+  override def description = ""
+
   override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
 
     val relevantLars =

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q001.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q001.scala
@@ -28,4 +28,6 @@ object Q001 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "Q001"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q001.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q001.scala
@@ -1,5 +1,7 @@
 package hmda.validation.rules.lar.quality
 
+import hmda.model.fi.lar.fields.LarLoanFields._
+import hmda.model.fi.lar.fields.LarApplicantFields._
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.Result
@@ -30,4 +32,9 @@ object Q001 extends EditCheck[LoanApplicationRegister] {
   override def name = "Q001"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    amount -> lar.loan.amount.toString,
+    income -> lar.applicant.income
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q002.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q002.scala
@@ -2,6 +2,7 @@ package hmda.validation.rules.lar.quality
 
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -24,4 +25,8 @@ object Q002 extends EditCheck[LoanApplicationRegister] {
   override def name = "Q002"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q002.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q002.scala
@@ -22,4 +22,6 @@ object Q002 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "Q002"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q003.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q003.scala
@@ -22,4 +22,6 @@ object Q003 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "Q003"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q003.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q003.scala
@@ -2,6 +2,7 @@ package hmda.validation.rules.lar.quality
 
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -24,4 +25,8 @@ object Q003 extends EditCheck[LoanApplicationRegister] {
   override def name = "Q003"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q004.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q004.scala
@@ -2,6 +2,7 @@ package hmda.validation.rules.lar.quality
 
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -22,4 +23,8 @@ object Q004 extends EditCheck[LoanApplicationRegister] {
   override def name = "Q004"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q004.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q004.scala
@@ -20,4 +20,6 @@ object Q004 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "Q004"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q005.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q005.scala
@@ -5,8 +5,8 @@ import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
-
 import com.typesafe.config.ConfigFactory
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 
 object Q005 extends EditCheck[LoanApplicationRegister] {
   override def apply(lar: LoanApplicationRegister): Result = {
@@ -23,4 +23,8 @@ object Q005 extends EditCheck[LoanApplicationRegister] {
   override def name = "Q005"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q005.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q005.scala
@@ -21,4 +21,6 @@ object Q005 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "Q005"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q013.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q013.scala
@@ -20,4 +20,6 @@ object Q013 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "Q013"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q013.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q013.scala
@@ -2,6 +2,7 @@ package hmda.validation.rules.lar.quality
 
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -22,4 +23,8 @@ object Q013 extends EditCheck[LoanApplicationRegister] {
   override def name = "Q013"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q014.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q014.scala
@@ -19,4 +19,6 @@ object Q014 extends EditCheck[LoanApplicationRegister] {
       income.toInt is lessThan(maxIncome)
     }
   }
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q014.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q014.scala
@@ -2,6 +2,7 @@ package hmda.validation.rules.lar.quality
 
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -21,4 +22,8 @@ object Q014 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q022.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q022.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.quality
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
@@ -34,4 +35,8 @@ object Q022 {
   def name = "Q022"
 
   def description = ""
+
+  def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q022.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q022.scala
@@ -32,4 +32,6 @@ object Q022 {
   }
 
   def name = "Q022"
+
+  def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q024.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q024.scala
@@ -2,6 +2,7 @@ package hmda.validation.rules.lar.quality
 
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -24,5 +25,9 @@ object Q024 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q024.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q024.scala
@@ -23,4 +23,6 @@ object Q024 extends EditCheck[LoanApplicationRegister] {
     }
   }
 
+  override def description = ""
+
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q025.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q025.scala
@@ -19,4 +19,6 @@ object Q025 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "Q025"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q025.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q025.scala
@@ -2,6 +2,7 @@ package hmda.validation.rules.lar.quality
 
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
@@ -21,4 +22,8 @@ object Q025 extends EditCheck[LoanApplicationRegister] {
   override def name = "Q025"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q027.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q027.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.quality
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -17,4 +18,8 @@ object Q027 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q027.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q027.scala
@@ -15,4 +15,6 @@ object Q027 extends EditCheck[LoanApplicationRegister] {
       lar.applicant.income not equalTo("NA")
     }
   }
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q029.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q029.scala
@@ -16,4 +16,6 @@ object Q029 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "Q029"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q029.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q029.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.quality
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -18,4 +19,8 @@ object Q029 extends EditCheck[LoanApplicationRegister] {
   override def name = "Q029"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q030.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q030.scala
@@ -1,5 +1,6 @@
 package hmda.validation.rules.lar.quality
 
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.model.fi.lar.{ Geography, LoanApplicationRegister }
 import hmda.model.institution.Institution
 import hmda.validation.context.ValidationContext
@@ -13,6 +14,10 @@ class Q030 private (institution: Institution) extends EditCheck[LoanApplicationR
   override def name: String = "Q030"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 
   override def apply(lar: LoanApplicationRegister): Result = {
     when(lar.actionTakenType is containedIn(1 to 6)) {

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q030.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q030.scala
@@ -12,6 +12,8 @@ import hmda.validation.rules.{ EditCheck, IfInstitutionPresentIn }
 class Q030 private (institution: Institution) extends EditCheck[LoanApplicationRegister] {
   override def name: String = "Q030"
 
+  override def description = ""
+
   override def apply(lar: LoanApplicationRegister): Result = {
     when(lar.actionTakenType is containedIn(1 to 6)) {
       val geo: Geography = lar.geography

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q032.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q032.scala
@@ -14,4 +14,6 @@ object Q032 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "Q032"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q032.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q032.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.quality
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
@@ -16,4 +17,8 @@ object Q032 extends EditCheck[LoanApplicationRegister] {
   override def name = "Q032"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q035.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q035.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.quality
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -16,4 +17,8 @@ object Q035 extends EditCheck[LoanApplicationRegister] {
   override def name = "Q035"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q035.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q035.scala
@@ -14,4 +14,6 @@ object Q035 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "Q035"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q036.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q036.scala
@@ -2,6 +2,7 @@ package hmda.validation.rules.lar.quality
 
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -21,4 +22,8 @@ object Q036 extends EditCheck[LoanApplicationRegister] {
   override def name = "Q036"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q036.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q036.scala
@@ -19,4 +19,6 @@ object Q036 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "Q036"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q037.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q037.scala
@@ -19,4 +19,6 @@ object Q037 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "Q037"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q037.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q037.scala
@@ -2,6 +2,7 @@ package hmda.validation.rules.lar.quality
 
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -21,4 +22,8 @@ object Q037 extends EditCheck[LoanApplicationRegister] {
   override def name = "Q037"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q038.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q038.scala
@@ -5,8 +5,8 @@ import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
-
 import com.typesafe.config.ConfigFactory
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 
 object Q038 extends EditCheck[LoanApplicationRegister] {
   override def apply(lar: LoanApplicationRegister): Result = {
@@ -22,4 +22,8 @@ object Q038 extends EditCheck[LoanApplicationRegister] {
   override def name = "Q038"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q038.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q038.scala
@@ -20,4 +20,6 @@ object Q038 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "Q038"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q039.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q039.scala
@@ -14,4 +14,6 @@ object Q039 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "Q039"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q039.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q039.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.quality
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
@@ -16,4 +17,8 @@ object Q039 extends EditCheck[LoanApplicationRegister] {
   override def name = "Q039"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q040.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q040.scala
@@ -20,4 +20,6 @@ object Q040 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "Q040"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q040.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q040.scala
@@ -2,6 +2,7 @@ package hmda.validation.rules.lar.quality
 
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
@@ -22,4 +23,8 @@ object Q040 extends EditCheck[LoanApplicationRegister] {
   override def name = "Q040"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q044.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q044.scala
@@ -2,6 +2,7 @@ package hmda.validation.rules.lar.quality
 
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -27,4 +28,8 @@ object Q044 extends EditCheck[LoanApplicationRegister] {
   override def name = "Q044"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q044.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q044.scala
@@ -25,4 +25,6 @@ object Q044 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "Q044"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q045.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q045.scala
@@ -2,6 +2,7 @@ package hmda.validation.rules.lar.quality
 
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -27,4 +28,8 @@ object Q045 extends EditCheck[LoanApplicationRegister] {
   override def name = "Q045"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q045.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q045.scala
@@ -25,4 +25,6 @@ object Q045 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "Q045"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q046.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q046.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.quality
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -16,4 +17,8 @@ object Q046 extends EditCheck[LoanApplicationRegister] {
   override def name = "Q046"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q046.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q046.scala
@@ -14,4 +14,6 @@ object Q046 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "Q046"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q049.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q049.scala
@@ -19,4 +19,6 @@ object Q049 extends EditCheck[LoanApplicationRegister] {
 
   override def name: String = "Q049"
 
+  override def description = ""
+
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q049.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q049.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.quality
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -20,5 +21,9 @@ object Q049 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "Q049"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q051.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q051.scala
@@ -15,4 +15,6 @@ object Q051 extends EditCheck[LoanApplicationRegister] with ApplicantUtils {
   }
 
   override def name = "Q051"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q051.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q051.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.quality
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
@@ -17,4 +18,8 @@ object Q051 extends EditCheck[LoanApplicationRegister] with ApplicantUtils {
   override def name = "Q051"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q052.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q052.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.quality
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -16,4 +17,8 @@ object Q052 extends EditCheck[LoanApplicationRegister] {
   override def name = "Q052"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q052.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q052.scala
@@ -14,4 +14,6 @@ object Q052 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "Q052"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q059.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q059.scala
@@ -14,4 +14,6 @@ object Q059 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "Q059"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q059.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q059.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.quality
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -16,4 +17,8 @@ object Q059 extends EditCheck[LoanApplicationRegister] {
   override def name = "Q059"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q064.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q064.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.quality
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -16,4 +17,8 @@ object Q064 extends EditCheck[LoanApplicationRegister] {
   override def name = "Q064"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q064.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q064.scala
@@ -14,4 +14,6 @@ object Q064 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "Q064"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q066.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q066.scala
@@ -2,6 +2,7 @@ package hmda.validation.rules.lar.quality
 
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.Result
 import hmda.validation.dsl.PredicateCommon._
@@ -20,4 +21,8 @@ object Q066 extends EditCheck[LoanApplicationRegister] {
   override def name = "Q066"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q066.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q066.scala
@@ -18,4 +18,6 @@ object Q066 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "Q066"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q067.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q067.scala
@@ -19,4 +19,6 @@ object Q067 extends EditCheck[LoanApplicationRegister] with ApplicantUtils {
     }
   }
 
+  override def description = ""
+
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q067.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q067.scala
@@ -1,5 +1,6 @@
 package hmda.validation.rules.lar.quality
 
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.model.fi.lar.{ Applicant, LoanApplicationRegister }
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
@@ -20,5 +21,9 @@ object Q067 extends EditCheck[LoanApplicationRegister] with ApplicantUtils {
   }
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q068.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q068.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.quality
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -21,4 +22,8 @@ object Q068 extends EditCheck[LoanApplicationRegister] with ApplicantUtils {
   }
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q068.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q068.scala
@@ -19,4 +19,6 @@ object Q068 extends EditCheck[LoanApplicationRegister] with ApplicantUtils {
         (app.coSex not equalTo(4))
     }
   }
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/syntactical/S010.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/syntactical/S010.scala
@@ -16,4 +16,6 @@ object S010 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "S010"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/syntactical/S010.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/syntactical/S010.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.syntactical
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateSyntax._
@@ -18,4 +19,8 @@ object S010 extends EditCheck[LoanApplicationRegister] {
   override def name = "S010"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/syntactical/S011.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/syntactical/S011.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.syntactical
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -15,5 +16,9 @@ object S011 extends EditCheck[Iterable[LoanApplicationRegister]] {
   override def name = "S011"
 
   override def description = ""
+
+  override def fields(lars: Iterable[LoanApplicationRegister]) = Map(
+    noField -> ""
+  )
 
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/syntactical/S011.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/syntactical/S011.scala
@@ -14,4 +14,6 @@ object S011 extends EditCheck[Iterable[LoanApplicationRegister]] {
 
   override def name = "S011"
 
+  override def description = ""
+
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/syntactical/S040.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/syntactical/S040.scala
@@ -17,4 +17,6 @@ object S040 extends EditCheck[Iterable[LoanApplicationRegister]] {
   }
 
   override def name = "S040"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/syntactical/S040.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/syntactical/S040.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.syntactical
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.{ Failure, Result, Success }
 import hmda.validation.rules.EditCheck
 
@@ -19,4 +20,8 @@ object S040 extends EditCheck[Iterable[LoanApplicationRegister]] {
   override def name = "S040"
 
   override def description = ""
+
+  override def fields(lars: Iterable[LoanApplicationRegister]) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/syntactical/S205.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/syntactical/S205.scala
@@ -14,4 +14,6 @@ object S205 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name: String = "S205"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/syntactical/S205.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/syntactical/S205.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.syntactical
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -16,4 +17,8 @@ object S205 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "S205"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V210.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V210.scala
@@ -3,6 +3,7 @@ package hmda.validation.rules.lar.validity
 import java.text.SimpleDateFormat
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -23,4 +24,8 @@ object V210 extends EditCheck[LoanApplicationRegister] {
   override def name = "V210"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V210.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V210.scala
@@ -21,4 +21,6 @@ object V210 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "V210"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V215.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V215.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -16,4 +17,8 @@ object V215 extends EditCheck[LoanApplicationRegister] {
   override def name = "V215"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V215.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V215.scala
@@ -14,4 +14,6 @@ object V215 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "V215"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V220.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V220.scala
@@ -15,4 +15,6 @@ object V220 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "V220"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V220.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V220.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
-import hmda.model.fi.lar.{ LoanApplicationRegister, Loan }
+import hmda.model.fi.lar.fields.LarTopLevelFields._
+import hmda.model.fi.lar.{ Loan, LoanApplicationRegister }
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -17,4 +18,8 @@ object V220 extends EditCheck[LoanApplicationRegister] {
   override def name = "V220"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V225.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V225.scala
@@ -15,4 +15,6 @@ object V225 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "V225"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V225.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V225.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -17,4 +18,8 @@ object V225 extends EditCheck[LoanApplicationRegister] {
   override def name = "V225"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V230.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V230.scala
@@ -15,4 +15,6 @@ object V230 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "V230"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V230.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V230.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
-import hmda.model.fi.lar.{ LoanApplicationRegister }
+import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -17,4 +18,8 @@ object V230 extends EditCheck[LoanApplicationRegister] {
   override def name = "V230"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V250.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V250.scala
@@ -16,4 +16,6 @@ object V250 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "V250"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V250.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V250.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -18,4 +19,8 @@ object V250 extends EditCheck[LoanApplicationRegister] {
   override def name = "V250"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V255.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V255.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -15,4 +16,8 @@ object V255 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "V255"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V255.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V255.scala
@@ -13,4 +13,6 @@ object V255 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name: String = "V255"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V260.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V260.scala
@@ -19,4 +19,6 @@ object V260 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "V260"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V260.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V260.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -21,4 +22,8 @@ object V260 extends EditCheck[LoanApplicationRegister] {
   override def name = "V260"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V262.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V262.scala
@@ -16,4 +16,6 @@ object V262 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "V262"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V262.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V262.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -18,4 +19,8 @@ object V262 extends EditCheck[LoanApplicationRegister] {
   override def name = "V262"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V265.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V265.scala
@@ -23,4 +23,5 @@ object V265 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "V265"
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V265.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V265.scala
@@ -3,6 +3,7 @@ package hmda.validation.rules.lar.validity
 import java.text.SimpleDateFormat
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -24,4 +25,8 @@ object V265 extends EditCheck[LoanApplicationRegister] {
 
   override def name = "V265"
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V275.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V275.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.{ Failure, Result }
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -22,4 +23,8 @@ object V275 extends EditCheck[LoanApplicationRegister] {
   override def name = "V275"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V275.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V275.scala
@@ -20,4 +20,6 @@ object V275 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "V275"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V280.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V280.scala
@@ -2,6 +2,7 @@ package hmda.validation.rules.lar.validity
 
 import hmda.model.census.CBSATractLookup
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -18,6 +19,10 @@ object V280 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "V280"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 
   override def apply(input: LoanApplicationRegister): Result = {
     val msa = input.geography.msa

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V280.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V280.scala
@@ -17,6 +17,8 @@ object V280 extends EditCheck[LoanApplicationRegister] {
 
   override def name: String = "V280"
 
+  override def description = ""
+
   override def apply(input: LoanApplicationRegister): Result = {
     val msa = input.geography.msa
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V285.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V285.scala
@@ -15,6 +15,8 @@ object V285 extends EditCheck[LoanApplicationRegister] {
 
   override def name: String = "V285"
 
+  override def description = ""
+
   override def apply(input: LoanApplicationRegister): Result = {
     val state = input.geography.state
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V285.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V285.scala
@@ -2,6 +2,7 @@ package hmda.validation.rules.lar.validity
 
 import hmda.model.census.CBSATractLookup
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -16,6 +17,10 @@ object V285 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "V285"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 
   override def apply(input: LoanApplicationRegister): Result = {
     val state = input.geography.state

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V290.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V290.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -12,6 +13,10 @@ object V290 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "V290"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 
   override def apply(lar: LoanApplicationRegister): Result = {
     when(lar.geography.msa not equalTo("NA")) {

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V290.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V290.scala
@@ -11,6 +11,8 @@ object V290 extends EditCheck[LoanApplicationRegister] {
 
   override def name: String = "V290"
 
+  override def description = ""
+
   override def apply(lar: LoanApplicationRegister): Result = {
     when(lar.geography.msa not equalTo("NA")) {
       lar.geography is validStateCountyMsaCombination

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V295.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V295.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -12,6 +13,10 @@ object V295 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "V295"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 
   override def apply(input: LoanApplicationRegister): Result = {
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V295.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V295.scala
@@ -11,6 +11,8 @@ object V295 extends EditCheck[LoanApplicationRegister] {
 
   override def name: String = "V295"
 
+  override def description = ""
+
   override def apply(input: LoanApplicationRegister): Result = {
 
     val msa = input.geography.msa

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V300.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V300.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -13,6 +14,10 @@ object V300 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "V300"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 
   override def apply(lar: LoanApplicationRegister): Result = {
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V300.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V300.scala
@@ -12,6 +12,8 @@ object V300 extends EditCheck[LoanApplicationRegister] {
 
   override def name: String = "V300"
 
+  override def description = ""
+
   override def apply(lar: LoanApplicationRegister): Result = {
 
     val msa = lar.geography.msa

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V310.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V310.scala
@@ -14,4 +14,6 @@ object V310 extends EditCheck[LoanApplicationRegister] {
 
   override def name: String = "V310"
 
+  override def description = ""
+
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V310.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V310.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -15,5 +16,9 @@ object V310 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "V310"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V315.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V315.scala
@@ -14,4 +14,6 @@ object V315 extends EditCheck[LoanApplicationRegister] {
 
   override def name: String = "V315"
 
+  override def description = ""
+
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V315.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V315.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -15,5 +16,9 @@ object V315 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "V315"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V317.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V317.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -10,6 +11,10 @@ object V317 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "V317"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 
   override def apply(lar: LoanApplicationRegister): Result = {
     when(lar.applicant.coRace1 is equalTo(8)) {

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V317.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V317.scala
@@ -9,6 +9,8 @@ import hmda.validation.dsl.PredicateSyntax._
 object V317 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "V317"
 
+  override def description = ""
+
   override def apply(lar: LoanApplicationRegister): Result = {
     when(lar.applicant.coRace1 is equalTo(8)) {
       (lar.applicant.coSex is equalTo(5)) and

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V320.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V320.scala
@@ -14,4 +14,6 @@ object V320 extends EditCheck[LoanApplicationRegister] {
 
   override def name = "V320"
 
+  override def description = ""
+
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V320.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V320.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -15,5 +16,9 @@ object V320 extends EditCheck[LoanApplicationRegister] {
   override def name = "V320"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V325.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V325.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -15,5 +16,9 @@ object V325 extends EditCheck[LoanApplicationRegister] {
   override def name = "V325"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V325.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V325.scala
@@ -14,4 +14,6 @@ object V325 extends EditCheck[LoanApplicationRegister] {
 
   override def name = "V325"
 
+  override def description = ""
+
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V326.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V326.scala
@@ -9,6 +9,8 @@ import hmda.validation.dsl.PredicateSyntax._
 object V326 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "V326"
 
+  override def description = ""
+
   override def apply(lar: LoanApplicationRegister): Result = {
     when(lar.applicant.coSex is equalTo(5)) {
       (lar.applicant.coRace1 is equalTo(8)) and

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V326.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V326.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -10,6 +11,10 @@ object V326 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "V326"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 
   override def apply(lar: LoanApplicationRegister): Result = {
     when(lar.applicant.coSex is equalTo(5)) {

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V330.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V330.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.{ Failure, Result }
 import hmda.validation.rules.EditCheck
 
@@ -19,5 +20,9 @@ object V330 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "V330"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V330.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V330.scala
@@ -18,4 +18,6 @@ object V330 extends EditCheck[LoanApplicationRegister] {
 
   override def name: String = "V330"
 
+  override def description = ""
+
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V335.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V335.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -17,5 +18,9 @@ object V335 extends EditCheck[LoanApplicationRegister] {
   override def name = "V335"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V335.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V335.scala
@@ -16,4 +16,6 @@ object V335 extends EditCheck[LoanApplicationRegister] {
 
   override def name = "V335"
 
+  override def description = ""
+
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V338.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V338.scala
@@ -10,6 +10,8 @@ import hmda.validation.rules.lar.ApplicantUtils
 object V338 extends EditCheck[LoanApplicationRegister] with ApplicantUtils {
   override def name: String = "V338"
 
+  override def description = ""
+
   override def apply(lar: LoanApplicationRegister): Result = {
     when(notANaturalPerson(lar)) {
       lar.applicant.income is "NA"

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V338.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V338.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -11,6 +12,10 @@ object V338 extends EditCheck[LoanApplicationRegister] with ApplicantUtils {
   override def name: String = "V338"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 
   override def apply(lar: LoanApplicationRegister): Result = {
     when(notANaturalPerson(lar)) {

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V340.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V340.scala
@@ -13,4 +13,6 @@ object V340 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "V340"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V340.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V340.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -15,4 +16,8 @@ object V340 extends EditCheck[LoanApplicationRegister] {
   override def name = "V340"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V347.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V347.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -11,6 +12,10 @@ object V347 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "V347"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 
   override def apply(lar: LoanApplicationRegister): Result = {
     when(lar.purchaserType is containedIn(1 to 9)) {

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V347.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V347.scala
@@ -10,6 +10,8 @@ object V347 extends EditCheck[LoanApplicationRegister] {
 
   override def name: String = "V347"
 
+  override def description = ""
+
   override def apply(lar: LoanApplicationRegister): Result = {
     when(lar.purchaserType is containedIn(1 to 9)) {
       lar.actionTakenType is oneOf(1, 6)

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V355.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V355.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -24,4 +25,8 @@ object V355 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "V355"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V355.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V355.scala
@@ -22,4 +22,6 @@ object V355 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name: String = "V355"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V360.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V360.scala
@@ -14,4 +14,6 @@ object V360 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name: String = "V360"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V360.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V360.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -16,4 +17,8 @@ object V360 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "V360"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V375.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V375.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -17,4 +18,8 @@ object V375 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "V375"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V375.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V375.scala
@@ -15,4 +15,6 @@ object V375 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name: String = "V375"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V385.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V385.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -28,4 +29,8 @@ object V385 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "V385"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V385.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V385.scala
@@ -26,4 +26,6 @@ object V385 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name: String = "V385"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V400.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V400.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -17,4 +18,8 @@ object V400 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "V400"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V400.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V400.scala
@@ -15,4 +15,6 @@ object V400 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name: String = "V400"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V410.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V410.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -17,5 +18,9 @@ object V410 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "V410"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V410.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V410.scala
@@ -16,4 +16,6 @@ object V410 extends EditCheck[LoanApplicationRegister] {
 
   override def name: String = "V410"
 
+  override def description = ""
+
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V415.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V415.scala
@@ -15,4 +15,6 @@ object V415 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "V415"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V415.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V415.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -17,4 +18,8 @@ object V415 extends EditCheck[LoanApplicationRegister] {
   override def name = "V415"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V425.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V425.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -17,4 +18,8 @@ object V425 extends EditCheck[LoanApplicationRegister] {
   override def name = "V425"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V425.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V425.scala
@@ -15,4 +15,6 @@ object V425 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "V425"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V430.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V430.scala
@@ -15,4 +15,6 @@ object V430 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "V430"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V430.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V430.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -17,4 +18,8 @@ object V430 extends EditCheck[LoanApplicationRegister] {
   override def name = "V430"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V435.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V435.scala
@@ -15,4 +15,6 @@ object V435 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "V435"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V435.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V435.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -17,4 +18,8 @@ object V435 extends EditCheck[LoanApplicationRegister] {
   override def name = "V435"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V440.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V440.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -17,4 +18,8 @@ object V440 extends EditCheck[LoanApplicationRegister] {
   override def name = "V440"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V440.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V440.scala
@@ -15,4 +15,6 @@ object V440 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "V440"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V445.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V445.scala
@@ -15,4 +15,6 @@ object V445 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "V445"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V445.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V445.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -17,4 +18,8 @@ object V445 extends EditCheck[LoanApplicationRegister] {
   override def name = "V445"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V447.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V447.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -17,4 +18,8 @@ object V447 extends EditCheck[LoanApplicationRegister] {
   override def name = "V447"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V447.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V447.scala
@@ -15,4 +15,6 @@ object V447 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "V447"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V450.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V450.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -11,6 +12,10 @@ object V450 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "V450"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 
   override def apply(lar: LoanApplicationRegister): Result = {
     lar.applicant.ethnicity is containedIn(1 to 4)

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V450.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V450.scala
@@ -10,6 +10,8 @@ object V450 extends EditCheck[LoanApplicationRegister] {
 
   override def name: String = "V450"
 
+  override def description = ""
+
   override def apply(lar: LoanApplicationRegister): Result = {
     lar.applicant.ethnicity is containedIn(1 to 4)
   }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V455.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V455.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -17,5 +18,9 @@ object V455 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "V455"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V455.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V455.scala
@@ -16,4 +16,6 @@ object V455 extends EditCheck[LoanApplicationRegister] {
 
   override def name: String = "V455"
 
+  override def description = ""
+
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V460.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V460.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -11,6 +12,10 @@ object V460 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "V460"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 
   override def apply(lar: LoanApplicationRegister): Result = {
     lar.applicant.coEthnicity is containedIn(1 to 5)

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V460.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V460.scala
@@ -10,6 +10,8 @@ object V460 extends EditCheck[LoanApplicationRegister] {
 
   override def name: String = "V460"
 
+  override def description = ""
+
   override def apply(lar: LoanApplicationRegister): Result = {
     lar.applicant.coEthnicity is containedIn(1 to 5)
   }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V463.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V463.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -10,6 +11,10 @@ object V463 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "V463"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 
   override def apply(lar: LoanApplicationRegister): Result = {
     when(lar.applicant.coEthnicity is equalTo(5)) {

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V463.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V463.scala
@@ -9,6 +9,8 @@ import hmda.validation.dsl.PredicateSyntax._
 object V463 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "V463"
 
+  override def description = ""
+
   override def apply(lar: LoanApplicationRegister): Result = {
     when(lar.applicant.coEthnicity is equalTo(5)) {
       (lar.applicant.coRace1 is equalTo(8)) and

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V465.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V465.scala
@@ -16,4 +16,6 @@ object V465 extends EditCheck[LoanApplicationRegister] {
 
   override def name: String = "V465"
 
+  override def description = ""
+
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V465.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V465.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -17,5 +18,9 @@ object V465 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "V465"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V470.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V470.scala
@@ -29,4 +29,6 @@ object V470 extends EditCheck[LoanApplicationRegister] {
 
   override def name: String = "V470"
 
+  override def description = ""
+
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V470.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V470.scala
@@ -1,8 +1,10 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
+
 import scala.util.Try
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
@@ -30,5 +32,9 @@ object V470 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "V470"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V475.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V475.scala
@@ -19,4 +19,6 @@ object V475 extends EditCheck[LoanApplicationRegister] {
 
   override def name: String = "V475"
 
+  override def description = ""
+
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V475.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V475.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -20,5 +21,9 @@ object V475 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "V475"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V480.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V480.scala
@@ -9,6 +9,8 @@ import hmda.validation.dsl.PredicateSyntax._
 object V480 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "V480"
 
+  override def description = ""
+
   override def apply(lar: LoanApplicationRegister): Result = {
     val appl: Applicant = lar.applicant
     val raceFields: List[String] = List(appl.race1.toString, appl.race2, appl.race3, appl.race4, appl.race5)

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V480.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V480.scala
@@ -1,5 +1,6 @@
 package hmda.validation.rules.lar.validity
 
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.model.fi.lar.{ Applicant, LoanApplicationRegister }
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
@@ -10,6 +11,10 @@ object V480 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "V480"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 
   override def apply(lar: LoanApplicationRegister): Result = {
     val appl: Applicant = lar.applicant

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V485.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V485.scala
@@ -29,4 +29,6 @@ object V485 extends EditCheck[LoanApplicationRegister] {
 
   override def name: String = "V485"
 
+  override def description = ""
+
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V485.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V485.scala
@@ -1,8 +1,10 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
+
 import scala.util.Try
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
@@ -30,5 +32,9 @@ object V485 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "V485"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V490.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V490.scala
@@ -19,4 +19,6 @@ object V490 extends EditCheck[LoanApplicationRegister] {
 
   override def name: String = "V490"
 
+  override def description = ""
+
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V490.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V490.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -20,5 +21,9 @@ object V490 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "V490"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V495.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V495.scala
@@ -9,6 +9,8 @@ import hmda.validation.dsl.PredicateSyntax._
 object V495 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "V495"
 
+  override def description = ""
+
   override def apply(lar: LoanApplicationRegister): Result = {
     val appl: Applicant = lar.applicant
     val coRaceFields: List[String] = List(appl.coRace1.toString, appl.coRace2, appl.coRace3, appl.coRace4, appl.coRace5)

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V495.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V495.scala
@@ -1,5 +1,6 @@
 package hmda.validation.rules.lar.validity
 
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.model.fi.lar.{ Applicant, LoanApplicationRegister }
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
@@ -10,6 +11,10 @@ object V495 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "V495"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 
   override def apply(lar: LoanApplicationRegister): Result = {
     val appl: Applicant = lar.applicant

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V500.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V500.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -12,6 +13,10 @@ object V500 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "V500"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 
   override def apply(lar: LoanApplicationRegister): Result = {
     (lar.rateSpread is equalTo("NA")) or (lar.rateSpread is numericMatching("NN.NN"))

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V500.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V500.scala
@@ -11,6 +11,8 @@ object V500 extends EditCheck[LoanApplicationRegister] {
 
   override def name: String = "V500"
 
+  override def description = ""
+
   override def apply(lar: LoanApplicationRegister): Result = {
     (lar.rateSpread is equalTo("NA")) or (lar.rateSpread is numericMatching("NN.NN"))
   }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V505.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V505.scala
@@ -15,4 +15,6 @@ object V505 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "V505"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V505.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V505.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -17,4 +18,8 @@ object V505 extends EditCheck[LoanApplicationRegister] {
   override def name = "V505"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V520.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V520.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -11,6 +12,10 @@ object V520 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "V520"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 
   override def apply(lar: LoanApplicationRegister): Result = {
     when(lar.lienStatus is 3) {

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V520.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V520.scala
@@ -10,6 +10,8 @@ object V520 extends EditCheck[LoanApplicationRegister] {
 
   override def name: String = "V520"
 
+  override def description = ""
+
   override def apply(lar: LoanApplicationRegister): Result = {
     when(lar.lienStatus is 3) {
       lar.rateSpread is "NA"

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V525.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V525.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -17,4 +18,8 @@ object V525 extends EditCheck[LoanApplicationRegister] {
   override def name = "V525"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V525.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V525.scala
@@ -15,4 +15,6 @@ object V525 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "V525"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V535.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V535.scala
@@ -17,4 +17,6 @@ object V535 extends EditCheck[LoanApplicationRegister] with ApplicantUtils {
   }
 
   override def name = "V535"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V535.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V535.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -19,4 +20,8 @@ object V535 extends EditCheck[LoanApplicationRegister] with ApplicantUtils {
   override def name = "V535"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V540.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V540.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -18,4 +19,8 @@ object V540 extends EditCheck[LoanApplicationRegister] {
   override def name = "V540"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V540.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V540.scala
@@ -16,4 +16,6 @@ object V540 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "V540"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V545.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V545.scala
@@ -15,4 +15,6 @@ object V545 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "V545"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V545.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V545.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -17,4 +18,8 @@ object V545 extends EditCheck[LoanApplicationRegister] {
   override def name = "V545"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V550.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V550.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -17,4 +18,8 @@ object V550 extends EditCheck[LoanApplicationRegister] {
   override def name = "V550"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V550.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V550.scala
@@ -15,4 +15,6 @@ object V550 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "V550"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V555.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V555.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -20,4 +21,8 @@ object V555 extends EditCheck[LoanApplicationRegister] {
   override def name = "V555"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V555.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V555.scala
@@ -18,4 +18,6 @@ object V555 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "V555"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V560.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V560.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -20,4 +21,8 @@ object V560 extends EditCheck[LoanApplicationRegister] {
   override def name = "V560"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V560.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V560.scala
@@ -18,4 +18,6 @@ object V560 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "V560"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V565.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V565.scala
@@ -15,4 +15,6 @@ object V565 extends EditCheck[LoanApplicationRegister] {
   }
 
   override def name = "V565"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V565.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V565.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -17,4 +18,8 @@ object V565 extends EditCheck[LoanApplicationRegister] {
   override def name = "V565"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V570.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V570.scala
@@ -10,6 +10,8 @@ object V570 extends EditCheck[LoanApplicationRegister] {
 
   override def name: String = "V570"
 
+  override def description = ""
+
   override def apply(lar: LoanApplicationRegister): Result = {
     when(lar.lienStatus is equalTo(1)) {
       (lar.rateSpread is equalTo("NA")) or (lar.rateSpread is numericallyBetween("1.50", "99.99"))

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V570.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V570.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -11,6 +12,10 @@ object V570 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "V570"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 
   override def apply(lar: LoanApplicationRegister): Result = {
     when(lar.lienStatus is equalTo(1)) {

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V575.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V575.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.validity
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
 import hmda.validation.dsl.PredicateCommon._
@@ -11,6 +12,10 @@ object V575 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "V575"
 
   override def description = ""
+
+  override def fields(lar: LoanApplicationRegister) = Map(
+    noField -> ""
+  )
 
   override def apply(lar: LoanApplicationRegister): Result = {
     when(lar.lienStatus is equalTo(2)) {

--- a/validation/src/main/scala/hmda/validation/rules/lar/validity/V575.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/validity/V575.scala
@@ -10,6 +10,8 @@ object V575 extends EditCheck[LoanApplicationRegister] {
 
   override def name: String = "V575"
 
+  override def description = ""
+
   override def apply(lar: LoanApplicationRegister): Result = {
     when(lar.lienStatus is equalTo(2)) {
       lar.rateSpread is equalTo("NA") or (lar.rateSpread is numericallyBetween("3.50", "99.99"))

--- a/validation/src/main/scala/hmda/validation/rules/ts/quality/Q020.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/quality/Q020.scala
@@ -1,5 +1,6 @@
 package hmda.validation.rules.ts.quality
 
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.model.fi.ts.TransmittalSheet
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
@@ -15,4 +16,8 @@ object Q020 extends EditCheck[TransmittalSheet] {
   override def name: String = "Q020"
 
   override def description = ""
+
+  override def fields(lar: TransmittalSheet) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/ts/quality/Q020.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/quality/Q020.scala
@@ -13,4 +13,6 @@ object Q020 extends EditCheck[TransmittalSheet] {
   }
 
   override def name: String = "Q020"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/ts/quality/Q033.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/quality/Q033.scala
@@ -1,5 +1,6 @@
 package hmda.validation.rules.ts.quality
 
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.model.fi.ts.TransmittalSheet
 import hmda.model.institution.Institution
 import hmda.model.institution.InstitutionType._
@@ -14,6 +15,10 @@ class Q033 private (respondent: Institution) extends EditCheck[TransmittalSheet]
   override def name: String = "Q033"
 
   override def description = ""
+
+  override def fields(lar: TransmittalSheet) = Map(
+    noField -> ""
+  )
 
   override def apply(ts: TransmittalSheet): Result = {
     when((respondent.institutionType is oneOf(Bank, SavingsAndLoan, IndependentMortgageCompany))

--- a/validation/src/main/scala/hmda/validation/rules/ts/quality/Q033.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/quality/Q033.scala
@@ -13,6 +13,8 @@ import hmda.validation.rules.{ EditCheck, IfInstitutionPresentIn }
 class Q033 private (respondent: Institution) extends EditCheck[TransmittalSheet] {
   override def name: String = "Q033"
 
+  override def description = ""
+
   override def apply(ts: TransmittalSheet): Result = {
     when((respondent.institutionType is oneOf(Bank, SavingsAndLoan, IndependentMortgageCompany))
       and (respondent.hasParent is true)) {

--- a/validation/src/main/scala/hmda/validation/rules/ts/syntactical/S010.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/syntactical/S010.scala
@@ -20,4 +20,6 @@ object S010 extends EditCheck[TransmittalSheet] {
   }
 
   override def name: String = "S010"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/ts/syntactical/S010.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/syntactical/S010.scala
@@ -1,5 +1,6 @@
 package hmda.validation.rules.ts.syntactical
 
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.model.fi.ts.TransmittalSheet
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
@@ -22,4 +23,8 @@ object S010 extends EditCheck[TransmittalSheet] {
   override def name: String = "S010"
 
   override def description = ""
+
+  override def fields(lar: TransmittalSheet) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/ts/syntactical/S020.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/syntactical/S020.scala
@@ -1,6 +1,8 @@
 package hmda.validation.rules.ts.syntactical
 
 import hmda.model.fi.HasControlNumber
+import hmda.model.fi.lar.fields.LarTopLevelFields._
+import hmda.model.fi.ts.TransmittalSheet
 import hmda.model.institution.Agency
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
@@ -18,5 +20,9 @@ object S020 extends EditCheck[HasControlNumber] {
   override def name: String = "S020"
 
   override def description = ""
+
+  override def fields(lar: HasControlNumber) = Map(
+    noField -> ""
+  )
 
 }

--- a/validation/src/main/scala/hmda/validation/rules/ts/syntactical/S020.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/syntactical/S020.scala
@@ -17,4 +17,6 @@ object S020 extends EditCheck[HasControlNumber] {
 
   override def name: String = "S020"
 
+  override def description = ""
+
 }

--- a/validation/src/main/scala/hmda/validation/rules/ts/syntactical/S025.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/syntactical/S025.scala
@@ -17,6 +17,8 @@ object S025 {
 class S025 private (institution: Institution) extends EditCheck[HasControlNumber] {
   def name = "S025"
 
+  override def description = ""
+
   def apply(input: HasControlNumber): Result = compare(input.respondentId, input.agencyCode)
 
   private def compare(filingRespId: String, filingAgencyCode: Int): Result = {

--- a/validation/src/main/scala/hmda/validation/rules/ts/syntactical/S025.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/syntactical/S025.scala
@@ -1,6 +1,8 @@
 package hmda.validation.rules.ts.syntactical
 
 import hmda.model.fi.HasControlNumber
+import hmda.model.fi.lar.fields.LarTopLevelFields._
+import hmda.model.fi.ts.TransmittalSheet
 import hmda.model.institution.Institution
 import hmda.validation.context.ValidationContext
 import hmda.validation.dsl.PredicateCommon._
@@ -20,6 +22,10 @@ class S025 private (institution: Institution) extends EditCheck[HasControlNumber
   override def description = ""
 
   def apply(input: HasControlNumber): Result = compare(input.respondentId, input.agencyCode)
+
+  override def fields(lar: HasControlNumber) = Map(
+    noField -> ""
+  )
 
   private def compare(filingRespId: String, filingAgencyCode: Int): Result = {
     institution.respondentId match {

--- a/validation/src/main/scala/hmda/validation/rules/ts/syntactical/S028.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/syntactical/S028.scala
@@ -1,5 +1,6 @@
 package hmda.validation.rules.ts.syntactical
 
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.model.fi.ts.TransmittalSheet
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
@@ -24,4 +25,8 @@ object S028 extends EditCheck[TransmittalSheet] {
   override def name: String = "S028"
 
   override def description = ""
+
+  override def fields(lar: TransmittalSheet) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/ts/syntactical/S028.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/syntactical/S028.scala
@@ -22,4 +22,6 @@ object S028 extends EditCheck[TransmittalSheet] {
   }
 
   override def name: String = "S028"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/ts/syntactical/S100.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/syntactical/S100.scala
@@ -18,5 +18,7 @@ object S100 {
 class S100 private (year: Int) extends EditCheck[TransmittalSheet] {
   def name = "S100"
 
+  override def description = ""
+
   def apply(input: TransmittalSheet): Result = input.activityYear is equalTo(year)
 }

--- a/validation/src/main/scala/hmda/validation/rules/ts/syntactical/S100.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/syntactical/S100.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.ts.syntactical
 
 import hmda.model.fi.HasControlNumber
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.model.fi.ts.TransmittalSheet
 import hmda.model.institution.Institution
 import hmda.validation.context.ValidationContext
@@ -19,6 +20,10 @@ class S100 private (year: Int) extends EditCheck[TransmittalSheet] {
   def name = "S100"
 
   override def description = ""
+
+  override def fields(lar: TransmittalSheet) = Map(
+    noField -> ""
+  )
 
   def apply(input: TransmittalSheet): Result = input.activityYear is equalTo(year)
 }

--- a/validation/src/main/scala/hmda/validation/rules/ts/validity/V105.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/validity/V105.scala
@@ -1,5 +1,6 @@
 package hmda.validation.rules.ts.validity
 
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.model.fi.ts.TransmittalSheet
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
@@ -18,4 +19,8 @@ object V105 extends EditCheck[TransmittalSheet] {
   override def name: String = "V105"
 
   override def description = ""
+
+  override def fields(lar: TransmittalSheet) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/ts/validity/V105.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/validity/V105.scala
@@ -16,4 +16,6 @@ object V105 extends EditCheck[TransmittalSheet] {
   }
 
   override def name: String = "V105"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/ts/validity/V108.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/validity/V108.scala
@@ -1,5 +1,6 @@
 package hmda.validation.rules.ts.validity
 
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.model.fi.ts.TransmittalSheet
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
@@ -10,6 +11,10 @@ object V108 extends EditCheck[TransmittalSheet] {
   override def name: String = "V108"
 
   override def description = ""
+
+  override def fields(lar: TransmittalSheet) = Map(
+    noField -> ""
+  )
 
   override def apply(ts: TransmittalSheet): Result = {
     when(ts.parent.name not equalTo("")) {

--- a/validation/src/main/scala/hmda/validation/rules/ts/validity/V108.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/validity/V108.scala
@@ -9,6 +9,8 @@ import hmda.validation.dsl.PredicateSyntax._
 object V108 extends EditCheck[TransmittalSheet] {
   override def name: String = "V108"
 
+  override def description = ""
+
   override def apply(ts: TransmittalSheet): Result = {
     when(ts.parent.name not equalTo("")) {
       ts.parent.name not equalTo(ts.respondent.name)

--- a/validation/src/main/scala/hmda/validation/rules/ts/validity/V110.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/validity/V110.scala
@@ -13,6 +13,8 @@ import hmda.validation.rules.{ EditCheck, IfInstitutionPresentIn }
 class V110 private (institution: Institution) extends EditCheck[TransmittalSheet] {
   override def name: String = "V110"
 
+  override def description = ""
+
   override def apply(ts: TransmittalSheet): Result = {
     when(institution.institutionType is oneOf(MBS, Affiliate)) {
       ts.parent is completeNameAndAddress

--- a/validation/src/main/scala/hmda/validation/rules/ts/validity/V110.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/validity/V110.scala
@@ -1,5 +1,6 @@
 package hmda.validation.rules.ts.validity
 
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.model.fi.ts.TransmittalSheet
 import hmda.model.institution.Institution
 import hmda.model.institution.InstitutionType._
@@ -14,6 +15,10 @@ class V110 private (institution: Institution) extends EditCheck[TransmittalSheet
   override def name: String = "V110"
 
   override def description = ""
+
+  override def fields(lar: TransmittalSheet) = Map(
+    noField -> ""
+  )
 
   override def apply(ts: TransmittalSheet): Result = {
     when(institution.institutionType is oneOf(MBS, Affiliate)) {

--- a/validation/src/main/scala/hmda/validation/rules/ts/validity/V111.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/validity/V111.scala
@@ -19,4 +19,6 @@ object V111 extends EditCheck[TransmittalSheet] {
   }
 
   override def name: String = "V111"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/ts/validity/V111.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/validity/V111.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.ts.validity
 
 import hmda.model.census.Census._
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.model.fi.ts.TransmittalSheet
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
@@ -21,4 +22,8 @@ object V111 extends EditCheck[TransmittalSheet] {
   override def name: String = "V111"
 
   override def description = ""
+
+  override def fields(lar: TransmittalSheet) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/ts/validity/V112.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/validity/V112.scala
@@ -1,5 +1,6 @@
 package hmda.validation.rules.ts.validity
 
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.model.fi.ts.TransmittalSheet
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
@@ -20,4 +21,8 @@ object V112 extends EditCheck[TransmittalSheet] {
   override def name: String = "V112"
 
   override def description = ""
+
+  override def fields(lar: TransmittalSheet) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/ts/validity/V112.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/validity/V112.scala
@@ -18,4 +18,6 @@ object V112 extends EditCheck[TransmittalSheet] {
   }
 
   override def name: String = "V112"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/ts/validity/V115.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/validity/V115.scala
@@ -9,6 +9,8 @@ import hmda.validation.dsl.PredicateSyntax._
 object V115 extends EditCheck[TransmittalSheet] {
   override def name: String = "V115"
 
+  override def description = ""
+
   override def apply(ts: TransmittalSheet): Result = {
     ts.contact.name not empty
   }

--- a/validation/src/main/scala/hmda/validation/rules/ts/validity/V115.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/validity/V115.scala
@@ -1,5 +1,6 @@
 package hmda.validation.rules.ts.validity
 
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.model.fi.ts.TransmittalSheet
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
@@ -10,6 +11,10 @@ object V115 extends EditCheck[TransmittalSheet] {
   override def name: String = "V115"
 
   override def description = ""
+
+  override def fields(lar: TransmittalSheet) = Map(
+    noField -> ""
+  )
 
   override def apply(ts: TransmittalSheet): Result = {
     ts.contact.name not empty

--- a/validation/src/main/scala/hmda/validation/rules/ts/validity/V120.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/validity/V120.scala
@@ -1,5 +1,6 @@
 package hmda.validation.rules.ts.validity
 
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.model.fi.ts.TransmittalSheet
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
@@ -15,4 +16,8 @@ object V120 extends EditCheck[TransmittalSheet] {
   override def name = "V120"
 
   override def description = ""
+
+  override def fields(lar: TransmittalSheet) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/ts/validity/V120.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/validity/V120.scala
@@ -13,4 +13,6 @@ object V120 extends EditCheck[TransmittalSheet] {
   }
 
   override def name = "V120"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/ts/validity/V125.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/validity/V125.scala
@@ -19,4 +19,6 @@ object V125 extends EditCheck[TransmittalSheet] {
   }
 
   override def name: String = "V125"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/ts/validity/V125.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/validity/V125.scala
@@ -1,5 +1,6 @@
 package hmda.validation.rules.ts.validity
 
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.model.fi.ts.TransmittalSheet
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
@@ -21,4 +22,8 @@ object V125 extends EditCheck[TransmittalSheet] {
   override def name: String = "V125"
 
   override def description = ""
+
+  override def fields(lar: TransmittalSheet) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/ts/validity/V135.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/validity/V135.scala
@@ -1,5 +1,6 @@
 package hmda.validation.rules.ts.validity
 
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.model.fi.ts.TransmittalSheet
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
@@ -15,4 +16,8 @@ object V135 extends EditCheck[TransmittalSheet] {
   override def name = "V135"
 
   override def description = ""
+
+  override def fields(lar: TransmittalSheet) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/ts/validity/V135.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/validity/V135.scala
@@ -13,4 +13,6 @@ object V135 extends EditCheck[TransmittalSheet] {
   }
 
   override def name = "V135"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/ts/validity/V140.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/validity/V140.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.ts.validity
 
 import hmda.model.census.Census._
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.model.fi.ts.TransmittalSheet
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
@@ -18,4 +19,8 @@ object V140 extends EditCheck[TransmittalSheet] {
   override def name: String = "V140"
 
   override def description = ""
+
+  override def fields(lar: TransmittalSheet) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/ts/validity/V140.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/validity/V140.scala
@@ -16,4 +16,6 @@ object V140 extends EditCheck[TransmittalSheet] {
   }
 
   override def name: String = "V140"
+
+  override def description = ""
 }

--- a/validation/src/main/scala/hmda/validation/rules/ts/validity/V145.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/validity/V145.scala
@@ -9,6 +9,8 @@ import hmda.validation.dsl.PredicateSyntax._
 object V145 extends EditCheck[TransmittalSheet] {
   override def name: String = "V145"
 
+  override def description = ""
+
   override def apply(ts: TransmittalSheet): Result = {
     ts.respondent.zipCode is validZipCode
   }

--- a/validation/src/main/scala/hmda/validation/rules/ts/validity/V145.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/validity/V145.scala
@@ -1,5 +1,6 @@
 package hmda.validation.rules.ts.validity
 
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.model.fi.ts.TransmittalSheet
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
@@ -10,6 +11,10 @@ object V145 extends EditCheck[TransmittalSheet] {
   override def name: String = "V145"
 
   override def description = ""
+
+  override def fields(lar: TransmittalSheet) = Map(
+    noField -> ""
+  )
 
   override def apply(ts: TransmittalSheet): Result = {
     ts.respondent.zipCode is validZipCode

--- a/validation/src/main/scala/hmda/validation/rules/ts/validity/V150.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/validity/V150.scala
@@ -9,6 +9,8 @@ import hmda.validation.dsl.PredicateSyntax._
 object V150 extends EditCheck[TransmittalSheet] {
   override def name: String = "V150"
 
+  override def description = ""
+
   override def apply(ts: TransmittalSheet): Result = {
     ts.contact.name not equalTo(ts.respondent.name)
   }

--- a/validation/src/main/scala/hmda/validation/rules/ts/validity/V150.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/validity/V150.scala
@@ -1,5 +1,6 @@
 package hmda.validation.rules.ts.validity
 
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.model.fi.ts.TransmittalSheet
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
@@ -10,6 +11,10 @@ object V150 extends EditCheck[TransmittalSheet] {
   override def name: String = "V150"
 
   override def description = ""
+
+  override def fields(lar: TransmittalSheet) = Map(
+    noField -> ""
+  )
 
   override def apply(ts: TransmittalSheet): Result = {
     ts.contact.name not equalTo(ts.respondent.name)

--- a/validation/src/main/scala/hmda/validation/rules/ts/validity/V155.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/validity/V155.scala
@@ -1,5 +1,6 @@
 package hmda.validation.rules.ts.validity
 
+import hmda.model.fi.lar.fields.LarTopLevelFields._
 import hmda.model.fi.ts.TransmittalSheet
 import hmda.validation.dsl.Result
 import hmda.validation.rules.EditCheck
@@ -17,4 +18,8 @@ object V155 extends EditCheck[TransmittalSheet] {
   override def name: String = "V155"
 
   override def description = ""
+
+  override def fields(lar: TransmittalSheet) = Map(
+    noField -> ""
+  )
 }

--- a/validation/src/main/scala/hmda/validation/rules/ts/validity/V155.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/validity/V155.scala
@@ -15,4 +15,6 @@ object V155 extends EditCheck[TransmittalSheet] {
   }
 
   override def name: String = "V155"
+
+  override def description = ""
 }


### PR DESCRIPTION
Close #717 

This PR finishes implementing #717 by adding a list within each lar of each edit which gives the names of relevant fields and the values which caused the edit to fail.

As a side effect, in order to return the fields for the transmittal sheet the transmittal sheet had to be treated like any other line and so this PR as Closes #721 