### PR TITLE
IRS Fix

### DIFF
--- a/persistence/src/main/scala/hmda/persistence/processing/HmdaFileValidator.scala
+++ b/persistence/src/main/scala/hmda/persistence/processing/HmdaFileValidator.scala
@@ -256,9 +256,13 @@ class HmdaFileValidator(submissionId: SubmissionId) extends HmdaPersistentActor 
 
     case CompleteValidation(replyTo, originalSender) =>
       if (state.readyToSign) {
+        log.info("Ready to persist IRS")
         for {
           stat <- statRef
-        } yield stat ! PersistIrs
+        } yield {
+          log.info("Sending IRS persistence message")
+          stat ! PersistIrs
+        }
         log.debug(s"Validation completed for $submissionId")
         replyTo ! ValidationCompleted(originalSender)
       } else {

--- a/persistence/src/main/scala/hmda/persistence/processing/HmdaFileValidator.scala
+++ b/persistence/src/main/scala/hmda/persistence/processing/HmdaFileValidator.scala
@@ -260,7 +260,7 @@ class HmdaFileValidator(submissionId: SubmissionId) extends HmdaPersistentActor 
         for {
           stat <- statRef
         } yield {
-          log.info("Sending IRS persistence message")
+          log.info(s"Sending IRS persistence message to SubmissionLarStats: $stat")
           stat ! PersistIrs
         }
         log.debug(s"Validation completed for $submissionId")

--- a/persistence/src/main/scala/hmda/persistence/processing/HmdaFileValidator.scala
+++ b/persistence/src/main/scala/hmda/persistence/processing/HmdaFileValidator.scala
@@ -115,7 +115,7 @@ class HmdaFileValidator(submissionId: SubmissionId) extends HmdaPersistentActor 
 
   val supervisor = system.actorSelection("/user/supervisor")
   val fHmdaFiling = (supervisor ? FindHmdaFiling(submissionId.period)).mapTo[ActorRef]
-  val statRef = for {
+  def statRef = for {
     manager <- (supervisor ? FindProcessingActor(SubmissionManager.name, submissionId)).mapTo[ActorRef]
     stat <- (manager ? GetActorRef(SubmissionLarStats.name)).mapTo[ActorRef]
   } yield stat
@@ -256,13 +256,6 @@ class HmdaFileValidator(submissionId: SubmissionId) extends HmdaPersistentActor 
 
     case CompleteValidation(replyTo, originalSender) =>
       if (state.readyToSign) {
-        log.info("Ready to persist IRS")
-        for {
-          stat <- statRef
-        } yield {
-          log.info(s"Sending IRS persistence message to SubmissionLarStats: $stat")
-          stat ! PersistIrs
-        }
         log.debug(s"Validation completed for $submissionId")
         replyTo ! ValidationCompleted(originalSender)
       } else {

--- a/validation/src/main/scala/hmda/validation/SubmissionLarStats.scala
+++ b/validation/src/main/scala/hmda/validation/SubmissionLarStats.scala
@@ -94,6 +94,7 @@ class SubmissionLarStats(submissionId: SubmissionId) extends HmdaPersistentActor
       tallyQ075Lar(lar)
       tallyQ076Lar(lar)
       msaMap = msaMap + lar
+      log.info("Msa Map: " + msaMap)
 
     case CountSubmittedLarsInSubmission =>
       persist(SubmittedLarsUpdated(totalSubmittedLars)) { e =>
@@ -129,8 +130,9 @@ class SubmissionLarStats(submissionId: SubmissionId) extends HmdaPersistentActor
 
     case PersistIrs =>
       val msaSeq = msaMap.msas.values.toSeq
+      log.info("SubmissionLarStats PersistIrs message received, about to persist IRS")
       persist(IrsStatsUpdated(msaSeq)) { e =>
-        log.debug(s"Persisted: $msaSeq")
+        log.info(s"Persisted: $msaSeq")
         updateState(e)
         val validationStats = context.actorSelection("/user/validation-stats")
         validationStats ! AddIrsStats(msaSeq, submissionId)

--- a/validation/src/main/scala/hmda/validation/SubmissionLarStats.scala
+++ b/validation/src/main/scala/hmda/validation/SubmissionLarStats.scala
@@ -94,7 +94,6 @@ class SubmissionLarStats(submissionId: SubmissionId) extends HmdaPersistentActor
       tallyQ075Lar(lar)
       tallyQ076Lar(lar)
       msaMap = msaMap + lar
-      log.info("Msa Map: " + msaMap)
 
     case CountSubmittedLarsInSubmission =>
       persist(SubmittedLarsUpdated(totalSubmittedLars)) { e =>
@@ -130,11 +129,11 @@ class SubmissionLarStats(submissionId: SubmissionId) extends HmdaPersistentActor
 
     case PersistIrs =>
       val msaSeq = msaMap.msas.values.toSeq
-      log.info("SubmissionLarStats PersistIrs message received, about to persist IRS")
+      log.info("PersistIrs message received at SubmissionLarStats, about to persist IRS")
       persist(IrsStatsUpdated(msaSeq)) { e =>
-        log.info(s"Persisted: $msaSeq")
         updateState(e)
         val validationStats = context.actorSelection("/user/validation-stats")
+        log.info(s"Persisted: $msaSeq, sending message to ValidationStats: $validationStats")
         validationStats ! AddIrsStats(msaSeq, submissionId)
       }
 

--- a/validation/src/main/scala/hmda/validation/SubmissionLarStats.scala
+++ b/validation/src/main/scala/hmda/validation/SubmissionLarStats.scala
@@ -124,16 +124,16 @@ class SubmissionLarStats(submissionId: SubmissionId) extends HmdaPersistentActor
           q075Ratio,
           q076Ratio
         )
+        self ! PersistIrs
         validationStats ! msg
       }
 
     case PersistIrs =>
       val msaSeq = msaMap.msas.values.toSeq
-      log.info("PersistIrs message received at SubmissionLarStats, about to persist IRS")
       persist(IrsStatsUpdated(msaSeq)) { e =>
+        log.debug(s"Persisted: $msaSeq")
         updateState(e)
         val validationStats = context.actorSelection("/user/validation-stats")
-        log.info(s"Persisted: $msaSeq, sending message to ValidationStats: $validationStats")
         validationStats ! AddIrsStats(msaSeq, submissionId)
       }
 

--- a/validation/src/main/scala/hmda/validation/ValidationStats.scala
+++ b/validation/src/main/scala/hmda/validation/ValidationStats.scala
@@ -148,6 +148,8 @@ class ValidationStats extends HmdaPersistentActor {
       sender ! state.latestStatsFor(id, period).totalValidatedLars
 
     case FindIrsStats(subId) =>
+      log.info(s"Finding IRS Stats for $subId")
+      log.info(s"Current stats are ${state.stats}")
       val stats = state.stats.find(s => s.id == subId).getOrElse(SubmissionStats(subId))
       sender ! stats.msas
 

--- a/validation/src/main/scala/hmda/validation/ValidationStats.scala
+++ b/validation/src/main/scala/hmda/validation/ValidationStats.scala
@@ -111,6 +111,7 @@ class ValidationStats extends HmdaPersistentActor {
   var state = ValidationStatsState()
 
   override def updateState(event: Event): Unit = {
+    log.info("ValidationStats event " + event)
     state = state.updated(event)
   }
 
@@ -134,8 +135,9 @@ class ValidationStats extends HmdaPersistentActor {
       }
 
     case AddIrsStats(map, id) =>
+      log.info("ValidationStats AddIrsStats message received")
       persist(IrsStatsAdded(map, id)) { e =>
-        log.debug(s"Persisted: $e")
+        log.info(s"Persisted: $e")
         updateState(e)
       }
 

--- a/validation/src/main/scala/hmda/validation/ValidationStats.scala
+++ b/validation/src/main/scala/hmda/validation/ValidationStats.scala
@@ -134,9 +134,8 @@ class ValidationStats extends HmdaPersistentActor {
       }
 
     case AddIrsStats(map, id) =>
-      log.info("ValidationStats AddIrsStats message received")
       persist(IrsStatsAdded(map, id)) { e =>
-        log.info(s"Persisted: $e")
+        log.debug(s"Persisted: $e")
         updateState(e)
       }
 
@@ -147,8 +146,6 @@ class ValidationStats extends HmdaPersistentActor {
       sender ! state.latestStatsFor(id, period).totalValidatedLars
 
     case FindIrsStats(subId) =>
-      log.info(s"Finding IRS Stats for $subId")
-      log.info(s"Current stats are ${state.stats}")
       val stats = state.stats.find(s => s.id == subId).getOrElse(SubmissionStats(subId))
       sender ! stats.msas
 

--- a/validation/src/main/scala/hmda/validation/ValidationStats.scala
+++ b/validation/src/main/scala/hmda/validation/ValidationStats.scala
@@ -111,7 +111,6 @@ class ValidationStats extends HmdaPersistentActor {
   var state = ValidationStatsState()
 
   override def updateState(event: Event): Unit = {
-    log.info("ValidationStats event " + event)
     state = state.updated(event)
   }
 


### PR DESCRIPTION
There were two problems that were occurring.

- First, the `SubmissionLarStats` ActorRef was [being calculated a single time](https://github.com/cfpb/hmda-platform/blob/master/persistence/src/main/scala/hmda/persistence/processing/HmdaFileValidator.scala#L118-L121) by the `HmdaFileValidator`.  This meant that if the `SubmissionLarStats` actor died and was restarted, the stored ActorRef wouldn't have changed and the `PersistIrs` message would fail to send.  Switching this ActorRef from `val` to `def` means it is recalculated every time it is called, avoiding this error.
- Second, if the `SubmissionLarStats` actor timed out and died, it would lose any variables that hadn't been persisted.  When the actor restarted, it would be with a clean slate (minus the persisted state).  This is fixed by persisting the IRS report much sooner, at the same time as the stats for the Macro edits.

Closes #1031 