### PR TITLE
Refactor - Cleanup implicits

### DIFF
--- a/api/src/main/scala/hmda/api/HmdaPlatform.scala
+++ b/api/src/main/scala/hmda/api/HmdaPlatform.scala
@@ -60,7 +60,7 @@ object HmdaPlatform {
     institutionRepository.dropSchema()
   }
 
-  private def startActors(system: ActorSystem, supervisor: ActorRef, querySupervisor: ActorRef)(implicit ec: ExecutionContext): Unit = {
+  private def startActors[_: EC](system: ActorSystem, supervisor: ActorRef, querySupervisor: ActorRef): Unit = {
     lazy val actorTimeout = configuration.getInt("hmda.actor.timeout")
     implicit val timeout = Timeout(actorTimeout.seconds)
 

--- a/api/src/main/scala/hmda/api/http/institutions/FilingPaths.scala
+++ b/api/src/main/scala/hmda/api/http/institutions/FilingPaths.scala
@@ -9,6 +9,7 @@ import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.pattern.ask
 import akka.stream.ActorMaterializer
 import akka.util.Timeout
+import hmda.api.EC
 import hmda.api.http.HmdaCustomDirectives
 import hmda.api.model.{ ErrorResponse, FilingDetail }
 import hmda.api.protocol.processing.{ ApiErrorProtocol, InstitutionProtocol }
@@ -29,7 +30,7 @@ trait FilingPaths extends InstitutionProtocol with ApiErrorProtocol with HmdaCus
   implicit val timeout: Timeout
 
   // institutions/<institutionId>/filings/<period>
-  def filingByPeriodPath(institutionId: String)(implicit ec: ExecutionContext) =
+  def filingByPeriodPath[_: EC](institutionId: String) =
     path("filings" / Segment) { period =>
       timedGet { uri =>
         val supervisor = system.actorSelection("/user/supervisor")
@@ -60,7 +61,7 @@ trait FilingPaths extends InstitutionProtocol with ApiErrorProtocol with HmdaCus
       }
     }
 
-  private def filingDetailsByPeriod(period: String, filingsActor: ActorRef, submissionActor: ActorRef)(implicit ec: ExecutionContext): Future[FilingDetail] = {
+  private def filingDetailsByPeriod[_: EC](period: String, filingsActor: ActorRef, submissionActor: ActorRef): Future[FilingDetail] = {
     val fFiling = (filingsActor ? GetFilingByPeriod(period)).mapTo[Filing]
     for {
       filing <- fFiling

--- a/api/src/main/scala/hmda/api/http/institutions/InstitutionPaths.scala
+++ b/api/src/main/scala/hmda/api/http/institutions/InstitutionPaths.scala
@@ -9,6 +9,7 @@ import akka.http.scaladsl.server.Directives._
 import akka.pattern.ask
 import akka.stream.ActorMaterializer
 import akka.util.Timeout
+import hmda.api.EC
 import hmda.api.http.HmdaCustomDirectives
 import hmda.api.model._
 import hmda.api.protocol.processing.{ ApiErrorProtocol, InstitutionProtocol }
@@ -32,7 +33,7 @@ trait InstitutionPaths extends InstitutionProtocol with ApiErrorProtocol with Hm
   val log: LoggingAdapter
 
   // institutions
-  def institutionsPath(implicit ec: ExecutionContext) =
+  def institutionsPath[_: EC] =
     path("institutions") {
       timedGet { uri =>
         extractRequestContext { ctx =>
@@ -54,7 +55,7 @@ trait InstitutionPaths extends InstitutionProtocol with ApiErrorProtocol with Hm
     }
 
   // institutions/<institutionId>
-  def institutionByIdPath(institutionId: String)(implicit ec: ExecutionContext) =
+  def institutionByIdPath[_: EC](institutionId: String) =
     pathEnd {
       timedGet { uri =>
         val supervisor = system.actorSelection("/user/supervisor")
@@ -81,7 +82,7 @@ trait InstitutionPaths extends InstitutionProtocol with ApiErrorProtocol with Hm
       }
     }
 
-  private def institutionDetails(institutionId: String, institutionsActor: ActorRef, filingsActor: ActorRef)(implicit ec: ExecutionContext): Future[InstitutionDetail] = {
+  private def institutionDetails[_: EC](institutionId: String, institutionsActor: ActorRef, filingsActor: ActorRef): Future[InstitutionDetail] = {
     val fInstitution = (institutionsActor ? GetInstitutionById(institutionId)).mapTo[Institution]
     for {
       i <- fInstitution

--- a/api/src/main/scala/hmda/api/http/institutions/UploadPaths.scala
+++ b/api/src/main/scala/hmda/api/http/institutions/UploadPaths.scala
@@ -14,6 +14,7 @@ import akka.pattern.ask
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{ Framing, Sink }
 import akka.util.{ ByteString, Timeout }
+import hmda.api.EC
 import hmda.api.http.HmdaCustomDirectives
 import hmda.persistence.messages.CommonMessages._
 import hmda.api.protocol.processing.{ ApiErrorProtocol, InstitutionProtocol, SubmissionProtocol }
@@ -42,7 +43,7 @@ trait UploadPaths extends InstitutionProtocol with ApiErrorProtocol with Submiss
   val splitLines = Framing.delimiter(ByteString("\n"), 2048, allowTruncation = true)
 
   // institutions/<institutionId>/filings/<period>/submissions/<seqNr>
-  def uploadPath(institutionId: String)(implicit ec: ExecutionContext) =
+  def uploadPath[_: EC](institutionId: String) =
     path("filings" / Segment / "submissions" / IntNumber) { (period, seqNr) =>
       timedPost { uri =>
         val submissionId = SubmissionId(institutionId, period, seqNr)

--- a/api/src/main/scala/hmda/api/http/public/PublicLarHttpApi.scala
+++ b/api/src/main/scala/hmda/api/http/public/PublicLarHttpApi.scala
@@ -6,6 +6,7 @@ import akka.http.scaladsl.model.HttpEntity.ChunkStreamPart
 import akka.http.scaladsl.model.{ ContentTypes, HttpEntity, HttpResponse }
 import akka.http.scaladsl.server.Directives._
 import akka.stream.ActorMaterializer
+import hmda.api.EC
 import hmda.api.http.HmdaCustomDirectives
 import hmda.query.DbConfiguration._
 import hmda.query.repository.filing.FilingComponent
@@ -20,7 +21,7 @@ trait PublicLarHttpApi extends HmdaCustomDirectives with FilingComponent {
 
   val modifiedLarRepository = new ModifiedLarRepository(config)
 
-  def modifiedLar(institutionId: String)(implicit ec: ExecutionContext) =
+  def modifiedLar[_: EC](institutionId: String) =
     path("filings" / Segment / "lar") { period =>
       timedGet { _ =>
         val data = modifiedLarRepository.findByInstitutionIdSource(institutionId, period)

--- a/api/src/main/scala/hmda/api/package.scala
+++ b/api/src/main/scala/hmda/api/package.scala
@@ -1,0 +1,12 @@
+package hmda
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+
+import scala.concurrent.ExecutionContext
+
+package object api {
+  type AS[_] = ActorSystem
+  type MAT[_] = ActorMaterializer
+  type EC[_] = ExecutionContext
+}

--- a/validation/src/main/scala/hmda/validation/dsl/PredicateCommon.scala
+++ b/validation/src/main/scala/hmda/validation/dsl/PredicateCommon.scala
@@ -4,17 +4,19 @@ import scala.language.implicitConversions
 import scala.util.Try
 
 object PredicateCommon {
+
   implicit def equalTo[T](that: T): Predicate[T] = (_: T) == that
 
-  def greaterThan[T](that: T)(implicit ord: Ordering[T]): Predicate[T] = ord.gt(_: T, that)
+  def greaterThan[T: Ordering](that: T): Predicate[T] = implicitly[Ordering[T]].gt(_: T, that)
 
-  def greaterThanOrEqual[T](that: T)(implicit ord: Ordering[T]): Predicate[T] = ord.gteq(_: T, that)
+  def greaterThanOrEqual[T: Ordering](that: T): Predicate[T] = implicitly[Ordering[T]].gteq(_: T, that)
 
-  def lessThan[T](that: T)(implicit ord: Ordering[T]): Predicate[T] = ord.lt(_: T, that)
+  def lessThan[T: Ordering](that: T): Predicate[T] = implicitly[Ordering[T]].lt(_: T, that)
 
-  def lessThanOrEqual[T](that: T)(implicit ord: Ordering[T]): Predicate[T] = ord.lteq(_: T, that)
+  def lessThanOrEqual[T: Ordering](that: T): Predicate[T] = implicitly[Ordering[T]].lteq(_: T, that)
 
-  def between[T](lower: T, upper: T)(implicit ord: Ordering[T]): Predicate[T] = { x: T =>
+  def between[T: Ordering](lower: T, upper: T): Predicate[T] = { x: T =>
+    val ord = implicitly[Ordering[T]]
     ord.lteq(lower, x) && ord.lteq(x, upper)
   }
 

--- a/validation/src/main/scala/hmda/validation/engine/lar/macro/LarMacroEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/lar/macro/LarMacroEngine.scala
@@ -1,7 +1,6 @@
 package hmda.validation.engine.lar.`macro`
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
+import hmda.validation._
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.api.ValidationApi
 import hmda.validation.context.ValidationContext
@@ -11,11 +10,11 @@ import hmda.validation.rules.AggregateEditCheck
 import hmda.validation.rules.lar.`macro`.MacroEditTypes.LoanApplicationRegisterSource
 import hmda.validation.rules.lar.`macro`._
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.Future
 
 trait LarMacroEngine extends LarCommonEngine with ValidationApi {
 
-  def checkMacro(larSource: LoanApplicationRegisterSource, ctx: ValidationContext)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[LarSourceValidation] = {
+  def checkMacro[_: AS: MAT: EC](larSource: LoanApplicationRegisterSource, ctx: ValidationContext): Future[LarSourceValidation] = {
     Future.sequence(
       List(
         Q006,
@@ -52,12 +51,12 @@ trait LarMacroEngine extends LarCommonEngine with ValidationApi {
 
   }
 
-  private def checkAggregate(
+  private def checkAggregate[_: AS: MAT: EC](
     editCheck: AggregateEditCheck[LoanApplicationRegisterSource, LoanApplicationRegister],
     input: LoanApplicationRegisterSource,
     inputId: String,
     errorType: ValidationErrorType
-  )(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[LarSourceValidation] = {
+  ): Future[LarSourceValidation] = {
     val fResult = editCheck(input)
     for {
       result <- fResult

--- a/validation/src/main/scala/hmda/validation/package.scala
+++ b/validation/src/main/scala/hmda/validation/package.scala
@@ -1,14 +1,12 @@
-package hmda.validation
+package hmda
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 
 import scala.concurrent.ExecutionContext
 
-package object rules {
-
+package object validation {
   type AS[_] = ActorSystem
   type MAT[_] = ActorMaterializer
   type EC[_] = ExecutionContext
-
 }

--- a/validation/src/main/scala/hmda/validation/rules/AggregateEditCheck.scala
+++ b/validation/src/main/scala/hmda/validation/rules/AggregateEditCheck.scala
@@ -1,15 +1,13 @@
 package hmda.validation.rules
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import hmda.validation.dsl.Result
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.Future
 
 abstract class AggregateEditCheck[-A, +B] extends SourceUtils {
 
   def name: String
 
-  def apply(input: A)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result]
+  def apply[as: AS, mat: MAT, ec: EC](input: A): Future[Result]
 
 }

--- a/validation/src/main/scala/hmda/validation/rules/AggregateEditCheck.scala
+++ b/validation/src/main/scala/hmda/validation/rules/AggregateEditCheck.scala
@@ -1,6 +1,7 @@
 package hmda.validation.rules
 
 import hmda.validation.dsl.Result
+import hmda.validation._
 
 import scala.concurrent.Future
 

--- a/validation/src/main/scala/hmda/validation/rules/EmptyAggregateEditCheck.scala
+++ b/validation/src/main/scala/hmda/validation/rules/EmptyAggregateEditCheck.scala
@@ -1,7 +1,7 @@
 package hmda.validation.rules
 
 import hmda.validation.dsl.{ Result, Success }
-
+import hmda.validation._
 import scala.concurrent.Future
 
 class EmptyAggregateEditCheck[A, B] extends AggregateEditCheck[A, B] {

--- a/validation/src/main/scala/hmda/validation/rules/EmptyAggregateEditCheck.scala
+++ b/validation/src/main/scala/hmda/validation/rules/EmptyAggregateEditCheck.scala
@@ -1,12 +1,11 @@
 package hmda.validation.rules
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
+
 import hmda.validation.dsl.{ Result, Success }
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.Future
 
 class EmptyAggregateEditCheck[A, B] extends AggregateEditCheck[A, B] {
   override def name: String = "empty"
 
-  override def apply(input: A)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = Future(Success())
+  override def apply[as: AS, mat: MAT, ec: EC](input: A): Future[Result] = Future(Success())
 }

--- a/validation/src/main/scala/hmda/validation/rules/SourceUtils.scala
+++ b/validation/src/main/scala/hmda/validation/rules/SourceUtils.scala
@@ -1,17 +1,17 @@
 package hmda.validation.rules
 
 import akka.NotUsed
-import akka.stream._
 import akka.stream.scaladsl._
 import scala.concurrent.Future
+import hmda.validation._
 
 trait SourceUtils {
 
-  def count[T](input: Source[T, NotUsed])(implicit materializer: ActorMaterializer): Future[Int] = {
+  def count[T: AS: MAT](input: Source[T, NotUsed]): Future[Int] = {
     input.runWith(sinkCount)
   }
 
-  def sum[T](input: Source[T, NotUsed], summation: T => Int)(implicit materializer: ActorMaterializer): Future[Int] = {
+  def sum[T: AS: MAT](input: Source[T, NotUsed], summation: T => Int): Future[Int] = {
     input.runWith(sinkSum(summation))
   }
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q006.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q006.scala
@@ -5,7 +5,7 @@ import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.Result
-import hmda.validation.rules.AggregateEditCheck
+import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._
@@ -20,7 +20,7 @@ object Q006 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q006"
 
-  override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
+  override def apply[as: AS, mat: MAT, ec: EC](lars: LoanApplicationRegisterSource): Future[Result] = {
 
     val originatedHomePurchase =
       count(lars.filter(lar => lar.actionTakenType == 1 && lar.loan.purpose == 1))

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q006.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q006.scala
@@ -1,16 +1,15 @@
 package hmda.validation.rules.lar.`macro`
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
+import hmda.validation._
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.Result
-import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
+import hmda.validation.rules.AggregateEditCheck
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.Future
 
 object Q006 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplicationRegister] {
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q007.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q007.scala
@@ -1,16 +1,14 @@
 package hmda.validation.rules.lar.`macro`
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.Result
-import hmda.validation.rules.AggregateEditCheck
+import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.Future
 
 object Q007 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplicationRegister] {
 
@@ -19,7 +17,7 @@ object Q007 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q007"
 
-  override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
+  override def apply[as: AS, mat: MAT, ec: EC](lars: LoanApplicationRegisterSource): Future[Result] = {
 
     val approvedButNotAccepted =
       count(lars.filter(lar => lar.actionTakenType == 2))

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q007.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q007.scala
@@ -1,9 +1,10 @@
 package hmda.validation.rules.lar.`macro`
 
+import hmda.validation._
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.Result
-import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
+import hmda.validation.rules.AggregateEditCheck
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q008.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q008.scala
@@ -1,11 +1,12 @@
 package hmda.validation.rules.lar.`macro`
 
+import hmda.validation._
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
-import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
+import hmda.validation.rules.AggregateEditCheck
 import hmda.validation.rules.lar.`macro`.MacroEditTypes.LoanApplicationRegisterSource
 
 import scala.concurrent.Future

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q008.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q008.scala
@@ -1,16 +1,14 @@
 package hmda.validation.rules.lar.`macro`
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
-import hmda.validation.rules.AggregateEditCheck
+import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
 import hmda.validation.rules.lar.`macro`.MacroEditTypes.LoanApplicationRegisterSource
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.Future
 
 object Q008 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplicationRegister] {
 
@@ -19,7 +17,7 @@ object Q008 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q008"
 
-  override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, mat: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
+  override def apply[as: AS, mat: MAT, ec: EC](lars: LoanApplicationRegisterSource): Future[Result] = {
 
     val applicationWithdrawn =
       count(lars.filter(lar => lar.actionTakenType == 4))

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q009.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q009.scala
@@ -1,11 +1,12 @@
 package hmda.validation.rules.lar.`macro`
 
+import hmda.validation._
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
-import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
+import hmda.validation.rules.AggregateEditCheck
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._
 
 import scala.concurrent.Future

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q009.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q009.scala
@@ -1,16 +1,14 @@
 package hmda.validation.rules.lar.`macro`
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
-import hmda.validation.rules.AggregateEditCheck
+import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.Future
 
 object Q009 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplicationRegister] {
 
@@ -19,7 +17,7 @@ object Q009 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q009"
 
-  override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
+  override def apply[as: AS, mat: MAT, ec: EC](lars: LoanApplicationRegisterSource): Future[Result] = {
 
     val incomplete = count(lars.filter(lar => lar.actionTakenType == 5))
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q010.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q010.scala
@@ -1,11 +1,12 @@
 package hmda.validation.rules.lar.`macro`
 
+import hmda.validation._
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
-import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
+import hmda.validation.rules.AggregateEditCheck
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._
 
 import scala.concurrent.Future

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q010.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q010.scala
@@ -1,16 +1,14 @@
 package hmda.validation.rules.lar.`macro`
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
-import hmda.validation.rules.AggregateEditCheck
+import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.Future
 
 object Q010 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplicationRegister] {
 
@@ -19,7 +17,7 @@ object Q010 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q010"
 
-  override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
+  override def apply[as: AS, mat: MAT, ec: EC](lars: LoanApplicationRegisterSource): Future[Result] = {
 
     val originated = count(lars.filter(lar => lar.actionTakenType == 1))
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q011.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q011.scala
@@ -2,21 +2,20 @@ package hmda.validation.rules.lar.`macro`
 
 import akka.actor.ActorSystem
 import akka.pattern.ask
-import akka.stream.ActorMaterializer
 import akka.util.Timeout
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.model.institution.Institution
 import hmda.validation.context.ValidationContext
 import hmda.validation.dsl.Result
-import hmda.validation.rules.AggregateEditCheck
+import hmda.validation.rules._
 import hmda.validation.rules.lar.`macro`.MacroEditTypes.LoanApplicationRegisterSource
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.Future
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
-import hmda.validation.rules.IfInstitutionPresentInAggregate
 import hmda.validation.ValidationStats.FindTotalLars
+
 import scala.concurrent.duration._
 
 object Q011 {
@@ -32,7 +31,9 @@ class Q011 private (institution: Institution, year: Int) extends AggregateEditCh
   val larSize = configuration.getInt("hmda.validation.macro.Q011.numOfTotalLars")
   val multiplier = configuration.getDouble("hmda.validation.macro.Q011.numOfLarsMultiplier")
 
-  override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
+  override def apply[as: AS, mat: MAT, ec: EC](lars: LoanApplicationRegisterSource): Future[Result] = {
+
+    val system = implicitly[AS[_]]
 
     val configuration = ConfigFactory.load()
     val duration = configuration.getInt("hmda.actor.timeout")

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q011.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q011.scala
@@ -1,6 +1,6 @@
 package hmda.validation.rules.lar.`macro`
 
-import akka.actor.ActorSystem
+import hmda.validation._
 import akka.pattern.ask
 import akka.util.Timeout
 import com.typesafe.config.ConfigFactory

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q015.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q015.scala
@@ -1,16 +1,14 @@
 package hmda.validation.rules.lar.`macro`
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.Result
-import hmda.validation.rules.AggregateEditCheck
+import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.Future
 
 object Q015 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplicationRegister] {
 
@@ -20,7 +18,7 @@ object Q015 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q015"
 
-  override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
+  override def apply[as: AS, mat: MAT, ec: EC](lars: LoanApplicationRegisterSource): Future[Result] = {
 
     def findAmount(lar: LoanApplicationRegister) = lar.loan.amount
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q015.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q015.scala
@@ -1,9 +1,10 @@
 package hmda.validation.rules.lar.`macro`
 
+import hmda.validation._
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.Result
-import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
+import hmda.validation.rules.AggregateEditCheck
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q016.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q016.scala
@@ -1,16 +1,14 @@
 package hmda.validation.rules.lar.`macro`
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
-import hmda.validation.rules.AggregateEditCheck
+import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.Future
 
 object Q016 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplicationRegister] {
 
@@ -20,7 +18,7 @@ object Q016 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q016"
 
-  override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
+  override def apply[as: AS, mat: MAT, ec: EC](lars: LoanApplicationRegisterSource): Future[Result] = {
 
     val belowIncomeThreshold = count(lars.filter(lar => lar.loan.amount < incomeCap))
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q016.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q016.scala
@@ -1,11 +1,12 @@
 package hmda.validation.rules.lar.`macro`
 
+import hmda.validation._
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
-import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
+import hmda.validation.rules.AggregateEditCheck
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._
 
 import scala.concurrent.Future

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q023.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q023.scala
@@ -1,16 +1,14 @@
 package hmda.validation.rules.lar.`macro`
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
-import hmda.validation.rules.AggregateEditCheck
+import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.Future
 
 object Q023 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplicationRegister] {
 
@@ -19,7 +17,7 @@ object Q023 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q023"
 
-  override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
+  override def apply[as: AS, mat: MAT, ec: EC](lars: LoanApplicationRegisterSource): Future[Result] = {
 
     val noMsa = count(lars.filter(lar => lar.geography.msa == "NA"))
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q023.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q023.scala
@@ -1,11 +1,12 @@
 package hmda.validation.rules.lar.`macro`
 
+import hmda.validation._
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
-import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
+import hmda.validation.rules.AggregateEditCheck
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._
 
 import scala.concurrent.Future

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q031.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q031.scala
@@ -1,16 +1,14 @@
 package hmda.validation.rules.lar.`macro`
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.Result
-import hmda.validation.rules.AggregateEditCheck
+import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.Future
 
 object Q031 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplicationRegister] {
 
@@ -20,7 +18,7 @@ object Q031 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q031"
 
-  override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
+  override def apply[as: AS, mat: MAT, ec: EC](lars: LoanApplicationRegisterSource): Future[Result] = {
 
     val multifamily =
       count(lars.filter(lar => lar.loan.propertyType == 3))

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q031.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q031.scala
@@ -1,9 +1,10 @@
 package hmda.validation.rules.lar.`macro`
 
+import hmda.validation._
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.Result
-import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
+import hmda.validation.rules.AggregateEditCheck
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q047.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q047.scala
@@ -1,9 +1,10 @@
 package hmda.validation.rules.lar.`macro`
 
+import hmda.validation._
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.Result
-import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
+import hmda.validation.rules.AggregateEditCheck
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q047.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q047.scala
@@ -1,16 +1,14 @@
 package hmda.validation.rules.lar.`macro`
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.Result
-import hmda.validation.rules.AggregateEditCheck
+import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.Future
 
 object Q047 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplicationRegister] {
 
@@ -19,7 +17,7 @@ object Q047 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q047"
 
-  override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
+  override def apply[as: AS, mat: MAT, ec: EC](lars: LoanApplicationRegisterSource): Future[Result] = {
 
     val singleFamilyWithdrawn =
       count(lars.filter(lar => lar.actionTakenType == 4 && lar.preapprovals == 1))

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q048.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q048.scala
@@ -1,9 +1,10 @@
 package hmda.validation.rules.lar.`macro`
 
+import hmda.validation._
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.Result
-import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
+import hmda.validation.rules.AggregateEditCheck
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q048.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q048.scala
@@ -1,16 +1,14 @@
 package hmda.validation.rules.lar.`macro`
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.Result
-import hmda.validation.rules.AggregateEditCheck
+import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.Future
 
 object Q048 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplicationRegister] {
 
@@ -19,7 +17,7 @@ object Q048 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q048"
 
-  override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
+  override def apply[as: AS, mat: MAT, ec: EC](lars: LoanApplicationRegisterSource): Future[Result] = {
 
     val incompletePreapprovalRequest =
       count(lars.filter(lar => lar.preapprovals == 1 && lar.actionTakenType == 5))

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q053.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q053.scala
@@ -1,16 +1,14 @@
 package hmda.validation.rules.lar.`macro`
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
-import hmda.validation.rules.AggregateEditCheck
+import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.Future
 
 object Q053 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplicationRegister] {
 
@@ -19,7 +17,7 @@ object Q053 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q053"
 
-  override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
+  override def apply[as: AS, mat: MAT, ec: EC](lars: LoanApplicationRegisterSource): Future[Result] = {
 
     val hoepaLoans =
       count(lars.filter(lar => lar.agencyCode == 5 && lar.actionTakenType == 1 && lar.hoepaStatus == 1))

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q053.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q053.scala
@@ -1,11 +1,12 @@
 package hmda.validation.rules.lar.`macro`
 
+import hmda.validation._
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
-import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
+import hmda.validation.rules.AggregateEditCheck
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._
 
 import scala.concurrent.Future

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q054.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q054.scala
@@ -1,16 +1,14 @@
 package hmda.validation.rules.lar.`macro`
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
-import hmda.validation.rules.AggregateEditCheck
+import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.Future
 
 object Q054 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplicationRegister] {
 
@@ -19,7 +17,7 @@ object Q054 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q054"
 
-  override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
+  override def apply[as: AS, mat: MAT, ec: EC](lars: LoanApplicationRegisterSource): Future[Result] = {
 
     val hoepaLoans =
       count(lars.filter(lar => lar.agencyCode == 5 && lar.actionTakenType == 6 && lar.hoepaStatus == 1))

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q054.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q054.scala
@@ -1,11 +1,12 @@
 package hmda.validation.rules.lar.`macro`
 
+import hmda.validation._
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
-import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
+import hmda.validation.rules.AggregateEditCheck
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._
 
 import scala.concurrent.Future

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q055.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q055.scala
@@ -1,16 +1,14 @@
 package hmda.validation.rules.lar.`macro`
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.Result
-import hmda.validation.rules.AggregateEditCheck
+import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.Future
 
 object Q055 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplicationRegister] {
 
@@ -19,7 +17,7 @@ object Q055 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q055"
 
-  override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
+  override def apply[as: AS, mat: MAT, ec: EC](lars: LoanApplicationRegisterSource): Future[Result] = {
 
     val hoepaLoans =
       count(lars.filter(lar => lar.hoepaStatus == 1 && lar.actionTakenType == 1 && lar.rateSpread != "NA")

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q055.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q055.scala
@@ -1,9 +1,10 @@
 package hmda.validation.rules.lar.`macro`
 
+import hmda.validation._
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.Result
-import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
+import hmda.validation.rules.AggregateEditCheck
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q056.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q056.scala
@@ -1,16 +1,14 @@
 package hmda.validation.rules.lar.`macro`
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.Result
-import hmda.validation.rules.AggregateEditCheck
+import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.Future
 
 object Q056 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplicationRegister] {
 
@@ -20,7 +18,7 @@ object Q056 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q056"
 
-  override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
+  override def apply[as: AS, mat: MAT, ec: EC](lars: LoanApplicationRegisterSource): Future[Result] = {
 
     val denied =
       count(lars.filter(lar => lar.loan.purpose == 1 && lar.loan.loanType == 1 && lar.actionTakenType == 3))

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q056.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q056.scala
@@ -1,9 +1,10 @@
 package hmda.validation.rules.lar.`macro`
 
+import hmda.validation._
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.Result
-import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
+import hmda.validation.rules.AggregateEditCheck
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q057.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q057.scala
@@ -1,16 +1,14 @@
 package hmda.validation.rules.lar.`macro`
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.Result
-import hmda.validation.rules.AggregateEditCheck
+import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.Future
 
 object Q057 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplicationRegister] {
 
@@ -19,7 +17,7 @@ object Q057 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q057"
 
-  override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
+  override def apply[as: AS, mat: MAT, ec: EC](lars: LoanApplicationRegisterSource): Future[Result] = {
 
     val denied =
       count(lars.filter(lar => lar.actionTakenType == 3))

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q057.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q057.scala
@@ -1,9 +1,10 @@
 package hmda.validation.rules.lar.`macro`
 
+import hmda.validation._
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.Result
-import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
+import hmda.validation.rules.AggregateEditCheck
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q058.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q058.scala
@@ -1,16 +1,14 @@
 package hmda.validation.rules.lar.`macro`
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.Result
-import hmda.validation.rules.AggregateEditCheck
+import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.Future
 
 object Q058 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplicationRegister] {
 
@@ -19,7 +17,7 @@ object Q058 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q058"
 
-  override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
+  override def apply[as: AS, mat: MAT, ec: EC](lars: LoanApplicationRegisterSource): Future[Result] = {
 
     val preapprovalRequested =
       count(lars.filter(lar => lar.preapprovals == 1))

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q058.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q058.scala
@@ -1,9 +1,10 @@
 package hmda.validation.rules.lar.`macro`
 
+import hmda.validation._
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.Result
-import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
+import hmda.validation.rules.AggregateEditCheck
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q061.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q061.scala
@@ -1,16 +1,14 @@
 package hmda.validation.rules.lar.`macro`
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.Result
-import hmda.validation.rules.AggregateEditCheck
+import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.Future
 
 object Q061 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplicationRegister] {
 
@@ -19,7 +17,7 @@ object Q061 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q061"
 
-  override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
+  override def apply[as: AS, mat: MAT, ec: EC](lars: LoanApplicationRegisterSource): Future[Result] = {
 
     val firstLienHoepaLoans =
       count(lars.filter(lar => lar.hoepaStatus == 1 && lar.actionTakenType == 1 && lar.lienStatus == 1 && lar.rateSpread != "NA")

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q061.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q061.scala
@@ -1,9 +1,10 @@
 package hmda.validation.rules.lar.`macro`
 
+import hmda.validation._
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.Result
-import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
+import hmda.validation.rules.AggregateEditCheck
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q062.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q062.scala
@@ -1,11 +1,12 @@
 package hmda.validation.rules.lar.`macro`
 
+import hmda.validation._
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
-import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
+import hmda.validation.rules.AggregateEditCheck
 import hmda.validation.rules.lar.`macro`.MacroEditTypes.LoanApplicationRegisterSource
 
 import scala.concurrent.Future

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q062.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q062.scala
@@ -1,16 +1,14 @@
 package hmda.validation.rules.lar.`macro`
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
-import hmda.validation.rules.AggregateEditCheck
+import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
 import hmda.validation.rules.lar.`macro`.MacroEditTypes.LoanApplicationRegisterSource
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.Future
 
 object Q062 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplicationRegister] {
 
@@ -19,7 +17,7 @@ object Q062 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name: String = "Q062"
 
-  override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
+  override def apply[as: AS, mat: MAT, ec: EC](lars: LoanApplicationRegisterSource): Future[Result] = {
 
     val fannieHoepaLoans =
       count(lars.filter(

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q063.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q063.scala
@@ -1,11 +1,12 @@
 package hmda.validation.rules.lar.`macro`
 
+import hmda.validation._
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
-import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
+import hmda.validation.rules.AggregateEditCheck
 import hmda.validation.rules.lar.`macro`.MacroEditTypes.LoanApplicationRegisterSource
 
 import scala.concurrent.Future

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q063.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q063.scala
@@ -1,16 +1,14 @@
 package hmda.validation.rules.lar.`macro`
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
-import hmda.validation.rules.AggregateEditCheck
+import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
 import hmda.validation.rules.lar.`macro`.MacroEditTypes.LoanApplicationRegisterSource
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.Future
 
 object Q063 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplicationRegister] {
 
@@ -19,7 +17,7 @@ object Q063 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name: String = "Q063"
 
-  override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
+  override def apply[as: AS, mat: MAT, ec: EC](lars: LoanApplicationRegisterSource): Future[Result] = {
     val freddieHoepaLoans =
       count(lars.filter(
         lar => {

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q065.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q065.scala
@@ -1,11 +1,12 @@
 package hmda.validation.rules.lar.`macro`
 
+import hmda.validation._
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
-import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
+import hmda.validation.rules.AggregateEditCheck
 import hmda.validation.rules.lar.`macro`.MacroEditTypes.LoanApplicationRegisterSource
 
 import scala.concurrent.Future

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q065.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q065.scala
@@ -1,16 +1,14 @@
 package hmda.validation.rules.lar.`macro`
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
-import hmda.validation.rules.AggregateEditCheck
+import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
 import hmda.validation.rules.lar.`macro`.MacroEditTypes.LoanApplicationRegisterSource
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.Future
 
 object Q065 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplicationRegister] {
 
@@ -19,7 +17,7 @@ object Q065 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name: String = "Q065"
 
-  override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
+  override def apply[as: AS, mat: MAT, ec: EC](lars: LoanApplicationRegisterSource): Future[Result] = {
 
     val hoepaCount = count(lars.filter(lar => lar.hoepaStatus == 1))
 

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q073.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q073.scala
@@ -1,11 +1,12 @@
 package hmda.validation.rules.lar.`macro`
 
+import hmda.validation._
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
-import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
+import hmda.validation.rules.AggregateEditCheck
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._
 
 import scala.concurrent.Future

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q073.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q073.scala
@@ -1,16 +1,14 @@
 package hmda.validation.rules.lar.`macro`
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
-import hmda.validation.rules.AggregateEditCheck
+import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.Future
 
 object Q073 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplicationRegister] {
 
@@ -20,7 +18,7 @@ object Q073 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q073"
 
-  override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
+  override def apply[as: AS, mat: MAT, ec: EC](lars: LoanApplicationRegisterSource): Future[Result] = {
     val applicableLoans = lars.filter(lar =>
       lar.loan.purpose == 1
         && Seq(1, 6).contains(lar.actionTakenType)

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q074.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q074.scala
@@ -1,16 +1,14 @@
 package hmda.validation.rules.lar.`macro`
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
-import hmda.validation.rules.AggregateEditCheck
+import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.Future
 
 object Q074 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplicationRegister] {
 
@@ -20,7 +18,7 @@ object Q074 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q074"
 
-  override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
+  override def apply[as: AS, mat: MAT, ec: EC](lars: LoanApplicationRegisterSource): Future[Result] = {
     val applicableLoans = lars.filter(lar =>
       lar.loan.purpose == 3
         && Seq(1, 6).contains(lar.actionTakenType)

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q074.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q074.scala
@@ -1,11 +1,12 @@
 package hmda.validation.rules.lar.`macro`
 
+import hmda.validation._
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
-import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
+import hmda.validation.rules.AggregateEditCheck
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._
 
 import scala.concurrent.Future

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q080.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q080.scala
@@ -1,16 +1,14 @@
 package hmda.validation.rules.lar.`macro`
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
-import hmda.validation.rules.AggregateEditCheck
+import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.Future
 
 object Q080 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplicationRegister] {
 
@@ -19,7 +17,7 @@ object Q080 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q080"
 
-  override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
+  override def apply[as: AS, mat: MAT, ec: EC](lars: LoanApplicationRegisterSource): Future[Result] = {
 
     val relevantLars =
       count(lars.filter(lar => (1 to 3).contains(lar.actionTakenType)

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q080.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q080.scala
@@ -1,11 +1,12 @@
 package hmda.validation.rules.lar.`macro`
 
+import hmda.validation._
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
-import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
+import hmda.validation.rules.AggregateEditCheck
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._
 
 import scala.concurrent.Future

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q081.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q081.scala
@@ -1,11 +1,12 @@
 package hmda.validation.rules.lar.`macro`
 
+import hmda.validation._
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
-import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
+import hmda.validation.rules.AggregateEditCheck
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._
 
 import scala.concurrent.Future

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q081.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q081.scala
@@ -1,16 +1,14 @@
 package hmda.validation.rules.lar.`macro`
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
-import hmda.validation.rules.AggregateEditCheck
+import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.Future
 
 object Q081 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplicationRegister] {
 
@@ -19,7 +17,7 @@ object Q081 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q081"
 
-  override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
+  override def apply[as: AS, mat: MAT, ec: EC](lars: LoanApplicationRegisterSource): Future[Result] = {
 
     val relevantLars =
       count(lars.filter(lar => (1 to 3).contains(lar.actionTakenType)

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q082.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q082.scala
@@ -1,16 +1,14 @@
 package hmda.validation.rules.lar.`macro`
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
-import hmda.validation.rules.AggregateEditCheck
+import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.Future
 
 object Q082 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplicationRegister] {
 
@@ -19,7 +17,7 @@ object Q082 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q082"
 
-  override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
+  override def apply[as: AS, mat: MAT, ec: EC](lars: LoanApplicationRegisterSource): Future[Result] = {
 
     val relevantLars =
       count(lars.filter(lar => (1 to 3).contains(lar.actionTakenType)

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q082.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q082.scala
@@ -1,11 +1,12 @@
 package hmda.validation.rules.lar.`macro`
 
+import hmda.validation._
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
-import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
+import hmda.validation.rules.AggregateEditCheck
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._
 
 import scala.concurrent.Future

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q083.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q083.scala
@@ -1,11 +1,12 @@
 package hmda.validation.rules.lar.`macro`
 
+import hmda.validation._
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
-import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
+import hmda.validation.rules.AggregateEditCheck
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._
 
 import scala.concurrent.Future

--- a/validation/src/main/scala/hmda/validation/rules/lar/macro/Q083.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/macro/Q083.scala
@@ -1,16 +1,14 @@
 package hmda.validation.rules.lar.`macro`
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 import hmda.validation.dsl.Result
-import hmda.validation.rules.AggregateEditCheck
+import hmda.validation.rules.{ AS, AggregateEditCheck, EC, MAT }
 import hmda.validation.rules.lar.`macro`.MacroEditTypes._
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.Future
 
 object Q083 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplicationRegister] {
 
@@ -19,7 +17,7 @@ object Q083 extends AggregateEditCheck[LoanApplicationRegisterSource, LoanApplic
 
   override def name = "Q083"
 
-  override def apply(lars: LoanApplicationRegisterSource)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[Result] = {
+  override def apply[as: AS, mat: MAT, ec: EC](lars: LoanApplicationRegisterSource): Future[Result] = {
 
     val relevantLars =
       count(lars.filter(lar => (1 to 3).contains(lar.actionTakenType)

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q022.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q022.scala
@@ -1,11 +1,12 @@
 package hmda.validation.rules.lar.quality
 
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.validation.EC
 import hmda.validation.dsl.Result
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.Future
 import scala.util.Try
 
 object Q022 {
@@ -19,7 +20,7 @@ object Q022 {
     (year - applicationYear) is between(0, 2)
   }
 
-  def apply(lar: LoanApplicationRegister, fYear: Future[Int])(implicit ec: ExecutionContext): Future[Result] = {
+  def apply[_: EC](lar: LoanApplicationRegister, fYear: Future[Int]): Future[Result] = {
     val applicationYear = parseYear(lar)
 
     fYear.map { year =>

--- a/validation/src/main/scala/hmda/validation/rules/package.scala
+++ b/validation/src/main/scala/hmda/validation/rules/package.scala
@@ -1,0 +1,14 @@
+package hmda.validation
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+
+import scala.concurrent.ExecutionContext
+
+package object rules {
+
+  type AS[_] = ActorSystem
+  type MAT[_] = ActorMaterializer
+  type EC[_] = ExecutionContext
+
+}


### PR DESCRIPTION
Uses [Context Bounds](http://docs.scala-lang.org/tutorials/FAQ/context-bounds) and type aliases in package objects to cleanup implicit declarations. No behavior has been changed