### PR TITLE
Prevent ValidationStats Timeout

### DIFF
--- a/validation/src/main/scala/hmda/validation/ValidationStats.scala
+++ b/validation/src/main/scala/hmda/validation/ValidationStats.scala
@@ -32,6 +32,10 @@ class ValidationStats extends HmdaPersistentActor {
 
   override def persistenceId: String = s"$name"
 
+  override def preStart(): Unit = {
+    log.info(s"Actor started at ${self.path}")
+  }
+
   var state = ValidationStatsState()
 
   override def updateState(event: Event): Unit = {


### PR DESCRIPTION
The ValidationStats actor was receiving a timeout and shutting itself down, which would cause the yield statements on both Q011 and Q012 to get stuck.  This PR overrides the `preStart` method so the actor doesn't stop itself.

Closes #936 