### PR TITLE
Fix SubmissionSummary Intermittent Spec Failure

### DIFF
--- a/model/shared/src/test/scala/hmda/model/institution/SubmissionGenerators.scala
+++ b/model/shared/src/test/scala/hmda/model/institution/SubmissionGenerators.scala
@@ -34,7 +34,8 @@ object SubmissionGenerators {
       status <- submissionStatusGen
       start <- Gen.choose(1483287071000L, 1514736671000L)
       end <- Gen.choose(1483287071000L, 1514736671000L)
+      fileName <- Gen.alphaStr
       receipt <- Gen.alphaStr
-    } yield Submission(id, status, start, end, receipt)
+    } yield Submission(id, status, start, end, fileName, receipt)
   }
 }

--- a/persistence/src/main/scala/hmda/persistence/processing/HmdaFileParser.scala
+++ b/persistence/src/main/scala/hmda/persistence/processing/HmdaFileParser.scala
@@ -64,11 +64,7 @@ class HmdaFileParser(submissionId: SubmissionId) extends HmdaPersistentActor {
   var state = HmdaFileParseState()
   var encounteredParsingErrors: Boolean = false
   val manager = context.parent
-  val statRef = for {
-    stat <- (manager ? GetActorRef(SubmissionLarStats.name)).mapTo[ActorRef]
-  } yield {
-    stat
-  }
+  val statRef = (manager ? GetActorRef(SubmissionLarStats.name)).mapTo[ActorRef]
 
   var tsParsingDone: Boolean = false
   var larParsingDone: Boolean = false
@@ -104,7 +100,7 @@ class HmdaFileParser(submissionId: SubmissionId) extends HmdaPersistentActor {
         .zip(Source.fromIterator(() => Iterator.from(2)))
         .map {
           case (lar, index) =>
-            sendLar(lar)
+            statRef.map(_ ! lar)
             LarCsvParser(lar, index)
         }
         .map {
@@ -172,12 +168,6 @@ class HmdaFileParser(submissionId: SubmissionId) extends HmdaPersistentActor {
     case Shutdown =>
       context stop self
 
-  }
-
-  private def sendLar(s: String) {
-    for {
-      stat <- statRef
-    } yield stat ! s
   }
 }
 


### PR DESCRIPTION
1. Solve intermittent failure in `SubmissionSummaryPathsSpec`. Do this by ensuring that all parsing is finished (TS and LARs) before moving on to validation step
2. Minorly refactor `HmdaFileValidator`: When an action is going to happen regardless of validation outcome (e.g. sending the validated LAR to be persisted), do that action before validation.
3. Improve `SubmissionGenerator` by including `fileName`

Related to #1129 