### PR TITLE
Single Edit Type endpoint - sort by row

### DIFF
--- a/Documents/API.md
+++ b/Documents/API.md
@@ -399,6 +399,8 @@ All endpoints in the `/institutions` namespace require two headers (see "Authori
 
 * `/institutions/<institution>/filings/<period>/submissions/<submissionId>/edits/<syntactical|validity|quality|macro>`
     * `GET`  - List of edits of a specific type, for a given submission
+       * By default, results are grouped by named edit.
+       * Use `sortBy=row` as a query parameter to group by the row in the submitted file.
 
     Example response, with HTTP code 200:
 
@@ -437,6 +439,41 @@ All endpoints in the `/institutions` namespace require two headers (see "Authori
     editType, editId, loanId
     validity, V555, 4977566612
     validity, V550, 4977566612
+    ```
+
+    Sorted by row:
+    ```json
+    {
+      "rows": [
+        {
+          "rowId": "Transmittal Sheet",
+          "edits": [
+            {
+              "editId": "S020",
+              "description": "Agency code must = 1, 2, 3, 5, 7, 9. The agency that submits the data must be the same as the reported agency code.",
+              "fields": {
+                "Agency Code": 4
+              }
+            }
+          ]
+        },
+        {
+          "rowId": "8299422144",
+          "edits": [
+            {
+              "editId": "S020",
+              "description": "Agency code must = 1, 2, 3, 5, 7, 9. The agency that submits the data must be the same as the reported agency code.",
+              "fields": {
+                "Agency Code": 11
+              }
+            }
+          ]
+        },
+      ],
+      "macro": {
+            "edits": []
+        }
+    }
     ```
 
     * `POST` - Provides verification for macro edits

--- a/api/src/test/scala/hmda/api/http/institutions/submissions/SubmissionEditPathsSpec.scala
+++ b/api/src/test/scala/hmda/api/http/institutions/submissions/SubmissionEditPathsSpec.scala
@@ -102,6 +102,50 @@ class SubmissionEditPathsSpec extends InstitutionHttpApiSpec {
     }
   }
 
+  "Sort single type of edits by row with sortBy parameter (syntactical)" in {
+    val expectedRows =
+      Seq(
+        RowResult("Transmittal Sheet", Seq(RowEditDetail("S020", s020Description))),
+        RowResult("loan1", Seq(
+          RowEditDetail("S010", s010Description),
+          RowEditDetail("S020", s020Description)
+        ))
+      )
+
+    getWithCfpbHeaders(s"/institutions/0/filings/2017/submissions/1/edits/syntactical?sortBy=row") ~> institutionsRoutes ~> check {
+      status mustBe StatusCodes.OK
+      val rowResponse = responseAs[RowResults]
+      rowResponse.rows.toSet mustBe expectedRows.toSet
+      rowResponse.`macro` mustBe MacroResults(List())
+    }
+  }
+  "Sort single type of edits by row with sortBy parameter (validity)" in {
+    val expectedRows =
+      Seq(
+        RowResult("loan1", Seq(RowEditDetail("V280", v280Description))),
+        RowResult("loan2", Seq(RowEditDetail("V285", v285Description))),
+        RowResult("loan3", Seq(RowEditDetail("V285", v285Description)))
+      )
+
+    getWithCfpbHeaders(s"/institutions/0/filings/2017/submissions/1/edits/validity?sortBy=row") ~> institutionsRoutes ~> check {
+      status mustBe StatusCodes.OK
+      val rowResponse = responseAs[RowResults]
+      rowResponse.rows.toSet mustBe expectedRows.toSet
+      rowResponse.`macro` mustBe MacroResults(List())
+    }
+  }
+  "SortBy parameter doesn't affect macro edits" in {
+    val expectedMacros =
+      MacroResults(List(MacroResult("Q007", MacroEditJustificationLookup.getJustifications("Q007"))))
+
+    getWithCfpbHeaders(s"/institutions/0/filings/2017/submissions/1/edits/macro?sortBy=row") ~> institutionsRoutes ~> check {
+      status mustBe StatusCodes.OK
+      val rowResponse = responseAs[RowResults]
+      rowResponse.rows.toSet mustBe Set()
+      rowResponse.`macro` mustBe expectedMacros
+    }
+  }
+
   "Edits endpoint: return 404 for nonexistent institution" in {
     getWithCfpbHeaders(s"/institutions/xxxxx/filings/2017/submissions/1/edits") ~> institutionsRoutes ~> check {
       status mustBe StatusCodes.NotFound

--- a/persistence/src/main/scala/hmda/persistence/demo/DemoData.scala
+++ b/persistence/src/main/scala/hmda/persistence/demo/DemoData.scala
@@ -85,6 +85,7 @@ object DemoData {
       case (instId: String, filings: Seq[Filing]) =>
         val filingActor = system.actorOf(FilingPersistence.props(instId))
         filings.foreach { filing => filingActor ? CreateFiling(filing) }
+        Thread.sleep(100)
         filingActor ! Shutdown
     }
   }


### PR DESCRIPTION
Completes more of #718.

Now, the "Single Edit Type" endpoint (aka, the endpoint that shows only a single category of edits--Syntactical, Validity, Quality, or Macro) allows sortBy=row.

I assumed that the format of the response should be the same as the Edits endpoint when using sortBy=row. Let me know if that's not the case.