### PR TITLE
2.11 to 2.12 for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,4 @@ ENTRYPOINT ["java", "-jar", "hmda.jar"]
 
 EXPOSE 8080
 
-COPY target/scala-2.11/hmda.jar . 
+COPY target/scala-2.12/hmda.jar . 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - '9090:8080'
     volumes:
-    - ./target/scala-2.11/hmda.jar:/opt/hmda.jar
+    - ./target/scala-2.12/hmda.jar:/opt/hmda.jar
 
   ui:
     build: ../hmda-platform-ui
@@ -29,7 +29,7 @@ services:
       KEYCLOAK_PASSWORD: admin
       POSTGRES_DB: keycloak
       POSTGRES_USER: keycloak
-      POSTGRES_PASSWORD: password 
+      POSTGRES_PASSWORD: password
       POSTGRES_SERVER: keycloak_db
       POSTGRES_PORT: 5432
       # Must use the external address since it is used both in frontend and backend.


### PR DESCRIPTION
#736 builds to a `2.12` path. This PR just updates the dockerfile and compose setup to use that instead.

_Not sure if we should or not, but can we specify a target for the jar file to prevent updates like this?_