### PR TITLE
Dependencies docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,11 @@ export ZOOKEEPER_HOST=192.168.99.100
 export ZOOKEEPER_PORT=2181
 ```
 
+Alternatively, these dependencies (`Cassandra`, `Zookeeper` and `PostgreSQL`) can be started from `docker` providing default resources for the `HMDA Platform`:
+
+`docker-compose -f docker-dev.yml up`
+
+
 * Start `sbt`
 
 ```shell

--- a/docker-dev.yml
+++ b/docker-dev.yml
@@ -1,0 +1,23 @@
+version: '2'
+
+services:
+  zookeeper:
+    image: jplock/zookeeper
+    ports:
+      - '2181:2181'
+
+  cassandra:
+    image: cassandra
+    ports:
+      - '9042:9042'
+      - '7000:7000'
+      - '7199:7199'
+
+  query_db:
+    image: postgres:9.6.1
+    ports:
+      - '54321:5432'
+    environment:
+      POSTGRES_DB: hmda
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres

--- a/query/src/main/resources/application.conf
+++ b/query/src/main/resources/application.conf
@@ -49,7 +49,7 @@ db {
   driver = "slick.driver.PostgresDriver$"
 
   db {
-    url = "jdbc:postgresql://localhost/hmda?user=postgres&password=postgres"
+    url = "jdbc:postgresql://192.168.99.100/hmda?user=postgres&password=postgres"
     url = ${?JDBC_URL}
     driver = org.postgresql.Driver
     numThreads = 2

--- a/query/src/main/resources/application.conf
+++ b/query/src/main/resources/application.conf
@@ -49,7 +49,7 @@ db {
   driver = "slick.driver.PostgresDriver$"
 
   db {
-    url = "jdbc:postgresql://192.168.99.100/hmda?user=postgres&password=postgres"
+    url = "jdbc:postgresql://192.168.99.100:54321/hmda?user=postgres&password=postgres"
     url = ${?JDBC_URL}
     driver = org.postgresql.Driver
     numThreads = 2


### PR DESCRIPTION
Configures the necessary dependencies for development of the HMDA Platform, so that `Cassandra`, `Zookeeper` and `PostgreSQL` can be brought up with one `docker-compose` command. Provides defaults in configuration files so that there is no need to configure environment variables for development. 