### PR TITLE
Create Filings when running Panel

### DIFF
--- a/panel/src/main/scala/hmda/panel/PanelCsvParser.scala
+++ b/panel/src/main/scala/hmda/panel/PanelCsvParser.scala
@@ -69,7 +69,7 @@ object PanelCsvParser extends InstitutionComponent {
 
     fromGraph
       .runForeach(i => {
-        val f = Filing(i.activityYear.toString, i.id, NotStarted, filingRequired = false, 0, 0)
+        val f = Filing(i.activityYear.toString, i.id)
         for {
           s <- (supervisor ? FindFilings(FilingPersistence.name, i.id)).mapTo[ActorRef]
         } yield s ! CreateFiling(f)

--- a/panel/src/main/scala/hmda/panel/PanelCsvParser.scala
+++ b/panel/src/main/scala/hmda/panel/PanelCsvParser.scala
@@ -6,8 +6,8 @@ import akka.NotUsed
 import akka.actor.{ ActorRef, ActorSystem }
 import akka.util.{ ByteString, Timeout }
 import akka.pattern.ask
-import akka.stream.{ ActorMaterializer, FlowShape }
-import akka.stream.scaladsl.{ Broadcast, BroadcastHub, FileIO, Flow, Framing, GraphDSL, Keep, Sink, Source }
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{ BroadcastHub, FileIO, Flow, Framing, Keep, Sink, Source }
 import hmda.model.fi.{ Filing, NotStarted }
 import hmda.model.institution.Institution
 import hmda.persistence.messages.CommonMessages._
@@ -74,21 +74,6 @@ object PanelCsvParser extends InstitutionComponent {
           s <- (supervisor ? FindFilings(FilingPersistence.name, i.id)).mapTo[ActorRef]
         } yield s ! CreateFiling(f)
       })
-
-    /*source
-      .via(Framing.delimiter(ByteString("\n"), maximumFrameLength = 1024, allowTruncation = true))
-      .drop(1)
-      .via(byte2StringFlow)
-      .via(parseInstitutions)
-      .map(inst => {
-          for {
-              s <- (supervisor ? FindFilings(FilingPersistence.name, inst.id)).mapTo[ActorRef]
-          } yield s ! CreateFiling(Filing(inst.activityYear.toString, inst.id, NotStarted, filingRequired = false, 0, 0))
-          inst
-        })
-      .map(i => CreateInstitution(i))
-      .runWith(Sink.actorRef(institutionPersistence, Shutdown))*/
-
   }
 
   private def parseInstitutions: Flow[String, Institution, NotUsed] =

--- a/query/src/main/scala/hmda/query/model/filing/Msa.scala
+++ b/query/src/main/scala/hmda/query/model/filing/Msa.scala
@@ -19,20 +19,20 @@ case class Msa(
 )
 
 case class MsaWithName(
-    id: String,
-    name: String,
-    totalLars: Int,
-    totalAmount: Int,
-    conv: Int,
-    FHA: Int,
-    VA: Int,
-    FSA: Int,
-    oneToFourFamily: Int,
-    MFD: Int,
-    multiFamily: Int,
-    homePurchase: Int,
-    homeImprovement: Int,
-    refinance: Int
+  id: String,
+  name: String,
+  totalLars: Int,
+  totalAmount: Int,
+  conv: Int,
+  FHA: Int,
+  VA: Int,
+  FSA: Int,
+  oneToFourFamily: Int,
+  MFD: Int,
+  multiFamily: Int,
+  homePurchase: Int,
+  homeImprovement: Int,
+  refinance: Int
 )
 
 case class MsaSummary(


### PR DESCRIPTION
This is one possible approach, using `BroadcastHub` to attach two consumers to the parsing `Source`, while still utilizing the advantages of Akka Streams.  I'm having issues when running panel on master, so this is still a work in progress.

Another approach is commented out, as it blocks the creation of institutions until the filing is created.

Closes #915 