### PR TITLE
Include Institution name in Disclosure reports

### DIFF
--- a/model/shared/src/main/scala/hmda/model/institution/Institution.scala
+++ b/model/shared/src/main/scala/hmda/model/institution/Institution.scala
@@ -8,20 +8,23 @@ import hmda.model.institution.InstitutionType.UndeterminedInstitutionType
  * A financial institution, geared towards requirements for filing HMDA data.
  */
 case class Institution(
-  id: String,
-  agency: Agency,
-  activityYear: Int,
-  institutionType: InstitutionType,
-  cra: Boolean,
-  externalIds: Set[ExternalId],
-  emailDomains: Set[String],
-  respondent: Respondent,
-  hmdaFilerFlag: Boolean,
-  parent: Parent,
-  assets: Int,
-  otherLenderCode: Int,
-  topHolder: TopHolder
-)
+    id: String,
+    agency: Agency,
+    activityYear: Int,
+    institutionType: InstitutionType,
+    cra: Boolean,
+    externalIds: Set[ExternalId],
+    emailDomains: Set[String],
+    respondent: Respondent,
+    hmdaFilerFlag: Boolean,
+    parent: Parent,
+    assets: Int,
+    otherLenderCode: Int,
+    topHolder: TopHolder
+) {
+  def respondentId: String = respondent.externalId.value
+}
+
 case object Institution {
   def empty: Institution = Institution(
     "",

--- a/publication/src/main/scala/hmda/publication/reports/disclosure/D51.scala
+++ b/publication/src/main/scala/hmda/publication/reports/disclosure/D51.scala
@@ -66,7 +66,12 @@ object D51 {
   // Loan Type 2,3,4
   // Property Type 1,2
   // Purpose of Loan 1
-  def generate[ec: EC, mat: MAT, as: AS](larSource: Source[LoanApplicationRegisterQuery, NotUsed], fipsCode: Int, respId: String): Future[D51] = {
+  def generate[ec: EC, mat: MAT, as: AS](
+    larSource: Source[LoanApplicationRegisterQuery, NotUsed],
+    fipsCode: Int,
+    respId: String,
+    institutionNameF: Future[String]
+  ): Future[D51] = {
 
     val lars = larSource
       .filter(lar => lar.respondentId == respId)
@@ -96,6 +101,7 @@ object D51 {
       lars100To120BorrowerCharacteristics <- borrowerCharacteristicsByIncomeF(Between100And119PercentOfMSAMedian)
       lars120BorrowerCharacteristics <- borrowerCharacteristicsByIncomeF(GreaterThan120PercentOfMSAMedian)
 
+      institutionName <- institutionNameF
       date <- dateF
       total <- totalF
     } yield {
@@ -122,7 +128,7 @@ object D51 {
 
       D51(
         respId,
-        "",
+        institutionName,
         date,
         formatDate(Calendar.getInstance().toInstant),
         msa,

--- a/publication/src/main/scala/hmda/publication/reports/disclosure/DisclosureReports.scala
+++ b/publication/src/main/scala/hmda/publication/reports/disclosure/DisclosureReports.scala
@@ -1,25 +1,47 @@
 package hmda.publication.reports.disclosure
 
-import akka.actor.ActorSystem
+import akka.actor.{ ActorRef, ActorSystem }
+import akka.pattern.ask
 import akka.stream.ActorMaterializer
+import akka.util.Timeout
+import com.typesafe.config.ConfigFactory
+import hmda.model.institution.Institution
+import hmda.persistence.model.HmdaSupervisorActor.FindActorByName
 import hmda.publication.reports.protocol.disclosure.D51Protocol._
 import hmda.query.repository.filing.FilingCassandraRepository
+import hmda.query.view.institutions.InstitutionView
+import hmda.query.view.institutions.InstitutionView.GetInstitutionByRespondentId
 
 import scala.concurrent.Future
+import scala.concurrent.duration._
 import spray.json._
 
 class DisclosureReports(val sys: ActorSystem, val mat: ActorMaterializer) extends FilingCassandraRepository {
 
   override implicit def system: ActorSystem = sys
   override implicit def materializer: ActorMaterializer = mat
+  val config = ConfigFactory.load()
+  val duration = config.getInt("hmda.actor-lookup-timeout")
+  implicit val timeout = Timeout(duration.seconds)
 
   val larSource = readData(1000)
 
   def generateReports(fipsCode: Int, respId: String): Future[Unit] = {
-    val d51F = D51.generate(larSource, fipsCode, respId)
+    val institutionNameF = institutionName(respId)
+
+    val d51F = D51.generate(larSource, fipsCode, respId, institutionNameF)
     d51F.map { d51 =>
       println(d51.toJson.prettyPrint)
     }
+  }
+
+  private def institutionName(respondentId: String): Future[String] = {
+    val querySupervisor = system.actorSelection("/user/query-supervisor")
+    val fInstitutionsActor = (querySupervisor ? FindActorByName(InstitutionView.name)).mapTo[ActorRef]
+    for {
+      a <- fInstitutionsActor
+      i <- (a ? GetInstitutionByRespondentId(respondentId)).mapTo[Institution]
+    } yield i.respondent.name
   }
 
 }

--- a/publication/src/test/scala/hmda/publication/reports/disclosure/D51Spec.scala
+++ b/publication/src/test/scala/hmda/publication/reports/disclosure/D51Spec.scala
@@ -13,7 +13,7 @@ import hmda.query.repository.filing.LarConverter._
 import org.scalacheck.Gen
 import org.scalatest.{ MustMatchers, WordSpec }
 
-import scala.concurrent.Await
+import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
 
 class D51Spec extends WordSpec with MustMatchers with LarGenerators {
@@ -40,11 +40,12 @@ class D51Spec extends WordSpec with MustMatchers with LarGenerators {
   val expectedDispositions = List(ApplicationReceived, LoansOriginated, ApprovedButNotAccepted, ApplicationsDenied, ApplicationsWithdrawn, ClosedForIncompleteness)
 
   "Generate a Disclosure 5-1 report" in {
-    val result = Await.result(D51.generate(source, fips, respId), 5.seconds)
+    val result = Await.result(D51.generate(source, fips, respId, Future("Corvallis Test Bank")), 5.seconds)
 
     result.msa mustBe MSAReport("18700", "Corvallis, OR", "OR", "Oregon")
     result.table mustBe "5-1"
     result.respondentId mustBe "98765"
+    result.institutionName mustBe "Corvallis Test Bank"
     result.applicantIncomes.size mustBe 5
 
     val lowestIncome = result.applicantIncomes.head

--- a/query/src/main/scala/hmda/query/view/institutions/InstitutionView.scala
+++ b/query/src/main/scala/hmda/query/view/institutions/InstitutionView.scala
@@ -19,6 +19,7 @@ object InstitutionView {
   val name = "institutions-view"
 
   case class GetInstitutionById(institutionId: String) extends Command
+  case class GetInstitutionByRespondentId(respondentId: String) extends Command
   case class GetInstitutionsById(ids: List[String]) extends Command
   case class FindInstitutionByPeriodAndDomain(domain: String) extends Command
 
@@ -61,6 +62,12 @@ class InstitutionView extends HmdaPersistentActor {
   override def receiveCommand: Receive = {
     case GetInstitutionById(institutionId) =>
       val institution = state.institutions.find(i => i.id == institutionId).getOrElse(Institution.empty)
+      sender() ! institution
+
+    case GetInstitutionByRespondentId(respondentId) =>
+      val institution = state.institutions.find { i =>
+        i.respondent.externalId.value == respondentId
+      }.getOrElse(Institution.empty)
       sender() ! institution
 
     case GetInstitutionsById(ids) =>

--- a/query/src/test/scala/hmda/query/view/institutions/InstitutionViewSpec.scala
+++ b/query/src/test/scala/hmda/query/view/institutions/InstitutionViewSpec.scala
@@ -56,6 +56,11 @@ class InstitutionViewSpec extends ActorSpec {
       probe.send(institutionQuery, GetProjectionActorRef)
       probe.expectMsgType[ActorRef]
     }
+
+    "return institution by respondentId" in {
+      probe.send(institutionQuery, GetInstitutionByRespondentId(i1.respondent.externalId.value))
+      probe.expectMsg(i1)
+    }
   }
 
 }

--- a/query/src/test/scala/hmda/query/view/institutions/InstitutionViewSpec.scala
+++ b/query/src/test/scala/hmda/query/view/institutions/InstitutionViewSpec.scala
@@ -58,7 +58,7 @@ class InstitutionViewSpec extends ActorSpec {
     }
 
     "return institution by respondentId" in {
-      probe.send(institutionQuery, GetInstitutionByRespondentId(i1.respondent.externalId.value))
+      probe.send(institutionQuery, GetInstitutionByRespondentId(i1.respondentId))
       probe.expectMsg(i1)
     }
   }


### PR DESCRIPTION
Closes #1068 

Closes #1045 (We left that ticket open after the [`D5-1` PR](https://github.com/cfpb/hmda-platform/pull/1064) because `institutionName` was missing. This PR should complete that disclosure report.)