### PR TITLE
Add in build arg to skip hmda-platform-ui's js build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,10 @@ services:
       JDBC_URL: jdbc:postgresql://192.168.99.100:54321/hmda?user=postgres&password=postgres
 
   ui:
-    build: ../hmda-platform-ui
+    build:
+      context: ../hmda-platform-ui
+      args:
+        SKIP_JS_BUILD: 1
     ports:
       - "80:80"
     depends_on:


### PR DESCRIPTION
This causes the default build to be much snappier, and an `npm install` was still necessary on the front-end due to the mounted volume.

Concomitant with https://github.com/cfpb/hmda-platform-ui/pull/455