### PR TITLE
Add yield comprehension to IRS

### DIFF
--- a/persistence/src/main/scala/hmda/persistence/processing/HmdaFileValidator.scala
+++ b/persistence/src/main/scala/hmda/persistence/processing/HmdaFileValidator.scala
@@ -258,7 +258,7 @@ class HmdaFileValidator(submissionId: SubmissionId) extends HmdaPersistentActor 
       if (state.readyToSign) {
         for {
           stat <- statRef
-        } stat ! PersistIrs
+        } yield stat ! PersistIrs
         log.debug(s"Validation completed for $submissionId")
         replyTo ! ValidationCompleted(originalSender)
       } else {


### PR DESCRIPTION
I'm not sure if this fixes the problem, but the error is definitely on line 261 either way.  If adding the `yield` statement doesn't fix the problem, it could just be that the message is never delivered to the stat actor.

Closes #1031 