### PR TITLE
Extract ExecutionContext from institutionsRoutes

### DIFF
--- a/api/src/main/scala/hmda/api/http/InstitutionsHttpApi.scala
+++ b/api/src/main/scala/hmda/api/http/InstitutionsHttpApi.scala
@@ -9,6 +9,8 @@ import hmda.api.http.institutions.submissions._
 import hmda.api.http.institutions.{ FilingPaths, InstitutionPaths, UploadPaths }
 import hmda.api.protocol.processing.{ ApiErrorProtocol, InstitutionProtocol }
 
+import scala.concurrent.ExecutionContext
+
 trait InstitutionsHttpApi
     extends InstitutionProtocol
     with InstitutionPaths
@@ -30,24 +32,27 @@ trait InstitutionsHttpApi
   implicit val timeout: Timeout
 
   val institutionsRoutes =
-    encodeResponse {
-      headerAuthorize {
-        institutionsPath ~
-          pathPrefix("institutions" / Segment) { instId =>
-            institutionAuthorize(instId) {
-              institutionByIdPath(instId) ~
-                filingByPeriodPath(instId) ~
-                submissionPath(instId) ~
-                submissionLatestPath(instId) ~
-                uploadPath(instId) ~
-                submissionEditsPath(instId) ~
-                submissionParseErrorsPath(instId) ~
-                submissionSingleEditPath(instId) ~
-                submissionIrsPath(instId) ~
-                submissionSignPath(instId) ~
-                submissionSummaryPath(instId)
+    extractExecutionContext { executor =>
+      implicit val ec: ExecutionContext = executor
+      encodeResponse {
+        headerAuthorize {
+          institutionsPath ~
+            pathPrefix("institutions" / Segment) { instId =>
+              institutionAuthorize(instId) {
+                institutionByIdPath(instId) ~
+                  filingByPeriodPath(instId) ~
+                  submissionPath(instId) ~
+                  submissionLatestPath(instId) ~
+                  uploadPath(instId) ~
+                  submissionEditsPath(instId) ~
+                  submissionParseErrorsPath(instId) ~
+                  submissionSingleEditPath(instId) ~
+                  submissionIrsPath(instId) ~
+                  submissionSignPath(instId) ~
+                  submissionSummaryPath(instId)
+              }
             }
-          }
+        }
       }
     }
 }

--- a/api/src/main/scala/hmda/api/http/institutions/FilingPaths.scala
+++ b/api/src/main/scala/hmda/api/http/institutions/FilingPaths.scala
@@ -29,36 +29,33 @@ trait FilingPaths extends InstitutionProtocol with ApiErrorProtocol with HmdaCus
   implicit val timeout: Timeout
 
   // institutions/<institutionId>/filings/<period>
-  def filingByPeriodPath(institutionId: String) =
+  def filingByPeriodPath(institutionId: String)(implicit ec: ExecutionContext) =
     path("filings" / Segment) { period =>
-      extractExecutionContext { executor =>
-        timedGet { uri =>
-          implicit val ec: ExecutionContext = executor
-          val supervisor = system.actorSelection("/user/supervisor")
-          val fFilings = (supervisor ? FindFilings(FilingPersistence.name, institutionId)).mapTo[ActorRef]
-          val fSubmissions = (supervisor ? FindSubmissions(SubmissionPersistence.name, institutionId, period)).mapTo[ActorRef]
+      timedGet { uri =>
+        val supervisor = system.actorSelection("/user/supervisor")
+        val fFilings = (supervisor ? FindFilings(FilingPersistence.name, institutionId)).mapTo[ActorRef]
+        val fSubmissions = (supervisor ? FindSubmissions(SubmissionPersistence.name, institutionId, period)).mapTo[ActorRef]
 
-          val fDetails = for {
-            f <- fFilings
-            s <- fSubmissions
-            d <- filingDetailsByPeriod(period, f, s)
-          } yield d
+        val fDetails = for {
+          f <- fFilings
+          s <- fSubmissions
+          d <- filingDetailsByPeriod(period, f, s)
+        } yield d
 
-          onComplete(fDetails) {
-            case Success(filingDetails) =>
-              val filing = filingDetails.filing
-              if (filing.institutionId == institutionId && filing.period == period)
-                complete(ToResponseMarshallable(filingDetails))
-              else if (filing.institutionId == institutionId && filing.period != period) {
-                val errorResponse = ErrorResponse(404, s"$period filing not found for institution $institutionId", uri.path)
-                complete(ToResponseMarshallable(StatusCodes.NotFound -> errorResponse))
-              } else {
-                val errorResponse = ErrorResponse(404, s"Institution $institutionId not found", uri.path)
-                complete(ToResponseMarshallable(StatusCodes.NotFound -> errorResponse))
-              }
-            case Failure(error) =>
-              completeWithInternalError(uri, error)
-          }
+        onComplete(fDetails) {
+          case Success(filingDetails) =>
+            val filing = filingDetails.filing
+            if (filing.institutionId == institutionId && filing.period == period)
+              complete(ToResponseMarshallable(filingDetails))
+            else if (filing.institutionId == institutionId && filing.period != period) {
+              val errorResponse = ErrorResponse(404, s"$period filing not found for institution $institutionId", uri.path)
+              complete(ToResponseMarshallable(StatusCodes.NotFound -> errorResponse))
+            } else {
+              val errorResponse = ErrorResponse(404, s"Institution $institutionId not found", uri.path)
+              complete(ToResponseMarshallable(StatusCodes.NotFound -> errorResponse))
+            }
+          case Failure(error) =>
+            completeWithInternalError(uri, error)
         }
       }
     }

--- a/api/src/main/scala/hmda/api/http/institutions/UploadPaths.scala
+++ b/api/src/main/scala/hmda/api/http/institutions/UploadPaths.scala
@@ -38,32 +38,29 @@ trait UploadPaths extends InstitutionProtocol with ApiErrorProtocol with Submiss
   val splitLines = Framing.delimiter(ByteString("\n"), 2048, allowTruncation = true)
 
   // institutions/<institutionId>/filings/<period>/submissions/<seqNr>
-  def uploadPath(institutionId: String) =
+  def uploadPath(institutionId: String)(implicit ec: ExecutionContext) =
     path("filings" / Segment / "submissions" / IntNumber) { (period, seqNr) =>
       timedPost { uri =>
         val submissionId = SubmissionId(institutionId, period, seqNr)
-        extractExecutionContext { executor =>
-          implicit val ec: ExecutionContext = executor
-          val uploadTimestamp = Instant.now.toEpochMilli
-          val supervisor = system.actorSelection("/user/supervisor")
-          val fProcessingActor = (supervisor ? FindProcessingActor(SubmissionManager.name, submissionId)).mapTo[ActorRef]
-          val fSubmissionsActor = (supervisor ? FindSubmissions(SubmissionPersistence.name, institutionId, period)).mapTo[ActorRef]
+        val uploadTimestamp = Instant.now.toEpochMilli
+        val supervisor = system.actorSelection("/user/supervisor")
+        val fProcessingActor = (supervisor ? FindProcessingActor(SubmissionManager.name, submissionId)).mapTo[ActorRef]
+        val fSubmissionsActor = (supervisor ? FindSubmissions(SubmissionPersistence.name, institutionId, period)).mapTo[ActorRef]
 
-          val fUploadSubmission = for {
-            p <- fProcessingActor
-            s <- fSubmissionsActor
-            fSubmission <- (s ? GetSubmissionById(submissionId)).mapTo[Submission]
-          } yield (fSubmission, fSubmission.status == Created, p)
+        val fUploadSubmission = for {
+          p <- fProcessingActor
+          s <- fSubmissionsActor
+          fSubmission <- (s ? GetSubmissionById(submissionId)).mapTo[Submission]
+        } yield (fSubmission, fSubmission.status == Created, p)
 
-          onComplete(fUploadSubmission) {
-            case Success((submission, true, processingActor)) =>
-              uploadFile(processingActor, uploadTimestamp, uri.path, submission)
-            case Success((submission, false, _)) =>
-              val errorResponse = Failed(s"Submission $seqNr not available for upload")
-              complete(ToResponseMarshallable(StatusCodes.BadRequest -> Submission(submissionId, errorResponse, 0L, 0L)))
-            case Failure(error) =>
-              completeWithInternalError(uri, error)
-          }
+        onComplete(fUploadSubmission) {
+          case Success((submission, true, processingActor)) =>
+            uploadFile(processingActor, uploadTimestamp, uri.path, submission)
+          case Success((submission, false, _)) =>
+            val errorResponse = Failed(s"Submission $seqNr not available for upload")
+            complete(ToResponseMarshallable(StatusCodes.BadRequest -> Submission(submissionId, errorResponse, 0L, 0L)))
+          case Failure(error) =>
+            completeWithInternalError(uri, error)
         }
       }
     }

--- a/api/src/main/scala/hmda/api/http/institutions/submissions/SubmissionBasePaths.scala
+++ b/api/src/main/scala/hmda/api/http/institutions/submissions/SubmissionBasePaths.scala
@@ -39,71 +39,65 @@ trait SubmissionBasePaths
   implicit val timeout: Timeout
 
   // institutions/<institutionId>/filings/<period>/submissions
-  def submissionPath(institutionId: String) =
+  def submissionPath(institutionId: String)(implicit ec: ExecutionContext) =
     path("filings" / Segment / "submissions") { period =>
-      extractExecutionContext { executor =>
-        timedPost { uri =>
-          implicit val ec: ExecutionContext = executor
-          val supervisor = system.actorSelection("/user/supervisor")
-          val fFilingsActor = (supervisor ? FindFilings(FilingPersistence.name, institutionId)).mapTo[ActorRef]
-          val fSubmissionsActor = (supervisor ? FindSubmissions(SubmissionPersistence.name, institutionId, period)).mapTo[ActorRef]
+      timedPost { uri =>
+        val supervisor = system.actorSelection("/user/supervisor")
+        val fFilingsActor = (supervisor ? FindFilings(FilingPersistence.name, institutionId)).mapTo[ActorRef]
+        val fSubmissionsActor = (supervisor ? FindSubmissions(SubmissionPersistence.name, institutionId, period)).mapTo[ActorRef]
 
-          val fFiling = for {
-            f <- fFilingsActor
-            s <- fSubmissionsActor
-            d <- (f ? GetFilingByPeriod(period)).mapTo[Filing]
-          } yield (s, d)
+        val fFiling = for {
+          f <- fFilingsActor
+          s <- fSubmissionsActor
+          d <- (f ? GetFilingByPeriod(period)).mapTo[Filing]
+        } yield (s, d)
 
-          onComplete(fFiling) {
-            case Success((submissionsActor, filing)) =>
-              if (filing.period == period) {
-                submissionsActor ! CreateSubmission
-                val fLatest = (submissionsActor ? GetLatestSubmission).mapTo[Submission]
-                onComplete(fLatest) {
-                  case Success(submission) =>
-                    complete(ToResponseMarshallable(StatusCodes.Created -> submission))
-                  case Failure(error) =>
-                    completeWithInternalError(uri, error)
-                }
-              } else if (!filing.institutionId.isEmpty) {
-                val errorResponse = ErrorResponse(404, s"$period filing not found for institution $institutionId", uri.path)
-                complete(ToResponseMarshallable(StatusCodes.NotFound -> errorResponse))
-              } else {
-                val errorResponse = ErrorResponse(404, s"Institution $institutionId not found", uri.path)
-                complete(ToResponseMarshallable(StatusCodes.NotFound -> errorResponse))
+        onComplete(fFiling) {
+          case Success((submissionsActor, filing)) =>
+            if (filing.period == period) {
+              submissionsActor ! CreateSubmission
+              val fLatest = (submissionsActor ? GetLatestSubmission).mapTo[Submission]
+              onComplete(fLatest) {
+                case Success(submission) =>
+                  complete(ToResponseMarshallable(StatusCodes.Created -> submission))
+                case Failure(error) =>
+                  completeWithInternalError(uri, error)
               }
-            case Failure(error) =>
-              completeWithInternalError(uri, error)
-          }
+            } else if (!filing.institutionId.isEmpty) {
+              val errorResponse = ErrorResponse(404, s"$period filing not found for institution $institutionId", uri.path)
+              complete(ToResponseMarshallable(StatusCodes.NotFound -> errorResponse))
+            } else {
+              val errorResponse = ErrorResponse(404, s"Institution $institutionId not found", uri.path)
+              complete(ToResponseMarshallable(StatusCodes.NotFound -> errorResponse))
+            }
+          case Failure(error) =>
+            completeWithInternalError(uri, error)
         }
       }
     }
 
   // institutions/<institutionId>/filings/<period>/submissions/latest
-  def submissionLatestPath(institutionId: String) =
+  def submissionLatestPath(institutionId: String)(implicit ec: ExecutionContext) =
     path("filings" / Segment / "submissions" / "latest") { period =>
-      extractExecutionContext { executor =>
-        timedGet { uri =>
-          implicit val ec: ExecutionContext = executor
-          val supervisor = system.actorSelection("/user/supervisor")
-          val fSubmissionsActor = (supervisor ? FindSubmissions(SubmissionPersistence.name, institutionId, period)).mapTo[ActorRef]
+      timedGet { uri =>
+        val supervisor = system.actorSelection("/user/supervisor")
+        val fSubmissionsActor = (supervisor ? FindSubmissions(SubmissionPersistence.name, institutionId, period)).mapTo[ActorRef]
 
-          val fSubmissions = for {
-            s <- fSubmissionsActor
-            xs <- (s ? GetLatestSubmission).mapTo[Submission]
-          } yield xs
+        val fSubmissions = for {
+          s <- fSubmissionsActor
+          xs <- (s ? GetLatestSubmission).mapTo[Submission]
+        } yield xs
 
-          onComplete(fSubmissions) {
-            case Success(submission) =>
-              if (submission.id.sequenceNumber == 0) {
-                val errorResponse = ErrorResponse(404, s"No submission found for $institutionId for $period", uri.path)
-                complete(ToResponseMarshallable(StatusCodes.NotFound -> errorResponse))
-              } else {
-                complete(ToResponseMarshallable(submission))
-              }
-            case Failure(error) =>
-              completeWithInternalError(uri, error)
-          }
+        onComplete(fSubmissions) {
+          case Success(submission) =>
+            if (submission.id.sequenceNumber == 0) {
+              val errorResponse = ErrorResponse(404, s"No submission found for $institutionId for $period", uri.path)
+              complete(ToResponseMarshallable(StatusCodes.NotFound -> errorResponse))
+            } else {
+              complete(ToResponseMarshallable(submission))
+            }
+          case Failure(error) =>
+            completeWithInternalError(uri, error)
         }
       }
     }

--- a/api/src/main/scala/hmda/api/http/institutions/submissions/SubmissionEditPaths.scala
+++ b/api/src/main/scala/hmda/api/http/institutions/submissions/SubmissionEditPaths.scala
@@ -37,84 +37,76 @@ trait SubmissionEditPaths
   implicit val timeout: Timeout
 
   // institutions/<institutionId>/filings/<period>/submissions/<seqNr>/edits
-  def submissionEditsPath(institutionId: String) =
+  def submissionEditsPath(institutionId: String)(implicit ec: ExecutionContext) =
     path("filings" / Segment / "submissions" / IntNumber / "edits") { (period, seqNr) =>
-      extractExecutionContext { executor =>
-        implicit val ec: ExecutionContext = executor
+      timedGet { uri =>
+        completeVerified(institutionId, period, seqNr, uri) {
+          val fEditChecks = getValidationState(institutionId, period, seqNr)
 
-        timedGet { uri =>
-          completeVerified(institutionId, period, seqNr, uri) {
-            val fEditChecks = getValidationState(institutionId, period, seqNr)
+          parameters("format".?, "sortBy".?) { (format: Option[String], sortBy: Option[String]) =>
+            sortBy match {
+              case Some("row") =>
+                val fRowSummary: Future[RowResults] = fEditChecks.map { e =>
+                  val tsErrors = e.tsSyntactical ++ e.tsValidity ++ e.tsQuality
+                  val larErrors = e.larSyntactical ++ e.larValidity ++ e.larQuality
+                  val macroErrors = e.larMacro
+                  validationErrorsToRowResults(tsErrors, larErrors, macroErrors)
+                }
+                onComplete(fRowSummary) {
+                  case Success(rows) => complete(ToResponseMarshallable(rows))
+                  case Failure(error) => completeWithInternalError(uri, error)
+                }
 
-            parameters("format".?, "sortBy".?) { (format: Option[String], sortBy: Option[String]) =>
-              sortBy match {
-                case Some("row") =>
-                  val fRowSummary: Future[RowResults] = fEditChecks.map { e =>
-                    val tsErrors = e.tsSyntactical ++ e.tsValidity ++ e.tsQuality
-                    val larErrors = e.larSyntactical ++ e.larValidity ++ e.larQuality
-                    val macroErrors = e.larMacro
-                    validationErrorsToRowResults(tsErrors, larErrors, macroErrors)
-                  }
-                  onComplete(fRowSummary) {
-                    case Success(rows) => complete(ToResponseMarshallable(rows))
-                    case Failure(error) => completeWithInternalError(uri, error)
-                  }
+              case _ =>
+                val fEditSummary: Future[SummaryEditResults] = fEditChecks.map { e =>
+                  val s = validationErrorsToEditResults(e.tsSyntactical, e.larSyntactical, Syntactical)
+                  val v = validationErrorsToEditResults(e.tsValidity, e.larValidity, Validity)
+                  val q = validationErrorsToEditResults(e.tsQuality, e.larQuality, Quality)
+                  val m = validationErrorsToMacroResults(e.larMacro)
+                  SummaryEditResults(s, v, q, m)
+                }
 
-                case _ =>
-                  val fEditSummary: Future[SummaryEditResults] = fEditChecks.map { e =>
-                    val s = validationErrorsToEditResults(e.tsSyntactical, e.larSyntactical, Syntactical)
-                    val v = validationErrorsToEditResults(e.tsValidity, e.larValidity, Validity)
-                    val q = validationErrorsToEditResults(e.tsQuality, e.larQuality, Quality)
-                    val m = validationErrorsToMacroResults(e.larMacro)
-                    SummaryEditResults(s, v, q, m)
-                  }
-
-                  onComplete(fEditSummary) {
-                    case Success(edits) =>
-                      if (format.getOrElse("") == "csv") complete(edits.toCsv)
-                      else complete(ToResponseMarshallable(edits))
-                    case Failure(error) => completeWithInternalError(uri, error)
-                  }
-              }
+                onComplete(fEditSummary) {
+                  case Success(edits) =>
+                    if (format.getOrElse("") == "csv") complete(edits.toCsv)
+                    else complete(ToResponseMarshallable(edits))
+                  case Failure(error) => completeWithInternalError(uri, error)
+                }
             }
-
           }
+
         }
       }
     }
 
   // institutions/<institutionId>/filings/<period>/submissions/<seqNr>/edits/<editType>
-  def submissionSingleEditPath(institutionId: String) =
+  def submissionSingleEditPath(institutionId: String)(implicit ec: ExecutionContext) =
     path("filings" / Segment / "submissions" / IntNumber / "edits" / Segment) { (period, seqNr, editType) =>
-      extractExecutionContext { executor =>
-        implicit val ec: ExecutionContext = executor
-        timedGet { uri =>
-          parameters("format".?) { format =>
-            implicit val ec: ExecutionContext = executor
+      timedGet { uri =>
+        parameters("format".?) { format =>
 
+          completeVerified(institutionId, period, seqNr, uri) {
+            val fValidationState = getValidationState(institutionId, period, seqNr)
+            completeValidationState(editType, fValidationState, uri, format.getOrElse(""))
+          }
+        }
+      } ~ timedPost { uri =>
+        if (editType == "macro") {
+          entity(as[MacroEditJustificationWithName]) { justifyEdit =>
             completeVerified(institutionId, period, seqNr, uri) {
-              val fValidationState = getValidationState(institutionId, period, seqNr)
-              completeValidationState(editType, fValidationState, uri, format.getOrElse(""))
+              val supervisor = system.actorSelection("/user/supervisor")
+              val submissionId = SubmissionId(institutionId, period, seqNr)
+              val fHmdaFileValidator = (supervisor ? FindProcessingActor(HmdaFileValidator.name, submissionId)).mapTo[ActorRef]
+              val fValidationState = for {
+                a <- fHmdaFileValidator
+                j <- (a ? JustifyMacroEdit(justifyEdit.edit, justifyEdit.justification)).mapTo[MacroEditJustified]
+                state <- getValidationState(institutionId, period, seqNr)
+              } yield state
+              completeValidationState(editType, fValidationState, uri, "")
             }
           }
-        } ~ timedPost { uri =>
-          if (editType == "macro") {
-            entity(as[MacroEditJustificationWithName]) { justifyEdit =>
-              completeVerified(institutionId, period, seqNr, uri) {
-                val supervisor = system.actorSelection("/user/supervisor")
-                val submissionId = SubmissionId(institutionId, period, seqNr)
-                val fHmdaFileValidator = (supervisor ? FindProcessingActor(HmdaFileValidator.name, submissionId)).mapTo[ActorRef]
-                val fValidationState = for {
-                  a <- fHmdaFileValidator
-                  j <- (a ? JustifyMacroEdit(justifyEdit.edit, justifyEdit.justification)).mapTo[MacroEditJustified]
-                  state <- getValidationState(institutionId, period, seqNr)
-                } yield state
-                completeValidationState(editType, fValidationState, uri, "")
-              }
-            }
-          } else {
-            completeWithMethodNotAllowed(uri)
-          }
+        } else {
+          completeWithMethodNotAllowed(uri)
         }
       }
     }

--- a/api/src/main/scala/hmda/api/http/institutions/submissions/SubmissionIrsPaths.scala
+++ b/api/src/main/scala/hmda/api/http/institutions/submissions/SubmissionIrsPaths.scala
@@ -29,20 +29,17 @@ trait SubmissionIrsPaths
 
   // institutions/<institutionId>/filings/<period>/submissions/<submissionId>/irs
   // NOTE:  This is currently a mocked, static endpoint
-  def submissionIrsPath(institutionId: String) =
+  def submissionIrsPath(institutionId: String)(implicit ec: ExecutionContext) =
     path("filings" / Segment / "submissions" / IntNumber / "irs") { (period, submissionId) =>
-      extractExecutionContext { executor =>
-        timedGet { uri =>
-          implicit val ec: ExecutionContext = executor
-          val supervisor = system.actorSelection("/user/supervisor")
+      timedGet { uri =>
+        val supervisor = system.actorSelection("/user/supervisor")
 
-          //To avoid having to deal with relative paths on different systems
-          val irsJson = "{\n  \"msas\": [\n    {\n      \"id\": \"123\",\n      \"name\": \"MSA 123\",\n      \"totalLARS\": 4,\n      \"totalAmount\": 123,\n      \"conv\": 4,\n      \"FHA\": 0,\n      \"VA\": 0,\n      \"FSA\": 0,\n      \"1to4Family\": 4,\n      \"MFD\": 0,\n      \"multiFamily\": 0,\n      \"homePurchase\": 0,\n      \"homeImprovement\": 0,\n      \"refinance\": 4\n    },\n    {\n      \"id\": \"456\",\n      \"name\": \"MSA 456\",\n      \"totalLARS\": 5,\n      \"totalAmount\": 456,\n      \"conv\": 5,\n      \"FHA\": 0,\n      \"VA\": 0,\n      \"FSA\": 0,\n      \"1to4Family\": 5,\n      \"MFD\": 0,\n      \"multiFamily\": 0,\n      \"homePurchase\": 0,\n      \"homeImprovement\": 0,\n      \"refinance\": 5\n    }\n  ],\n   \"status\": {\n       \"code\": 10,\n       \"message\": \"IRS report generated\"\n     }}"
+        //To avoid having to deal with relative paths on different systems
+        val irsJson = "{\n  \"msas\": [\n    {\n      \"id\": \"123\",\n      \"name\": \"MSA 123\",\n      \"totalLARS\": 4,\n      \"totalAmount\": 123,\n      \"conv\": 4,\n      \"FHA\": 0,\n      \"VA\": 0,\n      \"FSA\": 0,\n      \"1to4Family\": 4,\n      \"MFD\": 0,\n      \"multiFamily\": 0,\n      \"homePurchase\": 0,\n      \"homeImprovement\": 0,\n      \"refinance\": 4\n    },\n    {\n      \"id\": \"456\",\n      \"name\": \"MSA 456\",\n      \"totalLARS\": 5,\n      \"totalAmount\": 456,\n      \"conv\": 5,\n      \"FHA\": 0,\n      \"VA\": 0,\n      \"FSA\": 0,\n      \"1to4Family\": 5,\n      \"MFD\": 0,\n      \"multiFamily\": 0,\n      \"homePurchase\": 0,\n      \"homeImprovement\": 0,\n      \"refinance\": 5\n    }\n  ],\n   \"status\": {\n       \"code\": 10,\n       \"message\": \"IRS report generated\"\n     }}"
 
-          val response = HttpResponse(StatusCodes.OK, entity = HttpEntity(ContentTypes.`application/json`, irsJson))
+        val response = HttpResponse(StatusCodes.OK, entity = HttpEntity(ContentTypes.`application/json`, irsJson))
 
-          complete(response)
-        }
+        complete(response)
       }
     }
 }

--- a/api/src/main/scala/hmda/api/http/institutions/submissions/SubmissionSummaryPaths.scala
+++ b/api/src/main/scala/hmda/api/http/institutions/submissions/SubmissionSummaryPaths.scala
@@ -31,19 +31,16 @@ trait SubmissionSummaryPaths
 
   // institutions/<institutionId>/filings/<period>/submissions/<submissionId>/summary
   // NOTE:  This is currently a mocked, static endpoint
-  def submissionSummaryPath(institutionId: String) =
+  def submissionSummaryPath(institutionId: String)(implicit ec: ExecutionContext) =
     path("filings" / Segment / "submissions" / IntNumber / "summary") { (period, submissionId) =>
-      extractExecutionContext { executor =>
-        timedGet { uri =>
-          implicit val ec: ExecutionContext = executor
-          val supervisor = system.actorSelection("/user/supervisor")
+      timedGet { uri =>
+        val supervisor = system.actorSelection("/user/supervisor")
 
-          //To avoid having to deal with relative paths on different systems
-          val summaryJson = "{\n  \"respondent\": {\n    \"name\": \"Bank\",\n    \"id\": \"1234567890\",\n    \"taxId\": \"0987654321\",\n    \"agency\": \"CFPB\",\n    \"contact\": {\n      \"name\": \"Your Name\",\n      \"phone\": \"123-456-7890\",\n      \"email\": \"your.name@bank.com\"\n    }\n  },\n  \"file\": {\n    \"name\": \"lar.dat\",\n    \"year\": \"2016\",\n    \"totalLARS\": 25\n  }\n}"
-          val response = HttpResponse(StatusCodes.OK, entity = HttpEntity(ContentTypes.`application/json`, summaryJson))
+        //To avoid having to deal with relative paths on different systems
+        val summaryJson = "{\n  \"respondent\": {\n    \"name\": \"Bank\",\n    \"id\": \"1234567890\",\n    \"taxId\": \"0987654321\",\n    \"agency\": \"CFPB\",\n    \"contact\": {\n      \"name\": \"Your Name\",\n      \"phone\": \"123-456-7890\",\n      \"email\": \"your.name@bank.com\"\n    }\n  },\n  \"file\": {\n    \"name\": \"lar.dat\",\n    \"year\": \"2016\",\n    \"totalLARS\": 25\n  }\n}"
+        val response = HttpResponse(StatusCodes.OK, entity = HttpEntity(ContentTypes.`application/json`, summaryJson))
 
-          complete(response)
-        }
+        complete(response)
       }
     }
 }


### PR DESCRIPTION
This PR extracts the following code, which was repeated in each individual path, and puts it into `InstitutionsHttpApi` instead:
```scala
extractExecutionContext { executor =>
      implicit val ec: ExecutionContext = executor
```



To acommodate that, it also adds `(implicit ec: ExecutionContext)` to each path declaration.

This is just a quick change to reduce duplication and nesting level in individual paths.