### PR TITLE
Fix for Filing Status Bugs

### DIFF
--- a/persistence/src/main/scala/hmda/persistence/institutions/FilingPersistence.scala
+++ b/persistence/src/main/scala/hmda/persistence/institutions/FilingPersistence.scala
@@ -12,7 +12,7 @@ object FilingPersistence {
   val name = "filings"
 
   case class CreateFiling(filing: Filing) extends Command
-  case class UpdateFilingStatus(filing: Filing) extends Command
+  case class UpdateFilingStatus(period: String, status: FilingStatus) extends Command
   case class GetFilingByPeriod(period: String) extends Command
 
   def props(institutionId: String): Props = Props(new FilingPersistence(institutionId))
@@ -59,27 +59,20 @@ class FilingPersistence(institutionId: String) extends HmdaPersistentActor {
         log.warning(s"Could not create Filing. Filing period ${f.period} already exists for institution $institutionId.")
       }
 
-    case UpdateFilingStatus(modified) =>
-      if (state.filings.map(x => x.period).contains(modified.period)) {
-        val start = if (modified.status == InProgress) {
-          System.currentTimeMillis
-        } else {
-          modified.start
-        }
-        val end = if (modified.status == Completed) {
-          System.currentTimeMillis
-        } else {
-          modified.end
-        }
-        val updatedFiling = modified.copy(start = start, end = end)
-        persist(FilingStatusUpdated(updatedFiling)) { e =>
-          log.debug(s"persisted: $updatedFiling")
-          updateState(e)
-          sender() ! Some(updatedFiling)
-        }
-      } else {
-        sender() ! None
-        log.warning(s"Period does not exist. Could not update $modified")
+    case UpdateFilingStatus(period, newStatus) =>
+      state.filings.find(f => f.period == period) match {
+        case Some(filing) =>
+          val startTime = if (newStatus == InProgress) System.currentTimeMillis else filing.start
+          val endTime = if (newStatus == Completed) System.currentTimeMillis else filing.end
+          val updatedFiling = filing.copy(status = newStatus, start = startTime, end = endTime)
+          persist(FilingStatusUpdated(updatedFiling)) { e =>
+            log.debug(s"persisted: $updatedFiling")
+            updateState(e)
+            sender() ! Some(updatedFiling)
+          }
+        case None =>
+          sender() ! None
+          log.warning(s"Could not update filing status. Institution $institutionId, filing period $period")
       }
 
     case GetFilingByPeriod(period) =>

--- a/persistence/src/main/scala/hmda/persistence/institutions/FilingPersistence.scala
+++ b/persistence/src/main/scala/hmda/persistence/institutions/FilingPersistence.scala
@@ -57,6 +57,9 @@ class FilingPersistence(institutionId: String) extends HmdaPersistentActor {
 
     case UpdateFilingStatus(period, newStatus) =>
       state.filings.find(f => f.period == period) match {
+        case Some(filing) if filing.status == Completed =>
+          sender() ! None
+          log.debug(s"$period Filing for Institution $institutionId is already Completed. Not updating status")
         case Some(filing) =>
           val startTime = if (newStatus == InProgress) System.currentTimeMillis else filing.start
           val endTime = if (newStatus == Completed) System.currentTimeMillis else filing.end

--- a/persistence/src/main/scala/hmda/persistence/institutions/FilingPersistence.scala
+++ b/persistence/src/main/scala/hmda/persistence/institutions/FilingPersistence.scala
@@ -1,7 +1,7 @@
 package hmda.persistence.institutions
 
 import akka.actor.{ ActorRef, ActorSystem, Props }
-import hmda.model.fi.{ Completed, Filing, InProgress, NotStarted }
+import hmda.model.fi._
 import hmda.persistence.messages.CommonMessages._
 import hmda.persistence.institutions.FilingPersistence._
 import hmda.persistence.model.HmdaPersistentActor
@@ -48,7 +48,7 @@ class FilingPersistence(institutionId: String) extends HmdaPersistentActor {
 
   override def receiveCommand: Receive = super.receiveCommand orElse {
     case CreateFiling(f) =>
-      if (!state.filings.contains(f)) {
+      if (!state.filings.map(_.period).contains(f.period)) {
         persist(FilingCreated(f)) { e =>
           log.debug(s"Persisted: $f")
           updateState(e)
@@ -56,7 +56,7 @@ class FilingPersistence(institutionId: String) extends HmdaPersistentActor {
         }
       } else {
         sender() ! None
-        log.warning(s"Filing already exists. Could not create $f")
+        log.warning(s"Could not create Filing. Filing period ${f.period} already exists for institution $institutionId.")
       }
 
     case UpdateFilingStatus(modified) =>

--- a/persistence/src/main/scala/hmda/persistence/processing/SubmissionManager.scala
+++ b/persistence/src/main/scala/hmda/persistence/processing/SubmissionManager.scala
@@ -166,9 +166,8 @@ class SubmissionManager(submissionId: SubmissionId) extends HmdaActor {
   private def updateFilingStatus(filingStatus: FilingStatus) = {
     for {
       p <- filingPersistence
-      f <- (p ? GetFilingByPeriod(period)).mapTo[Filing]
     } yield {
-      p ? UpdateFilingStatus(f.copy(status = filingStatus))
+      p ? UpdateFilingStatus(period, filingStatus)
     }
   }
 

--- a/persistence/src/main/scala/hmda/persistence/processing/SubmissionManager.scala
+++ b/persistence/src/main/scala/hmda/persistence/processing/SubmissionManager.scala
@@ -164,11 +164,7 @@ class SubmissionManager(submissionId: SubmissionId) extends HmdaActor {
   }
 
   private def updateFilingStatus(filingStatus: FilingStatus) = {
-    for {
-      p <- filingPersistence
-    } yield {
-      p ? UpdateFilingStatus(period, filingStatus)
-    }
+    filingPersistence.map(_ ? UpdateFilingStatus(period, filingStatus))
   }
 
 }

--- a/persistence/src/test/resources/application.conf
+++ b/persistence/src/test/resources/application.conf
@@ -14,4 +14,5 @@ akka.test.single-expect-default = 10s
 
 hmda {
   isDemo = false
+  edits.demoMode = false
 }

--- a/persistence/src/test/scala/hmda/persistence/institutions/FilingPersistenceSpec.scala
+++ b/persistence/src/test/scala/hmda/persistence/institutions/FilingPersistenceSpec.scala
@@ -25,11 +25,12 @@ class FilingPersistenceSpec extends ActorSpec {
       probe.send(filingsActor, GetState)
       probe.expectMsg(filings.reverse)
     }
-    "return None when persisting a filing period that already exists" in {
+    "return Some when creating filing for period with no filings" in {
       val f1 = Filing("2018", "12345", Completed, true, 1483287071000L, 1514736671000L)
       probe.send(filingsActor, CreateFiling(f1))
       probe.expectMsg(Some(f1))
-
+    }
+    "return None when persisting a filing period that already has a filing" in {
       val f2 = Filing("2016", "12345", InProgress, true, 1483287071000L, 0L)
       probe.send(filingsActor, CreateFiling(f2))
       probe.expectMsg(None)

--- a/persistence/src/test/scala/hmda/persistence/institutions/FilingPersistenceSpec.scala
+++ b/persistence/src/test/scala/hmda/persistence/institutions/FilingPersistenceSpec.scala
@@ -11,11 +11,14 @@ class FilingPersistenceSpec extends ActorSpec {
 
   val filingsActor = createFilings("12345", system)
 
+  val sample1 = Filing("2016", "12345", Completed, filingRequired = true, 1483287071000L, 1514736671000L)
+  val sample2 = Filing("2017", "12345", NotStarted, filingRequired = true, 0L, 0L)
+
   val probe = TestProbe()
 
-  "Filings" must {
-    "be created and read back" in {
-      val filings = DemoData.testFilings
+  "CreateFiling" must {
+    "create a filing" in {
+      val filings = Seq(sample1, sample2)
       for (filing <- filings) {
         probe.send(filingsActor, CreateFiling(filing))
         probe.expectMsg(Some(filing))
@@ -32,12 +35,12 @@ class FilingPersistenceSpec extends ActorSpec {
       probe.expectMsg(modified)
     }
 
-    "return None when persisting a filing that already exists" in {
-      val f1 = Filing("2016", "12345", Completed, true, 1483287071000L, 1514736671000L)
+    "return None when persisting a filing period that already exists" in {
+      val f1 = Filing("2018", "12345", Completed, true, 1483287071000L, 1514736671000L)
       probe.send(filingsActor, CreateFiling(f1))
       probe.expectMsg(Some(f1))
 
-      val f2 = Filing("2016", "12345", Completed, true, 1483287071000L, 1514736671000L)
+      val f2 = Filing("2016", "12345", InProgress, true, 1483287071000L, 0L)
       probe.send(filingsActor, CreateFiling(f2))
       probe.expectMsg(None)
     }

--- a/persistence/src/test/scala/hmda/persistence/institutions/FilingPersistenceSpec.scala
+++ b/persistence/src/test/scala/hmda/persistence/institutions/FilingPersistenceSpec.scala
@@ -10,7 +10,7 @@ class FilingPersistenceSpec extends ActorSpec {
 
   val filingsActor = createFilings("12345", system)
 
-  val sample1 = Filing("2016", "12345", Completed, filingRequired = true, 1483287071000L, 1514736671000L)
+  val sample1 = Filing("2016", "12345", Cancelled, filingRequired = true, 1483287071000L, 1514736671000L)
   val sample2 = Filing("2017", "12345", NotStarted, filingRequired = true, 0L, 0L)
 
   val probe = TestProbe()
@@ -38,8 +38,8 @@ class FilingPersistenceSpec extends ActorSpec {
 
   "UpdateFilingStatus" must {
     "update status of filing for given period" in {
-      val expected = sample1.copy(status = Cancelled)
-      probe.send(filingsActor, UpdateFilingStatus("2016", Cancelled))
+      val expected = sample1.copy(status = NotStarted)
+      probe.send(filingsActor, UpdateFilingStatus("2016", NotStarted))
       probe.expectMsg(Some(expected))
       probe.send(filingsActor, GetFilingByPeriod("2016"))
       probe.expectMsg(expected)
@@ -61,6 +61,10 @@ class FilingPersistenceSpec extends ActorSpec {
       comp.status mustBe Completed
       comp.start mustBe startTime
       comp.end must be > 0L
+    }
+    "not update if filing status is already 'Completed'" in {
+      probe.send(filingsActor, UpdateFilingStatus("2017", InProgress))
+      probe.expectMsg(None)
     }
   }
 

--- a/validation/src/test/resources/application.conf
+++ b/validation/src/test/resources/application.conf
@@ -15,5 +15,6 @@ akka {
 
 hmda {
   isDemo = false
+  edits.demoMode = false
   persistent-actor-timeout = 60
 }


### PR DESCRIPTION
Closes #1115 

Also, fixes two bugs:
1. `CreateFiling` could previously persist multiple filings per filing period. Now it checks for duplicate filing periods before persisting new filings.
2. `UpdateFilingStatus` could previously overwrite all fields of a `Filing` object, not just the `status` and timestamps. Now it only updates the fields it should.