### PR TITLE
S011

### DIFF
--- a/model/shared/src/main/scala/hmda/model/fi/ts/TransmittalSheet.scala
+++ b/model/shared/src/main/scala/hmda/model/fi/ts/TransmittalSheet.scala
@@ -21,6 +21,8 @@ case class TransmittalSheet(
     TsFieldMapping.mapping(this).getOrElse(field, "error: field name mismatch")
   }
 
+  def errorId: String = this.agencyCode + this.respondent.id
+
   def toCSV: String = {
     s"$id|${respondent.id}|$agencyCode|$timestamp|$activityYear" +
       s"|$taxId|$totalLines|${respondent.name}|${respondent.address}" +

--- a/persistence/src/test/scala/hmda/persistence/processing/HmdaFileValidatorSpec.scala
+++ b/persistence/src/test/scala/hmda/persistence/processing/HmdaFileValidatorSpec.scala
@@ -105,7 +105,8 @@ class HmdaFileValidatorSpec extends ActorSpec with BeforeAndAfterEach with HmdaF
         Some(ts),
         lars,
         List(
-          SyntacticalValidationError("38800009923", "S025", true)
+          SyntacticalValidationError("38800009923", "S025", true),
+          SyntacticalValidationError("38800009923", "S011", true)
         ),
         Nil,
         Nil,

--- a/validation/src/main/scala/hmda/validation/api/ValidationApi.scala
+++ b/validation/src/main/scala/hmda/validation/api/ValidationApi.scala
@@ -1,10 +1,11 @@
 package hmda.validation.api
 
 import hmda.model.validation._
+import hmda.validation.{ AS, MAT, EC }
 import hmda.validation.dsl.{ Failure, Result, Success }
-import hmda.validation.engine._
-import hmda.validation.rules.EditCheck
+import hmda.validation.rules.{ AggregateEditCheck, EditCheck }
 
+import scala.concurrent.Future
 import scalaz._
 import scalaz.Scalaz._
 
@@ -24,6 +25,13 @@ trait ValidationApi {
         case Macro => MacroValidationError(ruleName).failure.toValidationNel
       }
     }
+  }
+
+  def checkAsync[T, E, as: AS, mat: MAT, ec: EC](editCheck: AggregateEditCheck[T, E], input: T, inputId: String, errorType: ValidationErrorType, ts: Boolean): Future[ValidationNel[ValidationError, T]] = {
+    val fEdit = editCheck(input)
+    for {
+      result <- fEdit
+    } yield convertResult(input, result, editCheck.name, inputId, errorType, ts)
   }
 
   def validateAll[E, T](checks: List[ValidationNel[E, T]], input: T): ValidationNel[E, T] = {

--- a/validation/src/main/scala/hmda/validation/api/ValidationApi.scala
+++ b/validation/src/main/scala/hmda/validation/api/ValidationApi.scala
@@ -27,7 +27,13 @@ trait ValidationApi {
     }
   }
 
-  def checkAsync[T, E, as: AS, mat: MAT, ec: EC](editCheck: AggregateEditCheck[T, E], input: T, inputId: String, errorType: ValidationErrorType, ts: Boolean): Future[ValidationNel[ValidationError, T]] = {
+  def checkAsync[T, E, as: AS, mat: MAT, ec: EC](
+    editCheck: AggregateEditCheck[T, E],
+    input: T,
+    inputId: String,
+    errorType: ValidationErrorType,
+    ts: Boolean
+  ): Future[ValidationNel[ValidationError, T]] = {
     val fEdit = editCheck(input)
     for {
       result <- fEdit

--- a/validation/src/main/scala/hmda/validation/engine/lar/LarCommonEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/lar/LarCommonEngine.scala
@@ -10,7 +10,6 @@ import scalaz._
 
 trait LarCommonEngine {
   type LarValidation = ValidationNel[ValidationError, LoanApplicationRegister]
-  type LarsValidation = ValidationNel[ValidationError, Iterable[LoanApplicationRegister]]
   type LarSourceValidation = ValidationNel[ValidationError, LoanApplicationRegisterSource]
 
   def validationErrors(lar: LoanApplicationRegister, ctx: ValidationContext, f: (LoanApplicationRegister, ValidationContext) => LarValidation): ValidationErrors = {

--- a/validation/src/main/scala/hmda/validation/engine/lar/LarEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/lar/LarEngine.scala
@@ -21,8 +21,4 @@ trait LarEngine extends LarSyntacticalEngine with LarValidityEngine with LarQual
 
   }
 
-  def validateLars(lars: Iterable[LoanApplicationRegister]): LarsValidation = {
-    checkSyntacticalCollection(lars)
-  }
-
 }

--- a/validation/src/main/scala/hmda/validation/engine/lar/macro/LarMacroEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/lar/macro/LarMacroEngine.scala
@@ -1,12 +1,10 @@
 package hmda.validation.engine.lar.`macro`
 
 import hmda.validation._
-import hmda.model.fi.lar.LoanApplicationRegister
-import hmda.model.validation.{ Macro, ValidationErrorType }
+import hmda.model.validation.Macro
 import hmda.validation.api.ValidationApi
 import hmda.validation.context.ValidationContext
 import hmda.validation.engine.lar.LarCommonEngine
-import hmda.validation.rules.AggregateEditCheck
 import hmda.validation.rules.lar.`macro`.MacroEditTypes.LoanApplicationRegisterSource
 import hmda.validation.rules.lar.`macro`._
 
@@ -50,24 +48,10 @@ trait LarMacroEngine extends LarCommonEngine with ValidationApi {
         Q081,
         Q082,
         Q083
-      ).map(checkAggregate(_, larSource, "", Macro))
+      ).map(checkAsync(_, larSource, "", Macro, false))
     )
       .map(checks => validateAll(checks, larSource))
 
-  }
-
-  private def checkAggregate[_: AS: MAT: EC](
-    editCheck: AggregateEditCheck[LoanApplicationRegisterSource, LoanApplicationRegister],
-    input: LoanApplicationRegisterSource,
-    inputId: String,
-    errorType: ValidationErrorType
-  ): Future[LarSourceValidation] = {
-    val fResult = editCheck(input)
-    for {
-      result <- fResult
-    } yield {
-      convertResult(input, result, editCheck.name, inputId, errorType, false)
-    }
   }
 
 }

--- a/validation/src/main/scala/hmda/validation/engine/lar/syntactical/LarSyntacticalEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/lar/syntactical/LarSyntacticalEngine.scala
@@ -25,7 +25,7 @@ trait LarSyntacticalEngine extends LarCommonEngine with ValidationApi {
 
   def checkSyntacticalCollection(lars: Iterable[LoanApplicationRegister]): LarsValidation = {
     val checks = List(
-      S011,
+      //S011,
       S040
     ).map(check(_, lars, "", Syntactical, false))
 

--- a/validation/src/main/scala/hmda/validation/engine/lar/syntactical/LarSyntacticalEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/lar/syntactical/LarSyntacticalEngine.scala
@@ -23,13 +23,4 @@ trait LarSyntacticalEngine extends LarCommonEngine with ValidationApi {
     validateAll(checks, lar)
   }
 
-  def checkSyntacticalCollection(lars: Iterable[LoanApplicationRegister]): LarsValidation = {
-    val checks = List(
-      //S011,
-      S040
-    ).map(check(_, lars, "", Syntactical, false))
-
-    validateAll(checks, lars)
-  }
-
 }

--- a/validation/src/main/scala/hmda/validation/engine/ts/TsEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/ts/TsEngine.scala
@@ -18,10 +18,11 @@ trait TsEngine extends TsSyntacticalEngine with TsValidityEngine with TsQualityE
     (
       checkValidity(ts, ctx)
       |@| checkSyntactical(ts, ctx)
-    )((_, _) => ts)
+      |@| checkQuality(ts, ctx)
+    )((_, _, _) => ts)
   }
 
   def validateTsQuality(ts: TransmittalSheet, ctx: ValidationContext)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[TsValidation] = {
-    checkQuality(ts, ctx)
+    checkQualityAsync(ts, ctx)
   }
 }

--- a/validation/src/main/scala/hmda/validation/engine/ts/TsEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/ts/TsEngine.scala
@@ -22,7 +22,13 @@ trait TsEngine extends TsSyntacticalEngine with TsValidityEngine with TsQualityE
     )((_, _, _) => ts)
   }
 
-  def validateTsQuality(ts: TransmittalSheet, ctx: ValidationContext)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[TsValidation] = {
-    checkQualityAsync(ts, ctx)
+  def performAsyncChecks(ts: TransmittalSheet, ctx: ValidationContext)(implicit system: ActorSystem, materializer: ActorMaterializer, ec: ExecutionContext): Future[TsValidation] = {
+    for {
+      syntactical <- checkSyntacticalAsync(ts, ctx)
+      quality <- checkQualityAsync(ts, ctx)
+    } yield {
+      (syntactical |@| quality)((_, _) => ts)
+    }
   }
+
 }

--- a/validation/src/main/scala/hmda/validation/engine/ts/syntactical/TsSyntacticalEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/ts/syntactical/TsSyntacticalEngine.scala
@@ -2,6 +2,7 @@ package hmda.validation.engine.ts.syntactical
 
 import hmda.model.fi.ts.TransmittalSheet
 import hmda.model.validation.Syntactical
+import hmda.validation.{ AS, MAT }
 import hmda.validation.api.ValidationApi
 import hmda.validation.context.ValidationContext
 import hmda.validation.engine.ts.TsCommonEngine
@@ -22,6 +23,16 @@ trait TsSyntacticalEngine extends TsCommonEngine with ValidationApi {
     val checks = checksToRun.map(check(_, ts, ts.agencyCode + ts.respondent.id, Syntactical, true))
 
     validateAll(checks, ts)
+  }
+
+  def checkSyntacticalAsync[as: AS, mat: MAT](ts: TransmittalSheet, ctx: ValidationContext): Future[TsValidation] = {
+    val checks = List(
+      S011.inContext(ctx)
+    ).map(edit => checkAsync(edit, ts, ts.errorId, Syntactical, true))
+
+    val fChecks = Future.sequence(checks)
+
+    fChecks.map(list => validateAll(list, ts))
   }
 
 }

--- a/validation/src/main/scala/hmda/validation/engine/ts/syntactical/TsSyntacticalEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/ts/syntactical/TsSyntacticalEngine.scala
@@ -20,7 +20,7 @@ trait TsSyntacticalEngine extends TsCommonEngine with ValidationApi {
       S028,
       S100.inContext(ctx)
     )
-    val checks = checksToRun.map(check(_, ts, ts.agencyCode + ts.respondent.id, Syntactical, true))
+    val checks = checksToRun.map(check(_, ts, ts.errorId, Syntactical, true))
 
     validateAll(checks, ts)
   }

--- a/validation/src/main/scala/hmda/validation/engine/ts/validity/TsValidityEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/ts/validity/TsValidityEngine.scala
@@ -10,7 +10,6 @@ import hmda.validation.rules.ts.validity._
 trait TsValidityEngine extends TsCommonEngine with ValidationApi {
 
   def checkValidity(ts: TransmittalSheet, ctx: ValidationContext): TsValidation = {
-    val tsId = ts.agencyCode + ts.respondent.id
     val checks: List[TsValidation] = List(
       V105,
       V108,
@@ -25,7 +24,7 @@ trait TsValidityEngine extends TsCommonEngine with ValidationApi {
       V145,
       V150,
       V155
-    ).map(check(_, ts, tsId, Validity, true))
+    ).map(check(_, ts, ts.errorId, Validity, true))
 
     validateAll(checks, ts)
   }

--- a/validation/src/main/scala/hmda/validation/rules/ts/syntactical/S011.scala
+++ b/validation/src/main/scala/hmda/validation/rules/ts/syntactical/S011.scala
@@ -1,4 +1,4 @@
-package hmda.validation.rules.lar.syntactical
+package hmda.validation.rules.ts.syntactical
 
 import akka.pattern.ask
 import hmda.model.fi.ts.TransmittalSheet
@@ -6,10 +6,10 @@ import hmda.model.institution.Institution
 import hmda.validation.ValidationStats.FindTotalSubmittedLars
 import hmda.validation._
 import hmda.validation.context.ValidationContext
-import hmda.validation.rules.{ AggregateEditCheck, IfContextPresentInAggregate, StatsLookup }
-import hmda.validation.dsl.Result
 import hmda.validation.dsl.PredicateCommon._
 import hmda.validation.dsl.PredicateSyntax._
+import hmda.validation.dsl.Result
+import hmda.validation.rules.{ AggregateEditCheck, IfContextPresentInAggregate, StatsLookup }
 
 import scala.concurrent.Future
 

--- a/validation/src/test/scala/hmda/validation/engine/lar/syntactical/LarSyntacticalEngineSpec.scala
+++ b/validation/src/test/scala/hmda/validation/engine/lar/syntactical/LarSyntacticalEngineSpec.scala
@@ -22,10 +22,4 @@ class LarSyntacticalEngineSpec
     }
   }
 
-  property("Pass syntactical checks on groups of LARs") {
-    forAll(larListGen) { lars =>
-      checkSyntacticalCollection(lars) mustBe a[Success[_]]
-    }
-  }
-
 }

--- a/validation/src/test/scala/hmda/validation/engine/ts/quality/TsQualityEngineSpec.scala
+++ b/validation/src/test/scala/hmda/validation/engine/ts/quality/TsQualityEngineSpec.scala
@@ -29,7 +29,7 @@ class TsQualityEngineSpec
       val line = Source.fromFile(new File("parser/jvm/src/test/resources/txt/clean_10-lars.txt")).getLines().take(1)
       val ts = line.map(l => TsCsvParser(l).right.getOrElse(TransmittalSheet())).toList.head
 
-      checkQuality(ts, ctx).map(validation => validation.isSuccess mustBe true)
+      checkQuality(ts, ctx).isSuccess mustBe true
     }
   }
 }

--- a/validation/src/test/scala/hmda/validation/rules/lar/syntactical/S011Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/syntactical/S011Spec.scala
@@ -1,15 +1,72 @@
 package hmda.validation.rules.lar.syntactical
 
-import hmda.model.fi.lar.LoanApplicationRegister
-import hmda.validation.rules.EditCheck
-import hmda.validation.rules.lar.MultipleLarEditCheckSpec
+import akka.actor.{ ActorRef, ActorSystem }
+import akka.stream.ActorMaterializer
+import com.typesafe.config.ConfigFactory
+import hmda.model.fi.SubmissionId
+import hmda.model.fi.ts.TransmittalSheet
+import hmda.model.institution.Institution
+import hmda.validation.ValidationStats._
+import hmda.validation.context.ValidationContext
+import hmda.validation.dsl.{ Failure, Success }
+import org.scalatest.{ AsyncWordSpec, BeforeAndAfterAll, MustMatchers }
 
-class S011Spec extends MultipleLarEditCheckSpec {
-  property("LAR list must not be empty") {
-    forAll(larListGen) { lars =>
-      lars.mustPass
+import scala.concurrent.duration._
+
+class S011Spec extends AsyncWordSpec with MustMatchers with BeforeAndAfterAll {
+  val configuration = ConfigFactory.load()
+
+  implicit val system = ActorSystem()
+  implicit val materializer = ActorMaterializer()
+  implicit override def executionContext = system.dispatcher
+
+  val validationStats = createValidationStats(system)
+
+  implicit val timeout = 5.seconds
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+    system.terminate()
+  }
+
+  "S011" must {
+    val currentYear = 2017
+
+    "succeed when 1 or more lars were submitted" in {
+      val instId = "instId1"
+      val ctx = generateValidationContext(currentYear, instId)
+      sendValidationStats(validationStats, instId, currentYear, 1)
+      S011.inContext(ctx)(TransmittalSheet()).map(r => r mustBe a[Success])
+    }
+
+    "fail when zero lars were submitted" in {
+      val instId = "instId2"
+      val ctx = generateValidationContext(currentYear, instId)
+      sendValidationStats(validationStats, instId, currentYear, 0)
+      S011.inContext(ctx)(TransmittalSheet()).map(r => r mustBe a[Failure])
+    }
+
+    /// Handling ValidationContext correctly
+    "be named S011 when institution and year are present" in {
+      val ctx = ValidationContext(Some(Institution.empty), Some(currentYear))
+      S011.inContext(ctx).name mustBe "S011"
+    }
+
+    "be named empty when institution is not present" in {
+      val ctx = ValidationContext(None, Some(currentYear))
+      S011.inContext(ctx).name mustBe "empty"
+    }
+
+    "be named empty when year is not present" in {
+      val ctx = ValidationContext(Some(Institution.empty), None)
+      S011.inContext(ctx).name mustBe "empty"
     }
   }
 
-  override def check: EditCheck[Iterable[LoanApplicationRegister]] = S011
+  private def generateValidationContext(currentYear: Int, institutionId: String): ValidationContext = {
+    ValidationContext(Some(Institution.empty.copy(id = institutionId)), Some(currentYear))
+  }
+  private def sendValidationStats(validationStats: ActorRef, institutionId: String, year: Int, submittedCount: Int): Unit = {
+    validationStats ! AddSubmissionSubmittedTotal(submittedCount, SubmissionId(institutionId, year.toString, 1))
+  }
 }

--- a/validation/src/test/scala/hmda/validation/rules/ts/quality/Q130Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/ts/quality/Q130Spec.scala
@@ -2,20 +2,15 @@ package hmda.validation.rules.ts.quality
 
 import akka.actor.{ ActorRef, ActorSystem }
 import akka.stream.ActorMaterializer
-import akka.stream.scaladsl.Source
 import com.typesafe.config.ConfigFactory
 import hmda.model.fi.SubmissionId
-import hmda.model.fi.lar.LarGenerators
 import hmda.model.fi.ts.{ TransmittalSheet, TsGenerators }
 import hmda.model.institution.Institution
 import hmda.validation.context.ValidationContext
 import hmda.validation.dsl.{ Failure, Success }
-import org.scalacheck.Gen
-import org.scalatest.{ AsyncWordSpec, BeforeAndAfterAll, MustMatchers }
-
-import scala.concurrent.duration._
 import hmda.validation.ValidationStats._
-import hmda.validation.rules.lar.`macro`.Q011
+import org.scalatest.{ AsyncWordSpec, BeforeAndAfterAll, MustMatchers }
+import scala.concurrent.duration._
 
 class Q130Spec extends AsyncWordSpec with MustMatchers with TsGenerators with BeforeAndAfterAll {
   val configuration = ConfigFactory.load()

--- a/validation/src/test/scala/hmda/validation/rules/ts/syntactical/S011Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/ts/syntactical/S011Spec.scala
@@ -1,4 +1,4 @@
-package hmda.validation.rules.lar.syntactical
+package hmda.validation.rules.ts.syntactical
 
 import akka.actor.{ ActorRef, ActorSystem }
 import akka.stream.ActorMaterializer


### PR DESCRIPTION
Closes #92 and finishes part of #839. (Though #839 can't be closed until I reimplement S040)

This moves the `S011` check from being categorized as a LAR edit to being a TS edit. This doesn't affect  the operation of the edit.