### PR TITLE
Increase timeout for probe.expectMsg tests

### DIFF
--- a/persistence/src/test/resources/application.conf
+++ b/persistence/src/test/resources/application.conf
@@ -9,3 +9,5 @@ akka {
 akka.persistence.journal.plugin = "inmemory-journal"
 akka.persistence.snapshot-store.plugin = "inmemory-snapshot-store"
 
+akka.test.single-expect-default = 10s
+

--- a/query/src/test/resources/application.conf
+++ b/query/src/test/resources/application.conf
@@ -8,6 +8,8 @@ akka {
   persistence.snapshot-store.plugin = "inmemory-snapshot-store"
 }
 
+akka.test.single-expect-default = 10s
+
 db {
   driver = "slick.driver.H2Driver$"
 


### PR DESCRIPTION
Increases default timeout for `probe.expectMsg` tests. Might help with random failures that happen sometimes in CI server under load