### PR TITLE
Sort Edits By Row

### DIFF
--- a/Documents/API.md
+++ b/Documents/API.md
@@ -223,10 +223,13 @@ All endpoints in the `/institutions` namespace require two headers (see "Authori
     ```
 
 * `/institutions/<institution>/filings/<period>/submissions/<submissionId>/edits`
-    * `GET`  - List of all edits for a given submission, grouped by edit type
+    * `GET`  - List of all edits for a given submission
+       * By default, results are grouped by edit type, then by named edit.
+       * Use `sortBy=row` as a query parameter to group by the row in the submitted file.
 
     Example response, with HTTP code 200:
 
+    Default Sorting:
     ```json
     {
       "syntactical": {
@@ -268,17 +271,18 @@ All endpoints in the `/institutions` namespace require two headers (see "Authori
         {
             "edits": [
                 {
-                   "edit": "Q007",
-                   "description": "Description of Q007",
-                   "justifications": [
-                     {
-                       "value": "don't worry",
-                       "selected": false
-                     },
-                     {
-                       "value": "be happy",
-                       "selected": false
-                     }
+                    "edit": "Q023",
+                    "justifications": [
+                        {
+                            "id": 1,
+                            "value": "Most of the loan activity are in areas outside of an MSA/MD",
+                            "verified": true
+                        },
+                        {
+                            "id": 2,
+                            "value": "Most branches or the main branch is located outside of an MSA/MD, therefore many loans are located outside of an MSA/MD.",
+                            "verified": false
+                        },
                    ]
                 }
             ]
@@ -300,6 +304,86 @@ All endpoints in the `/institutions` namespace require two headers (see "Authori
     macro, Q007
     ```
 
+
+    Sorted by Row:
+    ```json
+    {
+      "rows": [
+        {
+          "rowId": "Transmittal Sheet",
+          "edits": [
+            {
+              "editId": "S020",
+              "description": "Agency code must = 1, 2, 3, 5, 7, 9. The agency that submits the data must be the same as the reported agency code.",
+              "fields": {
+                "Agency Code": 4
+              }
+            }
+          ]
+        },
+        {
+          "rowId": "8299422144",
+          "edits": [
+            {
+              "editId": "S020",
+              "description": "Agency code must = 1, 2, 3, 5, 7, 9. The agency that submits the data must be the same as the reported agency code.",
+              "fields": {
+                "Agency Code": 11
+              }
+            }
+          ]
+        },
+        {
+          "rowId": "4977566612",
+          "edits": [
+            {
+              "editId": "V550",
+              "description": "Lien status must = 1, 2, 3, or 4.",
+              "fields": {
+                "Lien Status": 0
+              }
+            },
+            {
+              "editId": "V555",
+              "description": "If loan purpose = 1 or 3, then lien status must = 1, 2, or 4.",
+              "fields": {
+                "Loan Purpose": 1,
+                "Lien Status": 0
+              }
+            },
+            {
+              "editId": "V560",
+              "description": "If action taken type = 1-5, 7 or 8, then lien status must = 1, 2, or 3.",
+              "fields": {
+                "Action Taken Type": 3,
+                "Lien Status": 0
+              }
+            }
+          ]
+        }
+      ],
+      "macroResults": {
+            "edits": [
+                {
+                    "edit": "Q023",
+                    "justifications": [
+                        {
+                            "id": 1,
+                            "value": "Most of the loan activity are in areas outside of an MSA/MD",
+                            "verified": true
+                        },
+                        {
+                            "id": 2,
+                            "value": "Most branches or the main branch is located outside of an MSA/MD, therefore many loans are located outside of an MSA/MD.",
+                            "verified": false
+                        },
+                   ]
+                }
+            ]
+        }
+
+    }
+    ```
 
 * `/institutions/<institution>/filings/<period>/submissions/<submissionId>/edits/<syntactical|validity|quality|macro>`
     * `GET`  - List of edits of a specific type, for a given submission

--- a/Documents/API.md
+++ b/Documents/API.md
@@ -362,7 +362,7 @@ All endpoints in the `/institutions` namespace require two headers (see "Authori
           ]
         }
       ],
-      "macroResults": {
+      "macro": {
             "edits": [
                 {
                     "edit": "Q023",

--- a/api/src/main/scala/hmda/api/model/EditResults.scala
+++ b/api/src/main/scala/hmda/api/model/EditResults.scala
@@ -22,7 +22,7 @@ case object EditResults {
 
 // For a single row, all of the edits that it failed
 case class RowResult(rowId: String, edits: Seq[RowEditDetail])
-case class RowResults(rows: Seq[RowResult], macroResults: MacroResults)
+case class RowResults(rows: Seq[RowResult], `macro`: MacroResults)
 case class RowEditDetail(editId: String, description: String)
 
 case class MacroResult(edit: String, justifications: Set[MacroEditJustification])

--- a/api/src/main/scala/hmda/api/model/EditResults.scala
+++ b/api/src/main/scala/hmda/api/model/EditResults.scala
@@ -4,6 +4,8 @@ import hmda.validation.engine.MacroEditJustification
 
 case class LarId(loanId: String)
 case class LarEditResult(lar: LarId)
+
+// For an individual edit, all of the rows that failed it
 case class EditResult(edit: String, description: String, ts: Boolean, lars: Seq[LarEditResult]) {
   def toCsv(editType: String) = {
     val larCsv = lars.map(l => Seq(editType, edit, l.lar.loanId).mkString("", ", ", "\n")).mkString
@@ -17,6 +19,12 @@ case class EditResults(edits: Seq[EditResult]) {
 case object EditResults {
   def empty: EditResults = EditResults(Nil)
 }
+
+// For a single row, all of the edits that it failed
+case class RowResult(rowId: String, edits: Seq[RowEditDetail])
+case class RowResults(rows: Seq[RowResult], macroResults: MacroResults)
+case class RowEditDetail(editId: String, description: String)
+
 case class MacroResult(edit: String, justifications: Set[MacroEditJustification])
 case class MacroResults(edits: Seq[MacroResult]) {
   def toCsv = edits.map(e => "macro, " + e.edit + "\n").mkString

--- a/api/src/main/scala/hmda/api/protocol/processing/EditResultsProtocol.scala
+++ b/api/src/main/scala/hmda/api/protocol/processing/EditResultsProtocol.scala
@@ -9,7 +9,10 @@ trait EditResultsProtocol extends ValidationResultProtocol {
   implicit val larEditResultFormat = jsonFormat1(LarEditResult.apply)
   implicit val editResultFormat = jsonFormat4(EditResult.apply)
   implicit val editResultsFormat = jsonFormat1(EditResults.apply)
+  implicit val rowEditDetailFormat = jsonFormat2(RowEditDetail.apply)
+  implicit val rowResultFormat = jsonFormat2(RowResult.apply)
   implicit val macroResultFormat = jsonFormat2(MacroResult.apply)
   implicit val macroResultsFormat = jsonFormat1(MacroResults.apply)
+  implicit val rowResultsFormat = jsonFormat2(RowResults.apply)
   implicit val summaryEditResultsFormat = jsonFormat4(SummaryEditResults.apply)
 }

--- a/api/src/test/scala/hmda/api/http/ValidationErrorConverterSpec.scala
+++ b/api/src/test/scala/hmda/api/http/ValidationErrorConverterSpec.scala
@@ -50,7 +50,7 @@ class ValidationErrorConverterSpec extends WordSpec with MustMatchers with Valid
       val results: RowResults = validationErrorsToRowResults(tsErrors, larErrors, macroErrors)
       results.rows.size mustBe 4
       results.rows.contains(tsResults) mustBe true
-      results.macroResults.edits.contains(macros) mustBe true
+      results.`macro`.edits.contains(macros) mustBe true
 
       val larRow = results.rows.find(_.rowId == "4977566612").get
       larRow.edits.size mustBe 3

--- a/api/src/test/scala/hmda/api/http/ValidationErrorConverterSpec.scala
+++ b/api/src/test/scala/hmda/api/http/ValidationErrorConverterSpec.scala
@@ -2,44 +2,59 @@ package hmda.api.http
 
 import hmda.api.model._
 import hmda.model.fi.lar.LoanApplicationRegister
-import hmda.model.fi.ts.TransmittalSheet
 import hmda.model.util.FITestData._
 import hmda.parser.fi.lar.LarCsvParser
-import hmda.parser.fi.ts.TsCsvParser
 import hmda.validation.context.ValidationContext
 import hmda.validation.engine._
 import hmda.validation.engine.lar.LarEngine
-import hmda.validation.engine.ts.TsEngine
 import org.scalatest.{ MustMatchers, WordSpec }
 
 class ValidationErrorConverterSpec extends WordSpec with MustMatchers with ValidationErrorConverter with LarEngine {
 
   "Validation errors" must {
-    "be converted to edit check summary" in {
+
+    val tsErrors: Seq[ValidationError] = Seq(SyntacticalValidationError("8299422144", "S020"))
+
+    val larErrors: Seq[ValidationError] = {
       val badLars: Seq[LoanApplicationRegister] = fiCSVEditErrors.split("\n").tail.map(line => LarCsvParser(line).right.get)
       val ctx = ValidationContext(None, Some(2017))
-      val larErrors = badLars.flatMap(lar => validationErrors(lar, ctx, validateLar).errors)
+      badLars.flatMap(lar => validationErrors(lar, ctx, validateLar).errors)
+    }
 
-      val tsErrors = Seq(SyntacticalValidationError("8299422144", "S020"))
+    val macroErrors: Seq[MacroValidationError] = Seq(MacroValidationError("Q047", Seq()))
 
-      val syntacticalEditResults =
-        validationErrorsToEditResults(tsErrors, larErrors, Syntactical)
-      val validityEditResults =
-        validationErrorsToEditResults(tsErrors, larErrors, Validity)
-      val qualityEditResults =
-        validationErrorsToEditResults(tsErrors, larErrors, Quality)
-      val macroEditResults =
-        validationErrorsToMacroResults(larErrors)
+    val s020Desc = "Agency code must = 1, 2, 3, 5, 7, 9. The agency that submits the data must be the same as the reported agency code."
+    val s010Desc = "The first record identifier in the file must = 1 (TS). The second and all subsequent record identifiers must = 2 (LAR)."
+
+    "be converted to edit check summary" in {
+      val syntacticalEditResults = validationErrorsToEditResults(tsErrors, larErrors, Syntactical)
+      val validityEditResults = validationErrorsToEditResults(tsErrors, larErrors, Validity)
+      val qualityEditResults = validationErrorsToEditResults(tsErrors, larErrors, Quality)
+      val macroEditResults = validationErrorsToMacroResults(larErrors)
       val summaryEditResults = SummaryEditResults(syntacticalEditResults, validityEditResults, qualityEditResults, macroEditResults)
 
-      val s020 = EditResult("S020", "Agency code must = 1, 2, 3, 5, 7, 9. The agency that submits the data must be the same as the reported agency code.", ts = true, Seq(LarEditResult(LarId("8299422144")), LarEditResult(LarId("2185751599"))))
-      val s010 = EditResult("S010", "The first record identifier in the file must = 1 (TS). The second and all subsequent record identifiers must = 2 (LAR).", ts = false, Seq(LarEditResult(LarId("2185751599"))))
+      val s020 = EditResult("S020", s020Desc, ts = true, Seq(LarEditResult(LarId("8299422144")), LarEditResult(LarId("2185751599"))))
+      val s010 = EditResult("S010", s010Desc, ts = false, Seq(LarEditResult(LarId("2185751599"))))
       summaryEditResults.syntactical.edits.head mustBe s020
       summaryEditResults.syntactical.edits.tail.contains(s010) mustBe true
       summaryEditResults.validity.edits.size mustBe 3
       summaryEditResults.quality mustBe EditResults(Nil)
       summaryEditResults.`macro` mustBe MacroResults(Nil)
 
+    }
+
+    "sort failures by row" in {
+      val tsResults = RowResult("Transmittal Sheet", Seq(RowEditDetail("S020", s020Desc)))
+      val macros = MacroResult("Q047", Set(MacroEditJustification(1, "There were many requests for preapprovals, but the applicant did not proceed with the loan.", false)))
+
+      val results: RowResults = validationErrorsToRowResults(tsErrors, larErrors, macroErrors)
+      results.rows.size mustBe 4
+      results.rows.contains(tsResults) mustBe true
+      results.macroResults.edits.contains(macros) mustBe true
+
+      val larRow = results.rows.find(_.rowId == "4977566612").get
+      larRow.edits.size mustBe 3
+      larRow.edits.head.editId mustBe "V550"
     }
   }
 

--- a/api/src/test/scala/hmda/api/http/institutions/submissions/SubmissionEditPathsSpec.scala
+++ b/api/src/test/scala/hmda/api/http/institutions/submissions/SubmissionEditPathsSpec.scala
@@ -76,7 +76,7 @@ class SubmissionEditPathsSpec extends InstitutionHttpApiSpec {
       status mustBe StatusCodes.OK
       val rowResponse = responseAs[RowResults]
       rowResponse.rows.toSet mustBe expectedRows.toSet
-      rowResponse.macroResults mustBe expectedMacros
+      rowResponse.`macro` mustBe expectedMacros
     }
   }
 

--- a/api/src/test/scala/hmda/api/http/institutions/submissions/SubmissionEditPathsSpec.scala
+++ b/api/src/test/scala/hmda/api/http/institutions/submissions/SubmissionEditPathsSpec.scala
@@ -34,25 +34,10 @@ class SubmissionEditPathsSpec extends InstitutionHttpApiSpec {
 
   "return summary of validation errors" in {
     val expectedSummary = SummaryEditResults(
-      EditResults(
-        List(
-          s020,
-          s010
-        )
-      ),
-      EditResults(
-        List(
-          v285,
-          v280
-        )
-      ),
+      EditResults(List(s020, s010)),
+      EditResults(List(v285, v280)),
       EditResults.empty,
-      MacroResults(List(
-        MacroResult(
-          "Q007",
-          MacroEditJustificationLookup.getJustifications("Q007")
-        )
-      ))
+      MacroResults(List(MacroResult("Q007", MacroEditJustificationLookup.getJustifications("Q007"))))
     )
 
     getWithCfpbHeaders(s"/institutions/0/filings/2017/submissions/1/edits") ~> institutionsRoutes ~> check {
@@ -71,13 +56,7 @@ class SubmissionEditPathsSpec extends InstitutionHttpApiSpec {
   }
 
   "return a list of validation errors for a single type" in {
-    val expectedEdits =
-      EditResults(
-        List(
-          v285,
-          v280
-        )
-      )
+    val expectedEdits = EditResults(List(v285, v280))
 
     getWithCfpbHeaders(s"/institutions/0/filings/2017/submissions/1/edits/validity") ~> institutionsRoutes ~> check {
       status mustBe StatusCodes.OK

--- a/api/src/test/scala/hmda/api/protocol/processing/EditResultsProtocolSpec.scala
+++ b/api/src/test/scala/hmda/api/protocol/processing/EditResultsProtocolSpec.scala
@@ -58,7 +58,7 @@ class EditResultsProtocolSpec extends PropSpec with PropertyChecks with MustMatc
     val rows = RowResults(Seq(rowResult), macros)
     val expectedRowsJson = JsObject(
       ("rows", JsArray(expectedRowJson)),
-      ("macroResults", JsObject(
+      ("macro", JsObject(
         ("edits", JsArray(expectedMacroJson))
       ))
     )

--- a/api/src/test/scala/hmda/api/protocol/processing/EditResultsProtocolSpec.scala
+++ b/api/src/test/scala/hmda/api/protocol/processing/EditResultsProtocolSpec.scala
@@ -1,6 +1,7 @@
 package hmda.api.protocol.processing
 
-import hmda.api.model.{ EditResults, ModelGenerators, SummaryEditResults }
+import hmda.api.model._
+import hmda.validation.engine.MacroEditJustification
 import org.scalatest.{ MustMatchers, PropSpec }
 import org.scalatest.prop.PropertyChecks
 import spray.json._
@@ -17,5 +18,50 @@ class EditResultsProtocolSpec extends PropSpec with PropertyChecks with MustMatc
     forAll(summaryEditResultsGen) { s =>
       s.toJson.convertTo[SummaryEditResults] mustBe s
     }
+  }
+
+  val rowDetail = RowEditDetail("V111", "the values must be correct")
+  val expectedDetailJson = JsObject(
+    ("editId", JsString("V111")),
+    ("description", JsString("the values must be correct"))
+  )
+  property("Row Edit Detail must have proper json format") {
+    rowDetail.toJson mustBe expectedDetailJson
+  }
+
+  val rowResult = RowResult("lar55", Seq(rowDetail))
+  val expectedRowJson = JsObject(
+    ("rowId", JsString("lar55")),
+    ("edits", JsArray(expectedDetailJson))
+  )
+  property("RowResult must have proper json format") {
+    rowResult.toJson mustBe expectedRowJson
+  }
+
+  val macroResult = MacroResult("Q888", Set(MacroEditJustification(1, "justified 1", false)))
+  val expectedMacroJson = JsObject(
+    ("edit", JsString("Q888")),
+    ("justifications", JsArray(
+      JsObject(
+        ("id", JsNumber(1)),
+        ("value", JsString("justified 1")),
+        ("verified", JsBoolean(false))
+      )
+    ))
+  )
+  property("MacroResults must have proper json format") {
+    macroResult.toJson mustBe expectedMacroJson
+  }
+
+  property("RowResults must have proper json format") {
+    val macros = MacroResults(Seq(macroResult))
+    val rows = RowResults(Seq(rowResult), macros)
+    val expectedRowsJson = JsObject(
+      ("rows", JsArray(expectedRowJson)),
+      ("macroResults", JsObject(
+        ("edits", JsArray(expectedMacroJson))
+      ))
+    )
+    rows.toJson mustBe expectedRowsJson
   }
 }

--- a/persistence/src/main/scala/hmda/persistence/demo/DemoData.scala
+++ b/persistence/src/main/scala/hmda/persistence/demo/DemoData.scala
@@ -85,7 +85,6 @@ object DemoData {
       case (instId: String, filings: Seq[Filing]) =>
         val filingActor = system.actorOf(FilingPersistence.props(instId))
         filings.foreach { filing => filingActor ? CreateFiling(filing) }
-        Thread.sleep(100)
         filingActor ! Shutdown
     }
   }

--- a/persistence/src/main/scala/hmda/persistence/demo/DemoData.scala
+++ b/persistence/src/main/scala/hmda/persistence/demo/DemoData.scala
@@ -85,6 +85,7 @@ object DemoData {
       case (instId: String, filings: Seq[Filing]) =>
         val filingActor = system.actorOf(FilingPersistence.props(instId))
         filings.foreach { filing => filingActor ? CreateFiling(filing) }
+        Thread.sleep(100)
         filingActor ! Shutdown
     }
   }


### PR DESCRIPTION
This completes most of #718. 

Done: 
- You can now request the Edits endpoint with the query param `sortBy=row`, and the response will be sorted by row, (almost) as shown in the documentation (see below, about the "fields" node).

Major To Dos: 
- I still need to update the "Single Edit Type" endpoint (aka, the endpoint that shows only a single category of edits--Syntactical, Validity, Quality, or Macro) to allow `sortBy=row`. I'd like to put this in a separate PR, so this one doesn't get too big.
- Each failed edit needs a "fields" node in the Json that shows the edit's relevant fields and their values for that row. This will also come in a separate PR. (This could possibly be combined with the work that adds "field" info to this endpoint when it's sorted by edit)