### PR TITLE
Adds SUPPORT_EMAIL envvar to keycloak service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       INSTITUTION_SEARCH_URI: https://192.168.99.100:9443
       INSTITUTION_SEARCH_VALIDATE_SSL: "OFF"
       REDIRECT_URIS: '[ "http://192.168.99.100/oidc-callback", "http://192.168.99.100/silent_renew.html" ]'
+      SUPPORT_EMAIL: 'support@localhost.localdomain'
     volumes:
       - '../hmda-platform-auth/keycloak/themes/hmda:/opt/jboss/keycloak/themes/hmda'
     #  - '../hmda-platform-auth/keycloak/import:/opt/jboss/import'


### PR DESCRIPTION
Companion PR to cfpb/hmda-platform-auth#38.  The two PRs should be merged at the same time.