### PR TITLE
Set app root to a valid redirect uri in compose setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       INSTITUTION_SEARCH_URI: https://192.168.99.100:9443
       HOME_PAGE_URI: http://192.168.99.100
       INSTITUTION_SEARCH_VALIDATE_SSL: "OFF"
-      REDIRECT_URIS: '[ "http://192.168.99.100/oidc-callback", "http://192.168.99.100/silent_renew.html" ]'
+      REDIRECT_URIS: '[ "http://192.168.99.100", "http://192.168.99.100/oidc-callback", "http://192.168.99.100/silent_renew.html" ]'
       SUPPORT_EMAIL: 'support@localhost.localdomain'
     volumes:
       - '../hmda-platform-auth/keycloak/themes/hmda:/opt/jboss/keycloak/themes/hmda'


### PR DESCRIPTION
https://github.com/cfpb/hmda-platform-ui/pull/324 depends on this PR, this should be merged first

Updates REDIRECT_URIS envvar in the compose setup to allow redirects by keycloak to the homepage.