### PR TITLE
Reimplement Q022 using ValidationContext

### DIFF
--- a/validation/src/main/scala/hmda/validation/engine/lar/quality/LarQualityEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/lar/quality/LarQualityEngine.scala
@@ -9,10 +9,6 @@ import hmda.validation.rules.lar.quality._
 
 trait LarQualityEngine extends LarCommonEngine with ValidationApi {
 
-  private def q022(lar: LoanApplicationRegister): LarValidation = {
-    convertResult(lar, Q022(lar, 2017), "Q022", lar.loan.id, Quality, false)
-  }
-
   def checkQuality(lar: LoanApplicationRegister, ctx: ValidationContext): LarValidation = {
     val checks = List(
       Q001,
@@ -22,6 +18,7 @@ trait LarQualityEngine extends LarCommonEngine with ValidationApi {
       Q005,
       Q013,
       Q014,
+      Q022.inContext(ctx),
       Q024,
       Q025,
       Q027,
@@ -48,8 +45,6 @@ trait LarQualityEngine extends LarCommonEngine with ValidationApi {
       Q068
     ).map(check(_, lar, lar.loan.id, Quality, false))
 
-    val allChecks = checks :+ q022(lar)
-
-    validateAll(allChecks, lar)
+    validateAll(checks, lar)
   }
 }

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q022.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q022.scala
@@ -1,30 +1,30 @@
 package hmda.validation.rules.lar.quality
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.validation.context.ValidationContext
 import hmda.validation.dsl.Result
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
+import hmda.validation.rules.{ EditCheck, IfYearPresentIn }
 
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.Try
 
 object Q022 {
+  def inContext(context: ValidationContext): EditCheck[LoanApplicationRegister] = {
+    IfYearPresentIn(context) { new Q022(_) }
+  }
+}
 
-  def apply(lar: LoanApplicationRegister, year: Int): Result = {
+class Q022 private (year: Int) extends EditCheck[LoanApplicationRegister] {
+
+  def apply(lar: LoanApplicationRegister): Result = {
     // This edit should not fail if applicationDate is equal to "NA" or is otherwise non-convertible
     val applicationYear = parseYear(lar).getOrElse(year)
 
     // The two year time frame is to allow for construction loans, where properties are typically built within two years.
     // SEE: https://github.com/cfpb/hmda-platform/issues/469
     (year - applicationYear) is between(0, 2)
-  }
-
-  def apply(lar: LoanApplicationRegister, fYear: Future[Int])(implicit ec: ExecutionContext): Future[Result] = {
-    val applicationYear = parseYear(lar)
-
-    fYear.map { year =>
-      (year - applicationYear.getOrElse(year)) is between(0, 2)
-    }
   }
 
   private def parseYear(lar: LoanApplicationRegister): Try[Int] = {

--- a/validation/src/test/scala/hmda/validation/rules/lar/quality/Q022Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/quality/Q022Spec.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules.lar.quality
 
 import hmda.model.fi.lar.LarGenerators
+import hmda.validation.context.ValidationContext
 import hmda.validation.dsl.Success
 import hmda.validation.dsl.Failure
 import hmda.validation.rules.lar.BadValueUtils
@@ -8,18 +9,17 @@ import org.scalacheck.Gen
 import org.scalatest.{ MustMatchers, PropSpec }
 import org.scalatest.prop.PropertyChecks
 
-import scala.concurrent.{ ExecutionContext, Future }
-
 class Q022Spec extends PropSpec with PropertyChecks with MustMatchers with LarGenerators with BadValueUtils {
-  implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
 
   property("Passes if activity year is within two years after application date") {
     forAll(larGen, Gen.choose(0, 2), dateGen) { (lar, x, date) =>
       val newLoan = lar.loan.copy(applicationDate = date.toString)
       val newLar = lar.copy(loan = newLoan)
       val applicationYear = newLar.loan.applicationDate.substring(0, 4).toInt
-      Q022(newLar, applicationYear + x) mustBe Success()
-      Q022(newLar, Future(applicationYear + x)).map(x => x mustBe Success())
+
+      val ctx = ValidationContext(None, Some(applicationYear + x))
+
+      Q022.inContext(ctx)(newLar) mustBe Success()
     }
   }
 
@@ -28,8 +28,10 @@ class Q022Spec extends PropSpec with PropertyChecks with MustMatchers with LarGe
       val newLoan = lar.loan.copy(applicationDate = date.toString)
       val newLar = lar.copy(loan = newLoan)
       val applicationYear = newLar.loan.applicationDate.substring(0, 4).toInt
-      Q022(newLar, applicationYear + x) mustBe a[Failure]
-      Q022(newLar, Future(applicationYear + x)).map(x => x mustBe a[Failure])
+
+      val ctx = ValidationContext(None, Some(applicationYear + x))
+
+      Q022.inContext(ctx)(newLar) mustBe Failure()
     }
   }
 
@@ -38,8 +40,15 @@ class Q022Spec extends PropSpec with PropertyChecks with MustMatchers with LarGe
       val newLoan = lar.loan.copy(applicationDate = "NA")
       val newLar = lar.copy(loan = newLoan)
 
-      Q022(newLar, 2099) mustBe a[Success]
-      Q022(newLar, Future(2099)).map(x => x mustBe Success())
+      val ctx = ValidationContext(None, Some(2099))
+      Q022.inContext(ctx)(newLar) mustBe a[Success]
+    }
+  }
+
+  property("Passes if activity year is not provided in ValidationContext") {
+    forAll(larGen) { lar =>
+      val ctx = ValidationContext(None, None)
+      Q022.inContext(ctx)(lar) mustBe a[Success]
     }
   }
 }


### PR DESCRIPTION
Previously, Q022 was implemented using a workaround to provide the Activity Year. Now we use ValidationContext, so I updated it to use our current accepted method.