### PR TITLE
Make keyspace and cluster names configurable

### DIFF
--- a/api/src/main/resources/application-dev.conf
+++ b/api/src/main/resources/application-dev.conf
@@ -30,6 +30,7 @@ constructr.coordination.nodes = [${?ZOOKEEPER_HOST}":"${?ZOOKEEPER_PORT}]
 
 clustering {
   name = "hmda"
+  name = ${?HMDA_CLUSTER_NAME}
   ip = "127.0.0.1"
   port = 0
   port = ${?APP_PORT}

--- a/api/src/main/resources/application.conf
+++ b/api/src/main/resources/application.conf
@@ -36,6 +36,7 @@ constructr.coordination.nodes = [${?ZOOKEEPER_HOST}":"${?ZOOKEEPER_PORT}]
 
 clustering {
   name = "hmda"
+  name = ${?HMDA_CLUSTER_NAME}
   ip = "127.0.0.1"
   port = 0
   port = ${?APP_PORT}

--- a/api/src/main/scala/hmda/api/HmdaPlatform.scala
+++ b/api/src/main/scala/hmda/api/HmdaPlatform.scala
@@ -32,7 +32,7 @@ object HmdaPlatform {
 
   def main(args: Array[String]): Unit = {
 
-    val system = ActorSystem("hmda", configuration)
+    val system = ActorSystem(configuration.getString("clustering.name"), configuration)
     val supervisor = createSupervisor(system)
     val querySupervisor = createQuerySupervisor(system)
     implicit val ec = system.dispatcher

--- a/persistence-model/src/main/resources/application.conf
+++ b/persistence-model/src/main/resources/application.conf
@@ -70,6 +70,7 @@ cassandra-journal {
   contact-points = ["127.0.0.1"]
   contact-points = [${?CASSANDRA_CLUSTER_HOSTS}]
   keyspace = "hmda_journal"
+  keyspace = ${CASSANDRA_JOURNAL_KEYSPACE}
   table = "journal"
   keyspace-autocreate = true
   keyspace-autocreate-retries = 5
@@ -82,6 +83,7 @@ cassandra-snapshot-store {
   contact-points = ["127.0.0.1"]
   contact-points = [${?CASSANDRA_CLUSTER_HOSTS}]
   keyspace = "hmda_snapshot"
+  keyspace = ${CASSANDRA_SNAPSHOT_KEYSPACE}
   table = "snapshot"
   keyspace-autocreate = true
   keyspace-autocreate-retries = 5

--- a/persistence-model/src/main/resources/application.conf
+++ b/persistence-model/src/main/resources/application.conf
@@ -70,7 +70,7 @@ cassandra-journal {
   contact-points = ["127.0.0.1"]
   contact-points = [${?CASSANDRA_CLUSTER_HOSTS}]
   keyspace = "hmda_journal"
-  keyspace = ${CASSANDRA_JOURNAL_KEYSPACE}
+  keyspace = ${?CASSANDRA_JOURNAL_KEYSPACE}
   table = "journal"
   keyspace-autocreate = true
   keyspace-autocreate-retries = 5
@@ -83,7 +83,7 @@ cassandra-snapshot-store {
   contact-points = ["127.0.0.1"]
   contact-points = [${?CASSANDRA_CLUSTER_HOSTS}]
   keyspace = "hmda_snapshot"
-  keyspace = ${CASSANDRA_SNAPSHOT_KEYSPACE}
+  keyspace = ${?CASSANDRA_SNAPSHOT_KEYSPACE}
   table = "snapshot"
   keyspace-autocreate = true
   keyspace-autocreate-retries = 5

--- a/query/src/main/resources/application.conf
+++ b/query/src/main/resources/application.conf
@@ -37,7 +37,7 @@ cassandra {
   port = 9042
   port = ${CASSANDRA_CLUSTER_PORT}
   keyspace = "hmda_query"
-  keyspace = ${CASSANDRA_CLUSTER_KEYSPACE}
+  keyspace = ${CASSANDRA_QUERY_KEYSPACE}
   retries = 60
   retry-interval = 1000
 }

--- a/query/src/main/resources/application.conf
+++ b/query/src/main/resources/application.conf
@@ -37,6 +37,7 @@ cassandra {
   port = 9042
   port = ${CASSANDRA_CLUSTER_PORT}
   keyspace = "hmda_query"
+  keyspace = ${CASSANDRA_CLUSTER_KEYSPACE}
   retries = 60
   retry-interval = 1000
 }

--- a/query/src/main/resources/application.conf
+++ b/query/src/main/resources/application.conf
@@ -37,7 +37,7 @@ cassandra {
   port = 9042
   port = ${CASSANDRA_CLUSTER_PORT}
   keyspace = "hmda_query"
-  keyspace = ${CASSANDRA_QUERY_KEYSPACE}
+  keyspace = ${?CASSANDRA_QUERY_KEYSPACE}
   retries = 60
   retry-interval = 1000
 }

--- a/query/src/main/scala/hmda/query/repository/CassandraRepository.scala
+++ b/query/src/main/scala/hmda/query/repository/CassandraRepository.scala
@@ -22,7 +22,7 @@ trait CassandraRepository[A] {
 
   val log = LoggerFactory.getLogger("CassandraRepository")
 
-  val keyspace = "hmda_query"
+  val keyspace = cassandraKeyspace
 
   @tailrec
   private def retry[T](n: Int)(fn: => T): Try[T] = {


### PR DESCRIPTION
Adds new configuration settings that can be overridden with environment variables:
- HMDA_CLUSTER_NAME
- CASSANDRA_JOURNAL_KEYSPACE
- CASSANDRA_SNAPSHOT_KEYSPACE
- CASSANDRA_QUERY_KEYSPACE

This will help avoid any namespace collision when attempting to run two different instances of the hmda-platform service.

Closes #1027 