### PR TITLE
Fix for loading test Filings

### DIFF
--- a/persistence/src/main/scala/hmda/persistence/demo/DemoData.scala
+++ b/persistence/src/main/scala/hmda/persistence/demo/DemoData.scala
@@ -81,11 +81,11 @@ object DemoData {
   }
 
   def loadFilings(filings: Seq[Filing], system: ActorSystem): Unit = {
-    filings.foreach { filing =>
-      val filingActor = system.actorOf(FilingPersistence.props(filing.institutionId))
-      filingActor ? CreateFiling(filing)
-      Thread.sleep(100)
-      filingActor ! Shutdown
+    filings.groupBy(_.institutionId).foreach {
+      case (instId: String, filings: Seq[Filing]) =>
+        val filingActor = system.actorOf(FilingPersistence.props(instId))
+        filings.foreach { filing => filingActor ? CreateFiling(filing) }
+        filingActor ! Shutdown
     }
   }
 


### PR DESCRIPTION
Closes #741 

My hypothesis is that there were failures in `SubmissionEditPathsSpec` because the test Filings were not being loaded reliably. Please test thoroughly--I haven't seen the failures since I made this change, but I'm not 100% sure this fixes it.