### PR TITLE
Update IRS CSV formatting

### DIFF
--- a/Documents/API.md
+++ b/Documents/API.md
@@ -627,8 +627,8 @@ Example response:
 Example response:
 ```csv
 MSA/MD, MSA/MD Name, Total LARs, Total Amt. (in thousands), CONV, FHA, VA, FSA/RHS, 1-4 Family, MFD, Multi-Family, Home Purchase, Home Improvement, Refinance
-45460, Terre Haute, IN, 7, 297, 7, 0, 0, 0, 7, 0, 0, 0, 4, 3
-NA, NA, 3, 79, 3, 0, 0, 0, 3, 0, 0, 0, 1, 2
+45460,"Terre Haute, IN", 7, 297, 7, 0, 0, 0, 7, 0, 0, 0, 4, 3
+NA,"NA", 3, 79, 3, 0, 0, 0, 3, 0, 0, 0, 1, 2
 Totals,, 10, 376, 10, 0, 0, 0, 10, 0, 0, 0, 5, 5
 ```
 

--- a/api/src/test/scala/hmda/api/http/institutions/submissions/SubmissionIrsPathsSpec.scala
+++ b/api/src/test/scala/hmda/api/http/institutions/submissions/SubmissionIrsPathsSpec.scala
@@ -39,7 +39,7 @@ class SubmissionIrsPathsSpec
         val csv = responseAs[String]
         csv must include("MSA/MD, MSA/MD Name, Total LARs, Total Amt. (in thousands), CONV, FHA, VA, FSA/RHS, 1-4 Family, MFD, Multi-Family, Home Purchase, Home Improvement, Refinance")
         csv must include("Totals")
-        csv must include("13980, Blacksburg-Christiansburg-Radford, VA")
+        csv must include("13980,\"Blacksburg-Christiansburg-Radford, VA\"")
       }
     }
   }

--- a/census/src/main/scala/hmda/census/model/Msa.scala
+++ b/census/src/main/scala/hmda/census/model/Msa.scala
@@ -41,7 +41,7 @@ case class Msa(
     )
   }
 
-  def toCsv: String = s"$id, $name, $totalLars, $totalAmount, $conv, $FHA, $VA, $FSA, $oneToFourFamily, $MFD, $multiFamily, $homePurchase, $homeImprovement, $refinance"
+  def toCsv: String = s"""$id,\"$name\", $totalLars, $totalAmount, $conv, $FHA, $VA, $FSA, $oneToFourFamily, $MFD, $multiFamily, $homePurchase, $homeImprovement, $refinance"""
 }
 
 case class MsaMap(


### PR DESCRIPTION
Closes #1021 

According to [this StackOverflow](https://stackoverflow.com/questions/12473480/how-should-i-escape-commas-and-speech-marks-in-csv-files-so-they-work-in-excel), the values with commas need to be surrounded by quotation marks AND not have a leading space.

So, 
```
this works:
"12345,"Indianapolis,IN", 1, 2, 3"

but this doesn't:
"12345, "Indianapolis, IN", 1, 2, 3"
       ^ ... because of this space
```