### PR TITLE
Test Improvements

### DIFF
--- a/api/src/test/scala/hmda/api/http/InstitutionHttpSpec.scala
+++ b/api/src/test/scala/hmda/api/http/InstitutionHttpSpec.scala
@@ -20,6 +20,7 @@ import org.scalatest._
 import scala.concurrent.duration._
 
 trait InstitutionHttpSpec extends MustMatchers with BeforeAndAfterAll with RequestHeaderUtils with InstitutionsHttpApi with ScalatestRouteTest { suite: Suite =>
+  val supervisor = system.actorSelection("/user/supervisor")
 
   val duration = 10.seconds
   override val log: LoggingAdapter = NoLogging

--- a/api/src/test/scala/hmda/api/http/InstitutionsAuthSpec.scala
+++ b/api/src/test/scala/hmda/api/http/InstitutionsAuthSpec.scala
@@ -81,7 +81,6 @@ class InstitutionsAuthSpec extends InstitutionHttpApiSpec {
       val parent = Parent("123", 123, "test parent", "", "")
       val topHolder = TopHolder(-1, "", "", "", "")
       val caseInsensitiveBank = Institution("1", CFPB, 2017, MBS, cra = true, Set(), Set(), respondent = respondent, hmdaFilerFlag = true, parent = parent, assets = 0, otherLenderCode = 0, topHolder = topHolder)
-      val supervisor = system.actorSelection("/user/supervisor")
       val querySupervisor = system.actorSelection("/user/query-supervisor")
       val fInstitutionsActor = (supervisor ? FindActorByName(InstitutionPersistence.name)).mapTo[ActorRef]
 

--- a/api/src/test/scala/hmda/api/http/institutions/UploadPathsSpec.scala
+++ b/api/src/test/scala/hmda/api/http/institutions/UploadPathsSpec.scala
@@ -52,8 +52,6 @@ class UploadPathsSpec extends InstitutionHttpApiAsyncSpec with SubmissionProtoco
     }
 
     "return 400 when trying to upload to a completed submission" in {
-      val supervisor = system.actorSelection("/user/supervisor")
-
       val fSubmission = for {
         a <- (supervisor ? FindSubmissions(SubmissionPersistence.name, "0", "2017")).mapTo[ActorRef]
         s <- (a ? UpdateSubmissionStatus(SubmissionId("0", "2017", 1), Signed)).mapTo[Option[Submission]]

--- a/api/src/test/scala/hmda/api/http/institutions/submissions/SubmissionBasePathsSpec.scala
+++ b/api/src/test/scala/hmda/api/http/institutions/submissions/SubmissionBasePathsSpec.scala
@@ -11,8 +11,6 @@ import hmda.persistence.demo.DemoData
 
 class SubmissionBasePathsSpec extends InstitutionHttpApiSpec {
 
-  val supervisor = system.actorSelection("/user/supervisor")
-
   "Submission Paths" must {
     "return not found when looking for a latest submission for non existent institution" in {
       val path = Path("/institutions/xxxxx/filings/2017/submissions/latest")

--- a/api/src/test/scala/hmda/api/http/institutions/submissions/SubmissionEditPathsSpec.scala
+++ b/api/src/test/scala/hmda/api/http/institutions/submissions/SubmissionEditPathsSpec.scala
@@ -22,8 +22,6 @@ import scala.concurrent.duration._
 
 class SubmissionEditPathsSpec extends InstitutionHttpApiSpec with LarGenerators with TsGenerators {
 
-  val supervisor = system.actorSelection("/user/supervisor")
-
   override def beforeAll(): Unit = {
     super.beforeAll()
     loadValidationErrors()

--- a/api/src/test/scala/hmda/api/http/institutions/submissions/SubmissionParseErrorsPathsSpec.scala
+++ b/api/src/test/scala/hmda/api/http/institutions/submissions/SubmissionParseErrorsPathsSpec.scala
@@ -18,8 +18,6 @@ import scala.concurrent.duration._
 
 class SubmissionParseErrorsPathsSpec extends InstitutionHttpApiSpec {
 
-  val supervisor = system.actorSelection("/user/supervisor")
-
   "Submission Parse Errors Path" must {
     "return no errors for an unparsed submission" in {
       getWithCfpbHeaders("/institutions/0/filings/2017/submissions/1/parseErrors") ~> institutionsRoutes ~> check {

--- a/api/src/test/scala/hmda/api/http/institutions/submissions/SubmissionSignPathsSpec.scala
+++ b/api/src/test/scala/hmda/api/http/institutions/submissions/SubmissionSignPathsSpec.scala
@@ -3,7 +3,7 @@ package hmda.api.http.institutions.submissions
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.Uri.Path
-import hmda.api.http.{ InstitutionHttpApiAsyncSpec, InstitutionHttpApiSpec }
+import hmda.api.http.InstitutionHttpApiAsyncSpec
 import hmda.api.model.{ ErrorResponse, Receipt }
 import hmda.model.fi._
 import spray.json.{ JsBoolean, JsObject }
@@ -29,14 +29,17 @@ class SubmissionSignPathsSpec extends InstitutionHttpApiAsyncSpec {
       }
     }
 
-    /*
-    "set up: get a submission to 'validated with errors' state" in {
+    "Set up: get submission to ValidatedWithErrors state" in {
+      postWithCfpbHeaders("/institutions/0/filings/2017/submissions/1", file) ~> institutionsRoutes ~> check {
+        Thread.sleep(5000) // wait for the submission to complete validation
+        status mustBe StatusCodes.Accepted
+      }
     }
-    */
+
     "GET: return an empty receipt when submission hasn't been signed" in {
       getWithCfpbHeaders("/institutions/0/filings/2017/submissions/1/sign") ~> institutionsRoutes ~> check {
         status mustBe StatusCodes.OK
-        responseAs[Receipt] mustBe Receipt(0L, "", Created)
+        responseAs[Receipt] mustBe Receipt(0L, "", ValidatedWithErrors)
       }
     }
     "POST: Return 400 (Bad Request) when payload contains signed = false" in {
@@ -47,27 +50,29 @@ class SubmissionSignPathsSpec extends InstitutionHttpApiAsyncSpec {
         err.path mustBe Path("/institutions/0/filings/2017/submissions/1/sign")
       }
     }
-    /*
-    "POST: return filled receipt when payload contains signed = true" in {
-      val signed = JsObject("signed" -> JsBoolean(true))
 
-      postWithCfpbHeaders("/institutions/0/filings/2017/submissions/3/sign", signed) ~> institutionsRoutes ~> check {
+    var receivedTimestamp: Long = 0L
+    def expectedReceipt(time: Long): String = s"0-2017-1-$time"
+    "POST: return filled receipt when successfully signing" in {
+      postWithCfpbHeaders("/institutions/0/filings/2017/submissions/1/sign", signJson(true)) ~> institutionsRoutes ~> check {
+        val returnedReceipt = responseAs[Receipt]
+        receivedTimestamp = returnedReceipt.timestamp
+
         status mustBe StatusCodes.OK
-        responseAs[Receipt].timestamp mustBe 5
-        responseAs[Receipt].receipt mustBe "something real"
-        responseAs[Receipt].status mustBe Signed
+        returnedReceipt.receipt mustBe expectedReceipt(receivedTimestamp)
+        returnedReceipt.status mustBe Signed
       }
     }
-
-    "GET: return filled receipt when submissionStatus is signed" in {
-      getWithCfpbHeaders("/institutions/0/filings/2017/submissions/3/sign") ~> institutionsRoutes ~> check {
+    "GET: return same filled receipt after signature" in {
+      getWithCfpbHeaders("/institutions/0/filings/2017/submissions/1/sign") ~> institutionsRoutes ~> check {
         status mustBe StatusCodes.OK
         val receipt = responseAs[Receipt]
+        receipt.timestamp mustBe receivedTimestamp
+        receipt.receipt mustBe expectedReceipt(receivedTimestamp)
         receipt.status mustBe Signed
-        receipt.timestamp mustBe 55
-        receipt.receipt mustBe "same thing"
       }
+
     }
-    */
+
   }
 }

--- a/api/src/test/scala/hmda/api/http/institutions/submissions/SubmissionSignPathsSpec.scala
+++ b/api/src/test/scala/hmda/api/http/institutions/submissions/SubmissionSignPathsSpec.scala
@@ -9,7 +9,6 @@ import hmda.model.fi._
 import spray.json.{ JsBoolean, JsObject }
 
 class SubmissionSignPathsSpec extends InstitutionHttpApiAsyncSpec {
-  val supervisor = system.actorSelection("/user/supervisor")
 
   val csv = "1|0123456789|9|201301171330|2013|99-9999999|900|MIKES SMALL BANK   XXXXXXXXXXX|1234 Main St       XXXXXXXXXXXXXXXXXXXXX|Sacramento         XXXXXX|CA|99999-9999|MIKES SMALL INC    XXXXXXXXXXX|1234 Kearney St    XXXXXXXXXXXXXXXXXXXXX|San Francisco      XXXXXX|CA|99999-1234|Mrs. Krabappel     XXXXXXXXXXX|916-999-9999|999-753-9999|krabappel@gmail.comXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\n" +
     "2|0123456789|99|ABCDEFGHIJKLMNOPQRSTUVWXY|20130117|4|3|2|1|10000|1|5|20130119|06920|06|034|0100.01|4|5|7|4|3|2|1|8|7|6|5|4|1|2|9000|0|9|8|7|01.05|2|4\n" +


### PR DESCRIPTION
I'm still working on reworking the DemoData to be more reliable. In working on that, I've found some quick wins I can PR:

- The Submission Signature path didn't get fully tested before it merged last week. This PR completes the tests for that feature.
- Define `supervisor` in  `InstitutionHttpSpec`, so test suites that inherit from it don't need to all declare it individually.