### PR TITLE
Load Panel through Admin API

### DIFF
--- a/Documents/panel.md
+++ b/Documents/panel.md
@@ -6,27 +6,25 @@ The panel parser is designed to read a CSV file and load the data onto the HMDA-
 ## Running the parser
 An example panel file is located at `hmda-platform/panel/src/main/resources/inst_data_2015_20170308_dummy.csv`
 
-While in the `hmda-platform` project, start up `sbt`, then execute the following commands:
+In order for the panel data to be loaded, the API project must be up and running, along with a Docker container running Cassandra.  In one terminal, execute the following commands:
 ```shell
-> project panel
-> clean
-> run /path/to/panelData.csv
-```
-The project currently has to be force-stopped with `Ctrl+C`.
-
-At this point, make sure your `HMDA_IS_DEMO` environment variable is set to `false`, so the real data will be loaded.
-```shell
-export HMDA_IS_DEMO=false
+> export HMDA_IS_DEMO=false
+> sbt
+sbt> clean
+sbt> project api
+sbt> reStart
 ```
 
-Restart `sbt`, then execute the following commands (don't run `clean`!):
+In another terminal, execute the following commands:
 ```shell
-> project api
-> reStart
+> sbt
+sbt> project panel
+sbt> clean
+sbt> run /path/to/panelData.csv
 ```
-You should see the institutions table being populated with the institutions contained in the given panel file.  Note that any institutions with duplicate `id_rssd` fields will not be inserted, so the final row count may be lower than the file's line count.
+The panel project currently has to be force-stopped with `Ctrl+C`.
 
 ## Testing
-Make sure your authorization header is updated with a few real `id_rssd` fields from the given file.  This can be found in the log output (first field argument in the `InstitutionQuery` object), or in the CSV file (seventh field).
+Make sure your authorization header is updated with a few real `id_rssd` fields from the given file.  This can be found in the API log output (first field argument in the `InstitutionQuery` object), or in the CSV file (seventh field).
 
 Try out the endpoint `localhost:8080/institutions`, and you should see a response with real panel data.

--- a/api/src/main/scala/hmda/api/http/admin/InstitutionAdminHttpApi.scala
+++ b/api/src/main/scala/hmda/api/http/admin/InstitutionAdminHttpApi.scala
@@ -1,6 +1,6 @@
 package hmda.api.http.admin
 
-import akka.actor.{ ActorRef, ActorSystem }
+import akka.actor.{ActorRef, ActorSystem}
 import akka.event.LoggingAdapter
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.marshalling.ToResponseMarshallable
@@ -12,13 +12,16 @@ import akka.util.Timeout
 import hmda.api.http.HmdaCustomDirectives
 import hmda.api.protocol.admin.WriteInstitutionProtocol
 import hmda.api.protocol.processing.ApiErrorProtocol
+import hmda.model.fi.Filing
 import hmda.model.institution.Institution
-import hmda.persistence.institutions.InstitutionPersistence
-import hmda.persistence.institutions.InstitutionPersistence.{ CreateInstitution, ModifyInstitution }
+import hmda.persistence.HmdaSupervisor.FindFilings
+import hmda.persistence.institutions.FilingPersistence.CreateFiling
+import hmda.persistence.institutions.{FilingPersistence, InstitutionPersistence}
+import hmda.persistence.institutions.InstitutionPersistence.{CreateInstitution, ModifyInstitution}
 import hmda.persistence.model.HmdaSupervisorActor.FindActorByName
 
 import scala.concurrent.ExecutionContext
-import scala.util.{ Failure, Success }
+import scala.util.{Failure, Success}
 
 trait InstitutionAdminHttpApi
     extends WriteInstitutionProtocol
@@ -38,10 +41,14 @@ trait InstitutionAdminHttpApi
           implicit val ec: ExecutionContext = executor
           val supervisor = system.actorSelection("/user/supervisor")
           val fInstitutionsActor = (supervisor ? FindActorByName(InstitutionPersistence.name)).mapTo[ActorRef]
+          val fFilingPersistence = (supervisor ? FindFilings(FilingPersistence.name, institution.id)).mapTo[ActorRef]
+
           timedPost { uri =>
             val fCreated = for {
               a <- fInstitutionsActor
               i <- (a ? CreateInstitution(institution)).mapTo[Option[Institution]]
+              p <- fFilingPersistence
+              f <- p ! CreateFiling(Filing(institution.activityYear.toString, institution.id))
             } yield i
 
             onComplete(fCreated) {

--- a/api/src/main/scala/hmda/api/http/admin/InstitutionAdminHttpApi.scala
+++ b/api/src/main/scala/hmda/api/http/admin/InstitutionAdminHttpApi.scala
@@ -1,6 +1,6 @@
 package hmda.api.http.admin
 
-import akka.actor.{ActorRef, ActorSystem}
+import akka.actor.{ ActorRef, ActorSystem }
 import akka.event.LoggingAdapter
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.marshalling.ToResponseMarshallable
@@ -16,12 +16,12 @@ import hmda.model.fi.Filing
 import hmda.model.institution.Institution
 import hmda.persistence.HmdaSupervisor.FindFilings
 import hmda.persistence.institutions.FilingPersistence.CreateFiling
-import hmda.persistence.institutions.{FilingPersistence, InstitutionPersistence}
-import hmda.persistence.institutions.InstitutionPersistence.{CreateInstitution, ModifyInstitution}
+import hmda.persistence.institutions.{ FilingPersistence, InstitutionPersistence }
+import hmda.persistence.institutions.InstitutionPersistence.{ CreateInstitution, ModifyInstitution }
 import hmda.persistence.model.HmdaSupervisorActor.FindActorByName
 
 import scala.concurrent.ExecutionContext
-import scala.util.{Failure, Success}
+import scala.util.{ Failure, Success }
 
 trait InstitutionAdminHttpApi
     extends WriteInstitutionProtocol
@@ -48,7 +48,7 @@ trait InstitutionAdminHttpApi
               a <- fInstitutionsActor
               i <- (a ? CreateInstitution(institution)).mapTo[Option[Institution]]
               p <- fFilingPersistence
-              f <- p ! CreateFiling(Filing(institution.activityYear.toString, institution.id))
+              f <- p ? CreateFiling(Filing(institution.activityYear.toString, institution.id))
             } yield i
 
             onComplete(fCreated) {

--- a/build.sbt
+++ b/build.sbt
@@ -113,11 +113,10 @@ lazy val panel = (project in file("panel"))
         val oldStrategy = (assemblyMergeStrategy in assembly).value
         oldStrategy(x)
     },
-    libraryDependencies ++= akkaPersistenceDeps
-  ).dependsOn(persistenceModel % "compile->compile;test->test")
-  .dependsOn(persistence % "compile->compile;test->test")
-  .dependsOn(parserJVM % "compile->compile;test->test")
+    libraryDependencies ++= akkaPersistenceDeps ++ httpDeps
+  ).dependsOn(parserJVM % "compile->compile;test->test")
   .dependsOn(query % "compile->compile;test->test")
+  .dependsOn(api % "compile->compile;test->test")
 
 lazy val persistenceModel = (project in file("persistence-model"))
   .settings(hmdaBuildSettings:_*)

--- a/panel/src/main/scala/hmda/panel/PanelCsvParser.scala
+++ b/panel/src/main/scala/hmda/panel/PanelCsvParser.scala
@@ -29,7 +29,7 @@ object PanelCsvParser extends InstitutionComponent with WriteInstitutionProtocol
 
   val repository = new InstitutionRepository(hmda.query.DbConfiguration.config)
 
-  val config = ConfigFactory.parseFile(new File("api/src/main/resources/application.conf")).resolve()
+  val config = ConfigFactory.load()
   val host = config.getString("hmda.http.adminHost")
   val port = config.getInt("hmda.http.adminPort")
 

--- a/query/src/main/scala/hmda/query/model/filing/Msa.scala
+++ b/query/src/main/scala/hmda/query/model/filing/Msa.scala
@@ -3,19 +3,19 @@ package hmda.query.model.filing
 import hmda.census.model.CbsaLookup
 
 case class Msa(
-  id: String,
-  totalLars: Int,
-  totalAmount: Int,
-  conv: Int,
-  FHA: Int,
-  VA: Int,
-  FSA: Int,
-  oneToFourFamily: Int,
-  MFD: Int,
-  multiFamily: Int,
-  homePurchase: Int,
-  homeImprovement: Int,
-  refinance: Int
+    id: String,
+    totalLars: Int,
+    totalAmount: Int,
+    conv: Int,
+    FHA: Int,
+    VA: Int,
+    FSA: Int,
+    oneToFourFamily: Int,
+    MFD: Int,
+    multiFamily: Int,
+    homePurchase: Int,
+    homeImprovement: Int,
+    refinance: Int
 ) {
   def addName: MsaWithName = MsaWithName(
     this.id,

--- a/query/src/main/scala/hmda/query/model/filing/Msa.scala
+++ b/query/src/main/scala/hmda/query/model/filing/Msa.scala
@@ -3,19 +3,19 @@ package hmda.query.model.filing
 import hmda.census.model.CbsaLookup
 
 case class Msa(
-    id: String,
-    totalLars: Int,
-    totalAmount: Int,
-    conv: Int,
-    FHA: Int,
-    VA: Int,
-    FSA: Int,
-    oneToFourFamily: Int,
-    MFD: Int,
-    multiFamily: Int,
-    homePurchase: Int,
-    homeImprovement: Int,
-    refinance: Int
+  id: String,
+  totalLars: Int,
+  totalAmount: Int,
+  conv: Int,
+  FHA: Int,
+  VA: Int,
+  FSA: Int,
+  oneToFourFamily: Int,
+  MFD: Int,
+  multiFamily: Int,
+  homePurchase: Int,
+  homeImprovement: Int,
+  refinance: Int
 ) {
   def addName: MsaWithName = MsaWithName(
     this.id,


### PR DESCRIPTION
Note for testing: the API must be running in order for the panel data to load.  I had one terminal with the API running (`HMDA_IS_DEMO=false`), and ran panel in a separate window.  The panel process won't output any logs after "Creating schema", but you should see output from the API window.

Closes #938 