### PR TITLE
WIP: Add formatted names to external ID

### DIFF
--- a/api/src/main/scala/hmda/api/protocol/admin/WriteInstitutionProtocol.scala
+++ b/api/src/main/scala/hmda/api/protocol/admin/WriteInstitutionProtocol.scala
@@ -51,7 +51,7 @@ trait WriteInstitutionProtocol extends InstitutionProtocol {
     override def write(obj: ExternalIdType): JsValue =
       JsObject(
         "entryName" -> JsString(obj.entryName),
-        "formattedName" -> JsString(obj.name)
+        "formattedName" -> JsString(obj.formattedName)
       )
 
     override def read(json: JsValue): ExternalIdType = json match {

--- a/api/src/main/scala/hmda/api/protocol/admin/WriteInstitutionProtocol.scala
+++ b/api/src/main/scala/hmda/api/protocol/admin/WriteInstitutionProtocol.scala
@@ -50,17 +50,17 @@ trait WriteInstitutionProtocol extends InstitutionProtocol {
 
     override def write(obj: ExternalIdType): JsValue =
       JsObject(
-        "entryName" -> JsString(obj.entryName),
-        "formattedName" -> JsString(obj.formattedName)
+        "code" -> JsString(obj.entryName),
+        "name" -> JsString(obj.formattedName)
       )
 
-    override def read(json: JsValue): ExternalIdType = json.asJsObject.getFields("entryName", "formattedName") match {
-      case Seq(entryName, formattedName) =>
+    override def read(json: JsValue): ExternalIdType = json.asJsObject.getFields("code", "name") match {
+      case Seq(code, name) =>
         try {
-          ExternalIdType.withName(entryName.convertTo[String])
+          ExternalIdType.withName(code.convertTo[String])
         } catch {
           case _: NoSuchElementException => throw DeserializationException(
-            s"Unable to translate JSON string into valid ExternalIdType value: $entryName"
+            s"Unable to translate JSON string into valid ExternalIdType value: $code"
           )
         }
       case _ => throw DeserializationException("Unable to deserialize")

--- a/api/src/main/scala/hmda/api/protocol/admin/WriteInstitutionProtocol.scala
+++ b/api/src/main/scala/hmda/api/protocol/admin/WriteInstitutionProtocol.scala
@@ -54,13 +54,13 @@ trait WriteInstitutionProtocol extends InstitutionProtocol {
         "formattedName" -> JsString(obj.formattedName)
       )
 
-    override def read(json: JsValue): ExternalIdType = json match {
-      case JsString(name) =>
+    override def read(json: JsValue): ExternalIdType = json.asJsObject.getFields("entryName", "formattedName") match {
+      case Seq(entryName, formattedName) =>
         try {
-          ExternalIdType.withName(name)
+          ExternalIdType.withName(entryName.convertTo[String])
         } catch {
           case _: NoSuchElementException => throw DeserializationException(
-            s"Unable to translate JSON string into valid ExternalIdType value: $name"
+            s"Unable to translate JSON string into valid ExternalIdType value: $entryName"
           )
         }
       case _ => throw DeserializationException("Unable to deserialize")

--- a/api/src/main/scala/hmda/api/protocol/admin/WriteInstitutionProtocol.scala
+++ b/api/src/main/scala/hmda/api/protocol/admin/WriteInstitutionProtocol.scala
@@ -48,7 +48,11 @@ trait WriteInstitutionProtocol extends InstitutionProtocol {
 
   implicit object ExternalIdTypeJsonFormat extends RootJsonFormat[ExternalIdType] {
 
-    override def write(obj: ExternalIdType): JsValue = JsString(obj.entryName)
+    override def write(obj: ExternalIdType): JsValue =
+      JsObject(
+        "entryName" -> JsString(obj.entryName),
+        "formattedName" -> JsString(obj.name)
+      )
 
     override def read(json: JsValue): ExternalIdType = json match {
       case JsString(name) =>

--- a/api/src/test/scala/hmda/api/protocol/admin/WriteInstitutionProtocolSpec.scala
+++ b/api/src/test/scala/hmda/api/protocol/admin/WriteInstitutionProtocolSpec.scala
@@ -27,7 +27,10 @@ class WriteInstitutionProtocolSpec extends PropSpec with PropertyChecks with Mus
           ("externalIds", JsArray(i.externalIds.map { x =>
             JsObject(
               ("value", JsString(x.value)),
-              ("name", JsString(x.name.entryName))
+              ("name", JsObject(
+                ("entryName", JsString(x.name.entryName)),
+                ("formattedName", JsString(x.name.formattedName))
+              ))
             )
           }.toVector)),
           ("emailDomains", JsArray(i.emailDomains.map { e =>
@@ -36,7 +39,10 @@ class WriteInstitutionProtocolSpec extends PropSpec with PropertyChecks with Mus
           ("respondent", JsObject(
             ("externalId", JsObject(
               ("value", JsString(i.respondent.externalId.value)),
-              ("name", JsString(i.respondent.externalId.name.entryName))
+              ("name", JsObject(
+                ("entryName", JsString(i.respondent.externalId.name.entryName)),
+                ("formattedName", JsString(i.respondent.externalId.name.formattedName))
+              ))
             )),
             ("name", JsString(i.respondent.name)),
             ("state", JsString(i.respondent.state)),

--- a/api/src/test/scala/hmda/api/protocol/admin/WriteInstitutionProtocolSpec.scala
+++ b/api/src/test/scala/hmda/api/protocol/admin/WriteInstitutionProtocolSpec.scala
@@ -27,9 +27,9 @@ class WriteInstitutionProtocolSpec extends PropSpec with PropertyChecks with Mus
           ("externalIds", JsArray(i.externalIds.map { x =>
             JsObject(
               ("value", JsString(x.value)),
-              ("name", JsObject(
-                ("entryName", JsString(x.name.entryName)),
-                ("formattedName", JsString(x.name.formattedName))
+              ("externalIdType", JsObject(
+                ("code", JsString(x.externalIdType.entryName)),
+                ("name", JsString(x.externalIdType.formattedName))
               ))
             )
           }.toVector)),
@@ -39,9 +39,9 @@ class WriteInstitutionProtocolSpec extends PropSpec with PropertyChecks with Mus
           ("respondent", JsObject(
             ("externalId", JsObject(
               ("value", JsString(i.respondent.externalId.value)),
-              ("name", JsObject(
-                ("entryName", JsString(i.respondent.externalId.name.entryName)),
-                ("formattedName", JsString(i.respondent.externalId.name.formattedName))
+              ("externalIdType", JsObject(
+                ("code", JsString(i.respondent.externalId.externalIdType.entryName)),
+                ("name", JsString(i.respondent.externalId.externalIdType.formattedName))
               ))
             )),
             ("name", JsString(i.respondent.name)),

--- a/model/shared/src/main/scala/hmda/model/institution/ExternalId.scala
+++ b/model/shared/src/main/scala/hmda/model/institution/ExternalId.scala
@@ -5,7 +5,7 @@ import enumeratum.{ Enum, EnumEntry }
 /**
  * Additional unique identifiers for a financial institution.
  */
-case class ExternalId(value: String, name: ExternalIdType)
+case class ExternalId(value: String, externalIdType: ExternalIdType)
 
 sealed abstract class ExternalIdType(override val entryName: String, val formattedName: String) extends EnumEntry with Serializable
 

--- a/model/shared/src/main/scala/hmda/model/institution/ExternalId.scala
+++ b/model/shared/src/main/scala/hmda/model/institution/ExternalId.scala
@@ -7,16 +7,16 @@ import enumeratum.{ Enum, EnumEntry }
  */
 case class ExternalId(value: String, name: ExternalIdType)
 
-sealed abstract class ExternalIdType(override val entryName: String) extends EnumEntry with Serializable
+sealed abstract class ExternalIdType(override val entryName: String, val formattedName: String) extends EnumEntry with Serializable
 
 object ExternalIdType extends Enum[ExternalIdType] {
 
   val values = findValues
 
-  case object FdicCertNo extends ExternalIdType("fdic-certificate-number")
-  case object FederalTaxId extends ExternalIdType("federal-tax-id")
-  case object NcuaCharterId extends ExternalIdType("ncua-charter-id")
-  case object OccCharterId extends ExternalIdType("occ-charter-id")
-  case object RssdId extends ExternalIdType("rssd-id")
-  case object UndeterminedExternalId extends ExternalIdType("undetermined-external-id")
+  case object FdicCertNo extends ExternalIdType("fdic-certificate-number", "FDIC Certificate Number")
+  case object FederalTaxId extends ExternalIdType("federal-tax-id", "Federal Tax ID")
+  case object NcuaCharterId extends ExternalIdType("ncua-charter-id", "NCUA Charter Number")
+  case object OccCharterId extends ExternalIdType("occ-charter-id", "OCC Charter Number")
+  case object RssdId extends ExternalIdType("rssd-id", "RSSD ID")
+  case object UndeterminedExternalId extends ExternalIdType("undetermined-external-id", "Unknown ID")
 }


### PR DESCRIPTION
For testing, the only response that includes external ID is the institution search path on the public API.

Closes #806 