### PR TITLE
Pagination for IRS Endpoint

### DIFF
--- a/Documents/API.md
+++ b/Documents/API.md
@@ -529,6 +529,18 @@ Macro, Q023,
 
 `GET` - Returns the Institution Register Summary
 
+| Query parameter | Description |
+| --------------- | ----------- |
+| page | Integer. If blank, will default to page 1. Page size is 20 MSAs. |
+
+
+This endpoint is paginated. The response contains 3 fields of pagination metadata:
+
+ - `total`: total number of parser errors for this file
+ - `count`: number of errors returned on this page. Full page contains errors from 20 lines of the HMDA file.
+ - `links`: the `href` field is the path to this resource, with a `{rel}` to be replaced with the query strings in the `first`, `prev`, `self`, `next`, `last` fields.
+
+
 Example response:
 
 ```json
@@ -578,6 +590,16 @@ Example response:
     "conv": 9,
     "homePurchase": 0,
     "VA": 0
+  },
+  "count": 20,
+  "total": 130,
+  "_links": {
+    "first": "?page=1",
+    "prev": "?page=1",
+    "self": "?page=1",
+    "next": "?page=2",
+    "last": "?page=7",
+    "href": "/institutions/1/filings/2017/submissions/1/irs{rel}"
   }
 }
 ```

--- a/api/src/main/scala/hmda/api/model/IrsResponse.scala
+++ b/api/src/main/scala/hmda/api/model/IrsResponse.scala
@@ -1,0 +1,35 @@
+package hmda.api.model
+
+import hmda.persistence.PaginatedResource
+import hmda.query.model.filing.{ Msa, MsaSummary }
+
+case class Irs(msas: Seq[Msa]) {
+
+  def page(page: Int, path: String): IrsResponse = {
+    val total = msas.size
+    val p = PaginatedResource(total)(page)
+    val pageOfMsas = msas.slice(p.fromIndex, p.toIndex)
+    val summary = MsaSummary.fromMsaCollection(msas)
+    IrsResponse(pageOfMsas.toList, summary, path, page, total)
+  }
+
+}
+
+case class IrsResponse(
+  msas: List[Msa],
+  summary: MsaSummary,
+  path: String,
+  currentPage: Int,
+  total: Int
+) extends PaginatedResponse
+
+/* When converted to JSON, IrsResponse has this format:
+
+IrsResponse(
+  msas: List[Msa],
+  summary: MsaSummary,
+  count: Int,
+  total: Int,
+  _links: PaginatedLinks)
+
+This happens in MsaProtocol.scala */ 

--- a/api/src/main/scala/hmda/api/protocol/processing/MsaProtocol.scala
+++ b/api/src/main/scala/hmda/api/protocol/processing/MsaProtocol.scala
@@ -22,11 +22,11 @@ trait MsaProtocol extends DefaultJsonProtocol with ParserResultsProtocol {
     override def read(json: JsValue): IrsResponse = {
       json.asJsObject.getFields("msas", "summary", "total", "_links") match {
         case Seq(JsArray(msas), JsObject(summ), JsNumber(tot), JsObject(links)) =>
-          val msaCollection: Seq[MsaWithName] = msas.map(_.convertTo[MsaWithName])
-          val path: String = PaginatedResponse.staticPath(links("href").convertTo[String])
-          val currentPage: Int = PaginatedResponse.currentPage(links("self").convertTo[String])
-          val summary: MsaSummary = JsObject(summ).convertTo[MsaSummary]
-          val total: Int = tot.intValue
+          val msaCollection = msas.map(_.convertTo[MsaWithName])
+          val path = PaginatedResponse.staticPath(links("href").convertTo[String])
+          val currentPage = PaginatedResponse.currentPage(links("self").convertTo[String])
+          val summary = JsObject(summ).convertTo[MsaSummary]
+          val total = tot.intValue
           IrsResponse(msaCollection.toList, summary, path, currentPage, total)
 
         case _ => throw DeserializationException("IRS Summary expected")

--- a/api/src/main/scala/hmda/api/protocol/processing/MsaProtocol.scala
+++ b/api/src/main/scala/hmda/api/protocol/processing/MsaProtocol.scala
@@ -1,6 +1,6 @@
 package hmda.api.protocol.processing
 
-import hmda.api.model.{ IrsResponse, PaginatedResponse, PaginationLinks }
+import hmda.api.model.{ IrsResponse, PaginatedResponse }
 import hmda.query.model.filing.{ Msa, MsaSummary }
 import spray.json._
 

--- a/api/src/main/scala/hmda/api/protocol/processing/MsaProtocol.scala
+++ b/api/src/main/scala/hmda/api/protocol/processing/MsaProtocol.scala
@@ -1,10 +1,37 @@
 package hmda.api.protocol.processing
 
-import hmda.query.model.filing.{ Irs, Msa, MsaSummary }
-import spray.json.DefaultJsonProtocol
+import hmda.api.model.{ IrsResponse, PaginatedResponse, PaginationLinks }
+import hmda.query.model.filing.{ Msa, MsaSummary }
+import spray.json._
 
 trait MsaProtocol extends DefaultJsonProtocol {
   implicit val msaProtocol = jsonFormat13(Msa.apply)
   implicit val msaSummaryProtocol = jsonFormat12(MsaSummary.apply)
-  implicit val irsProtocol = jsonFormat2(Irs.apply)
+  implicit val paginationLinkFormat = jsonFormat6(PaginationLinks.apply)
+
+  implicit object IrsResponseJsonFormat extends RootJsonFormat[IrsResponse] {
+    override def write(irs: IrsResponse): JsValue = {
+      JsObject(
+        "msas" -> irs.msas.toJson,
+        "summary" -> irs.summary.toJson,
+        "count" -> JsNumber(irs.count),
+        "total" -> JsNumber(irs.total),
+        "_links" -> irs.links.toJson
+      )
+    }
+
+    override def read(json: JsValue): IrsResponse = {
+      json.asJsObject.getFields("msas", "summary", "total", "_links") match {
+        case Seq(JsArray(msas), JsObject(summ), JsNumber(tot), JsObject(links)) =>
+          val msaCollection: Seq[Msa] = msas.map(_.convertTo[Msa])
+          val path: String = PaginatedResponse.staticPath(links("href").convertTo[String])
+          val currentPage: Int = PaginatedResponse.currentPage(links("self").convertTo[String])
+          val summary: MsaSummary = JsObject(summ).convertTo[MsaSummary]
+          val total: Int = tot.intValue
+          IrsResponse(msaCollection.toList, summary, path, currentPage, total)
+
+        case _ => throw DeserializationException("IRS Summary expected")
+      }
+    }
+  }
 }

--- a/api/src/main/scala/hmda/api/protocol/processing/MsaProtocol.scala
+++ b/api/src/main/scala/hmda/api/protocol/processing/MsaProtocol.scala
@@ -4,10 +4,10 @@ import hmda.api.model.{ IrsResponse, PaginatedResponse, PaginationLinks }
 import hmda.query.model.filing.{ Msa, MsaSummary }
 import spray.json._
 
-trait MsaProtocol extends DefaultJsonProtocol {
+trait MsaProtocol extends DefaultJsonProtocol with ParserResultsProtocol {
   implicit val msaProtocol = jsonFormat13(Msa.apply)
   implicit val msaSummaryProtocol = jsonFormat12(MsaSummary.apply)
-  implicit val paginationLinkFormat = jsonFormat6(PaginationLinks.apply)
+  //implicit val paginationLinkFormat = jsonFormat6(PaginationLinks.apply)
 
   implicit object IrsResponseJsonFormat extends RootJsonFormat[IrsResponse] {
     override def write(irs: IrsResponse): JsValue = {

--- a/api/src/main/scala/hmda/api/protocol/processing/MsaProtocol.scala
+++ b/api/src/main/scala/hmda/api/protocol/processing/MsaProtocol.scala
@@ -7,7 +7,6 @@ import spray.json._
 trait MsaProtocol extends DefaultJsonProtocol with ParserResultsProtocol {
   implicit val msaProtocol = jsonFormat13(Msa.apply)
   implicit val msaSummaryProtocol = jsonFormat12(MsaSummary.apply)
-  //implicit val paginationLinkFormat = jsonFormat6(PaginationLinks.apply)
 
   implicit object IrsResponseJsonFormat extends RootJsonFormat[IrsResponse] {
     override def write(irs: IrsResponse): JsValue = {

--- a/api/src/test/scala/hmda/api/http/institutions/submissions/SubmissionIrsPathsSpec.scala
+++ b/api/src/test/scala/hmda/api/http/institutions/submissions/SubmissionIrsPathsSpec.scala
@@ -5,7 +5,6 @@ import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import hmda.api.http.{ InstitutionHttpApiAsyncSpec, InstitutionHttpApiSpec }
 import hmda.model.fi.lar.LarGenerators
 import hmda.query.DbConfiguration._
-import hmda.query.model.filing.Irs
 import hmda.query.repository.filing.{ FilingComponent, LarConverter }
 
 import scala.concurrent.Await

--- a/api/src/test/scala/hmda/api/protocol/processing/MsaProtocolSpec.scala
+++ b/api/src/test/scala/hmda/api/protocol/processing/MsaProtocolSpec.scala
@@ -1,0 +1,74 @@
+package hmda.api.protocol.processing
+
+import hmda.api.model.{ IrsResponse, ModelGenerators }
+import hmda.query.model.filing.{ Msa, MsaSummary }
+import org.scalatest.{ MustMatchers, PropSpec }
+import org.scalatest.prop.PropertyChecks
+import spray.json.{ JsArray, JsNumber, JsObject, JsString }
+
+class MsaProtocolSpec extends PropSpec with PropertyChecks with MustMatchers with ModelGenerators with MsaProtocol {
+
+  val msa1 = Msa("second", 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1)
+  val expectedMsa1 = JsObject(
+    ("id", JsString("second")),
+    ("totalLars", JsNumber(12)),
+    ("totalAmount", JsNumber(11)),
+    ("conv", JsNumber(10)),
+    ("FHA", JsNumber(9)),
+    ("VA", JsNumber(8)),
+    ("FSA", JsNumber(7)),
+    ("oneToFourFamily", JsNumber(6)),
+    ("MFD", JsNumber(5)),
+    ("multiFamily", JsNumber(4)),
+    ("homePurchase", JsNumber(3)),
+    ("homeImprovement", JsNumber(2)),
+    ("refinance", JsNumber(1))
+  )
+  /*
+  property("Msa must have correct JSON format") {
+    msa1.toJson mustBe expectedMsa1
+  }
+  */
+
+  val summ = MsaSummary(55, 54, 53, 52, 51, 59, 58, 57, 56, 55, 54, 53)
+  val expectedSummary = JsObject(
+    ("lars", JsNumber(55)),
+    ("amount", JsNumber(54)),
+    ("conv", JsNumber(53)),
+    ("FHA", JsNumber(52)),
+    ("VA", JsNumber(51)),
+    ("FSA", JsNumber(59)),
+    ("oneToFourFamily", JsNumber(58)),
+    ("MFD", JsNumber(57)),
+    ("multiFamily", JsNumber(56)),
+    ("homePurchase", JsNumber(55)),
+    ("homeImprovement", JsNumber(54)),
+    ("refinance", JsNumber(53))
+  )
+
+  /*
+  property("MsaSummary must have correct json format") {
+    summ.toJson mustBe expectedSummary
+  }
+  */
+
+  val irs = IrsResponse(List(msa1), summ, "uri/path/", 4, 315)
+
+  property("IrsResponse must have correct JSON format") {
+    IrsResponseJsonFormat.write(irs) mustBe JsObject(
+      ("msas", JsArray(expectedMsa1)),
+      ("summary", expectedSummary),
+      ("count", JsNumber(20)),
+      ("total", JsNumber(315)),
+      ("_links", JsObject(
+        ("href", JsString("uri/path/{rel}")),
+        ("self", JsString("?page=4")),
+        ("first", JsString("?page=1")),
+        ("prev", JsString("?page=3")),
+        ("next", JsString("?page=5")),
+        ("last", JsString("?page=16"))
+      ))
+    )
+  }
+
+}

--- a/api/src/test/scala/hmda/api/protocol/processing/MsaProtocolSpec.scala
+++ b/api/src/test/scala/hmda/api/protocol/processing/MsaProtocolSpec.scala
@@ -1,12 +1,12 @@
 package hmda.api.protocol.processing
 
-import hmda.api.model.{ IrsResponse, ModelGenerators }
+import hmda.api.model.IrsResponse
 import hmda.query.model.filing.{ Msa, MsaSummary }
 import org.scalatest.{ MustMatchers, PropSpec }
 import org.scalatest.prop.PropertyChecks
-import spray.json.{ JsArray, JsNumber, JsObject, JsString }
+import spray.json._
 
-class MsaProtocolSpec extends PropSpec with PropertyChecks with MustMatchers with ModelGenerators with MsaProtocol {
+class MsaProtocolSpec extends PropSpec with PropertyChecks with MustMatchers with MsaProtocol {
 
   val msa1 = Msa("second", 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1)
   val expectedMsa1 = JsObject(
@@ -24,11 +24,9 @@ class MsaProtocolSpec extends PropSpec with PropertyChecks with MustMatchers wit
     ("homeImprovement", JsNumber(2)),
     ("refinance", JsNumber(1))
   )
-  /*
   property("Msa must have correct JSON format") {
     msa1.toJson mustBe expectedMsa1
   }
-  */
 
   val summ = MsaSummary(55, 54, 53, 52, 51, 59, 58, 57, 56, 55, 54, 53)
   val expectedSummary = JsObject(
@@ -46,11 +44,9 @@ class MsaProtocolSpec extends PropSpec with PropertyChecks with MustMatchers wit
     ("refinance", JsNumber(53))
   )
 
-  /*
   property("MsaSummary must have correct json format") {
     summ.toJson mustBe expectedSummary
   }
-  */
 
   val irs = IrsResponse(List(msa1), summ, "uri/path/", 4, 315)
 

--- a/census/src/main/scala/hmda/census/model/CbsaLookup.scala
+++ b/census/src/main/scala/hmda/census/model/CbsaLookup.scala
@@ -34,10 +34,12 @@ object CbsaLookup extends CbsaResourceUtils {
     }
   }.toSeq
 
+  private val cbsaIdToNameMap: Map[String, String] = {
+    values.map(x => (x.cbsa, x.cbsaTitle)).toMap
+  }
+
   def nameFor(cbsaId: String): String = {
-    values.find(_.cbsa == cbsaId)
-      .getOrElse(Cbsa(cbsaTitle = "NA"))
-      .cbsaTitle
+    cbsaIdToNameMap.getOrElse(cbsaId, "NA")
   }
 }
 

--- a/query/src/main/scala/hmda/query/model/filing/Msa.scala
+++ b/query/src/main/scala/hmda/query/model/filing/Msa.scala
@@ -50,13 +50,8 @@ case class MsaSummary(
 
 case object MsaSummary {
   def empty: MsaSummary = MsaSummary(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-}
 
-case class Irs(msas: List[Msa], totals: MsaSummary)
-
-case object Irs {
-  def createIrs(msas: List[Msa]): Irs = {
-    val summary = msas.foldLeft(MsaSummary.empty) { (summary, msa) => summary + msa }
-    Irs(msas, summary)
+  def fromMsaCollection(msas: Seq[Msa]): MsaSummary = {
+    msas.foldLeft(MsaSummary.empty) { (summary, msa) => summary + msa }
   }
 }


### PR DESCRIPTION
Closes #864 

Known issue: This PR doesn't update the `SubmissionIrsPathsSpec`. It is still commented out to avoid the `slick.util.AsyncExecutor` issue from previous sprints.