### PR TITLE
Refactor Cassandra Projection for lar filing

### DIFF
--- a/publication/src/main/scala/hmda/publication/reports/aggregate/A52.scala
+++ b/publication/src/main/scala/hmda/publication/reports/aggregate/A52.scala
@@ -2,21 +2,21 @@ package hmda.publication.reports.aggregate
 
 import akka.NotUsed
 import akka.stream.scaladsl.Source
+import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.publication.reports._
-import hmda.query.model.filing.LoanApplicationRegisterQuery
 
 import scala.concurrent.Future
 
 object A52 {
 
-  def filters(lar: LoanApplicationRegisterQuery): Boolean = {
-    (lar.loanType == 1) &&
-      (lar.propertyType == 1 || lar.propertyType == 2) &&
-      (lar.purpose == 1)
+  def filters(lar: LoanApplicationRegister): Boolean = {
+    (lar.loan.loanType == 1) &&
+      (lar.loan.propertyType == 1 || lar.loan.propertyType == 2) &&
+      (lar.loan.purpose == 1)
   }
 
   def generate[ec: EC, mat: MAT, as: AS](
-    larSource: Source[LoanApplicationRegisterQuery, NotUsed],
+    larSource: Source[LoanApplicationRegister, NotUsed],
     fipsCode: Int
   ): Future[A5X] = A5X.generate("A52", larSource, fipsCode, filters)
 }

--- a/publication/src/main/scala/hmda/publication/reports/aggregate/A53.scala
+++ b/publication/src/main/scala/hmda/publication/reports/aggregate/A53.scala
@@ -2,20 +2,20 @@ package hmda.publication.reports.aggregate
 
 import akka.NotUsed
 import akka.stream.scaladsl.Source
+import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.publication.reports._
-import hmda.query.model.filing.LoanApplicationRegisterQuery
 
 import scala.concurrent.Future
 
 object A53 {
 
-  def filters(lar: LoanApplicationRegisterQuery): Boolean = {
-    (lar.propertyType == 1 || lar.propertyType == 2) &&
-      (lar.purpose == 3)
+  def filters(lar: LoanApplicationRegister): Boolean = {
+    (lar.loan.propertyType == 1 || lar.loan.propertyType == 2) &&
+      (lar.loan.purpose == 3)
   }
 
   def generate[ec: EC, mat: MAT, as: AS](
-    larSource: Source[LoanApplicationRegisterQuery, NotUsed],
+    larSource: Source[LoanApplicationRegister, NotUsed],
     fipsCode: Int
   ): Future[A5X] = A5X.generate("A53", larSource, fipsCode, filters)
 

--- a/publication/src/main/scala/hmda/publication/reports/aggregate/A5X.scala
+++ b/publication/src/main/scala/hmda/publication/reports/aggregate/A5X.scala
@@ -2,11 +2,11 @@ package hmda.publication.reports.aggregate
 
 import akka.NotUsed
 import akka.stream.scaladsl.Source
+import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.model.publication.reports.{ ApplicantIncome, Disposition, MSAReport }
 import hmda.publication.reports._
 import hmda.publication.reports.util.ReportUtil._
 import hmda.publication.reports.util.ReportsMetaDataLookup
-import hmda.query.model.filing.LoanApplicationRegisterQuery
 
 import scala.concurrent.Future
 
@@ -23,20 +23,20 @@ case class A5X(
 object A5X {
   def generate[ec: EC, mat: MAT, as: AS](
     reportId: String,
-    larSource: Source[LoanApplicationRegisterQuery, NotUsed],
+    larSource: Source[LoanApplicationRegister, NotUsed],
     fipsCode: Int,
-    filters: LoanApplicationRegisterQuery => Boolean
+    filters: LoanApplicationRegister => Boolean
   ): Future[A5X] = {
 
     val metaData = ReportsMetaDataLookup.values(reportId)
     val dispositions = metaData.dispositions
 
     val lars = larSource
-      .filter(lar => lar.msa != "NA")
-      .filter(lar => lar.msa.toInt == fipsCode)
+      .filter(lar => lar.geography.msa != "NA")
+      .filter(lar => lar.geography.msa.toInt == fipsCode)
       .filter(filters)
 
-    val larsWithIncome = lars.filter(lar => lar.income != "NA")
+    val larsWithIncome = lars.filter(lar => lar.applicant.income != "NA")
 
     val msa = msaReport(fipsCode.toString)
 

--- a/publication/src/main/scala/hmda/publication/reports/aggregate/AggregateReports.scala
+++ b/publication/src/main/scala/hmda/publication/reports/aggregate/AggregateReports.scala
@@ -3,7 +3,6 @@ package hmda.publication.reports.aggregate
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.util.Timeout
-import com.typesafe.config.ConfigFactory
 import hmda.query.repository.filing.FilingCassandraRepository
 import hmda.publication.reports.protocol.aggregate.A5XProtocol._
 
@@ -16,7 +15,6 @@ class AggregateReports(val sys: ActorSystem, val mat: ActorMaterializer) extends
 
   override implicit def system: ActorSystem = sys
   override implicit def materializer: ActorMaterializer = mat
-  val config = ConfigFactory.load()
   val duration = config.getInt("hmda.actor-lookup-timeout")
   implicit val timeout = Timeout(duration.seconds)
 

--- a/publication/src/main/scala/hmda/publication/reports/disclosure/D51.scala
+++ b/publication/src/main/scala/hmda/publication/reports/disclosure/D51.scala
@@ -2,21 +2,21 @@ package hmda.publication.reports.disclosure
 
 import akka.NotUsed
 import akka.stream.scaladsl.Source
+import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.publication.reports._
-import hmda.query.model.filing.LoanApplicationRegisterQuery
 
 import scala.concurrent.Future
 
 object D51 {
 
-  def filters(lar: LoanApplicationRegisterQuery): Boolean = {
-    (lar.loanType == 2 || lar.loanType == 3 || lar.loanType == 4) &&
-      (lar.propertyType == 1 || lar.propertyType == 2) &&
-      (lar.purpose == 1)
+  def filters(lar: LoanApplicationRegister): Boolean = {
+    (lar.loan.loanType == 2 || lar.loan.loanType == 3 || lar.loan.loanType == 4) &&
+      (lar.loan.propertyType == 1 || lar.loan.propertyType == 2) &&
+      (lar.loan.purpose == 1)
   }
 
   def generate[ec: EC, mat: MAT, as: AS](
-    larSource: Source[LoanApplicationRegisterQuery, NotUsed],
+    larSource: Source[LoanApplicationRegister, NotUsed],
     fipsCode: Int,
     respondentId: String,
     institutionNameF: Future[String]

--- a/publication/src/main/scala/hmda/publication/reports/disclosure/D52.scala
+++ b/publication/src/main/scala/hmda/publication/reports/disclosure/D52.scala
@@ -2,21 +2,21 @@ package hmda.publication.reports.disclosure
 
 import akka.NotUsed
 import akka.stream.scaladsl.Source
+import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.publication.reports._
-import hmda.query.model.filing.LoanApplicationRegisterQuery
 
 import scala.concurrent.Future
 
 object D52 {
 
-  def filters(lar: LoanApplicationRegisterQuery): Boolean = {
-    (lar.loanType == 1) &&
-      (lar.propertyType == 1 || lar.propertyType == 2) &&
-      (lar.purpose == 1)
+  def filters(lar: LoanApplicationRegister): Boolean = {
+    (lar.loan.loanType == 1) &&
+      (lar.loan.propertyType == 1 || lar.loan.propertyType == 2) &&
+      (lar.loan.purpose == 1)
   }
 
   def generate[ec: EC, mat: MAT, as: AS](
-    larSource: Source[LoanApplicationRegisterQuery, NotUsed],
+    larSource: Source[LoanApplicationRegister, NotUsed],
     fipsCode: Int,
     respondentId: String,
     institutionNameF: Future[String]

--- a/publication/src/main/scala/hmda/publication/reports/disclosure/D53.scala
+++ b/publication/src/main/scala/hmda/publication/reports/disclosure/D53.scala
@@ -2,20 +2,20 @@ package hmda.publication.reports.disclosure
 
 import akka.NotUsed
 import akka.stream.scaladsl.Source
+import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.publication.reports._
-import hmda.query.model.filing.LoanApplicationRegisterQuery
 
 import scala.concurrent.Future
 
 object D53 {
 
-  def filters(lar: LoanApplicationRegisterQuery): Boolean = {
-    (lar.propertyType == 1 || lar.propertyType == 2) &&
-      (lar.purpose == 3)
+  def filters(lar: LoanApplicationRegister): Boolean = {
+    (lar.loan.propertyType == 1 || lar.loan.propertyType == 2) &&
+      (lar.loan.purpose == 3)
   }
 
   def generate[ec: EC, mat: MAT, as: AS](
-    larSource: Source[LoanApplicationRegisterQuery, NotUsed],
+    larSource: Source[LoanApplicationRegister, NotUsed],
     fipsCode: Int,
     respondentId: String,
     institutionNameF: Future[String]

--- a/publication/src/main/scala/hmda/publication/reports/disclosure/D5X.scala
+++ b/publication/src/main/scala/hmda/publication/reports/disclosure/D5X.scala
@@ -5,8 +5,8 @@ import hmda.publication.reports.util.ReportsMetaDataLookup
 import hmda.publication.reports.util.ReportUtil._
 import akka.NotUsed
 import akka.stream.scaladsl.Source
+import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.publication.reports._
-import hmda.query.model.filing.LoanApplicationRegisterQuery
 
 import scala.concurrent.Future
 
@@ -25,8 +25,8 @@ case class D5X(
 object D5X {
   def generate[ec: EC, mat: MAT, as: AS](
     reportId: String,
-    filters: LoanApplicationRegisterQuery => Boolean,
-    larSource: Source[LoanApplicationRegisterQuery, NotUsed],
+    filters: LoanApplicationRegister => Boolean,
+    larSource: Source[LoanApplicationRegister, NotUsed],
     fipsCode: Int,
     respondentId: String,
     institutionNameF: Future[String]
@@ -37,11 +37,11 @@ object D5X {
 
     val lars = larSource
       .filter(lar => lar.respondentId == respondentId)
-      .filter(lar => lar.msa != "NA")
-      .filter(lar => lar.msa.toInt == fipsCode)
+      .filter(lar => lar.geography.msa != "NA")
+      .filter(lar => lar.geography.msa.toInt == fipsCode)
       .filter(filters)
 
-    val larsWithIncome = lars.filter(lar => lar.income != "NA")
+    val larsWithIncome = lars.filter(lar => lar.applicant.income != "NA")
 
     val msa = msaReport(fipsCode.toString)
 

--- a/publication/src/main/scala/hmda/publication/reports/disclosure/DisclosureReports.scala
+++ b/publication/src/main/scala/hmda/publication/reports/disclosure/DisclosureReports.scala
@@ -4,7 +4,6 @@ import akka.actor.{ ActorRef, ActorSystem }
 import akka.pattern.ask
 import akka.stream.ActorMaterializer
 import akka.util.Timeout
-import com.typesafe.config.ConfigFactory
 import hmda.model.institution.Institution
 import hmda.persistence.model.HmdaSupervisorActor.FindActorByName
 import hmda.publication.reports.protocol.disclosure.D5XProtocol._
@@ -20,7 +19,6 @@ class DisclosureReports(val sys: ActorSystem, val mat: ActorMaterializer) extend
 
   override implicit def system: ActorSystem = sys
   override implicit def materializer: ActorMaterializer = mat
-  val config = ConfigFactory.load()
   val duration = config.getInt("hmda.actor-lookup-timeout")
   implicit val timeout = Timeout(duration.seconds)
 

--- a/publication/src/main/scala/hmda/publication/reports/national/N52.scala
+++ b/publication/src/main/scala/hmda/publication/reports/national/N52.scala
@@ -3,12 +3,12 @@ package hmda.publication.reports.national
 import akka.NotUsed
 import akka.stream.scaladsl.Source
 import hmda.census.model.MsaIncomeLookup
+import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.model.publication.reports._
 import hmda.publication.reports._
 import hmda.publication.reports.aggregate.{ A52, A5X }
 import hmda.publication.reports.util.ReportUtil._
 import hmda.publication.reports.util.ReportsMetaDataLookup
-import hmda.query.model.filing.LoanApplicationRegisterQuery
 
 import scala.concurrent.Future
 
@@ -61,7 +61,7 @@ object N52 {
   // Loan Type 1
   // Property Type 1,2
   // Purpose of Loan 1
-  def generate[ec: EC, mat: MAT, as: AS](larSource: Source[LoanApplicationRegisterQuery, NotUsed]): Future[N52] = {
+  def generate[ec: EC, mat: MAT, as: AS](larSource: Source[LoanApplicationRegister, NotUsed]): Future[N52] = {
     val fipsList = MsaIncomeLookup.values.map(_.fips).filterNot(_ == 99999)
 
     val a52List = fipsList.map(fipsCode => A52.generate(larSource, fipsCode))

--- a/publication/src/main/scala/hmda/publication/reports/national/NationalAggregateReports.scala
+++ b/publication/src/main/scala/hmda/publication/reports/national/NationalAggregateReports.scala
@@ -3,7 +3,6 @@ package hmda.publication.reports.national
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.util.Timeout
-import com.typesafe.config.ConfigFactory
 import hmda.query.repository.filing.FilingCassandraRepository
 import hmda.publication.reports.protocol.national.N52Protocol._
 
@@ -14,7 +13,6 @@ import spray.json._
 class NationalAggregateReports(val sys: ActorSystem, val mat: ActorMaterializer) extends FilingCassandraRepository {
   override implicit def system: ActorSystem = sys
   override implicit def materializer: ActorMaterializer = mat
-  val config = ConfigFactory.load()
   val duration = config.getInt("hmda.actor-lookup-timeout")
   implicit val timeout = Timeout(duration.seconds)
 

--- a/publication/src/main/scala/hmda/publication/reports/util/DispositionType.scala
+++ b/publication/src/main/scala/hmda/publication/reports/util/DispositionType.scala
@@ -2,10 +2,10 @@ package hmda.publication.reports.util
 
 import akka.NotUsed
 import akka.stream.scaladsl.Source
+import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.model.publication.reports.ActionTakenTypeEnum._
 import hmda.model.publication.reports._
 import hmda.publication.reports.{ AS, EC, MAT }
-import hmda.query.model.filing.LoanApplicationRegisterQuery
 import hmda.util.SourceUtils
 
 import scala.concurrent.Future
@@ -28,11 +28,11 @@ object DispositionType {
   }
 
   sealed trait DispositionType extends SourceUtils {
-    def filter(lar: LoanApplicationRegisterQuery): Boolean
+    def filter(lar: LoanApplicationRegister): Boolean
 
     def actionTaken: ActionTakenTypeEnum
 
-    def calculateDisposition[ec: EC, mat: MAT, as: AS](larSource: Source[LoanApplicationRegisterQuery, NotUsed]): Future[Disposition] = {
+    def calculateDisposition[ec: EC, mat: MAT, as: AS](larSource: Source[LoanApplicationRegister, NotUsed]): Future[Disposition] = {
       val loansFiltered = larSource.filter(filter)
       val loanCountF = count(loansFiltered)
       val incomeF = sum(loansFiltered, incomeSum)
@@ -44,45 +44,45 @@ object DispositionType {
       }
     }
 
-    private def incomeSum(lar: LoanApplicationRegisterQuery): Int = Try(lar.income.toInt).getOrElse(0)
+    private def incomeSum(lar: LoanApplicationRegister): Int = Try(lar.applicant.income.toInt).getOrElse(0)
   }
 
   object ReceivedDisp extends DispositionType {
-    override def filter(lar: LoanApplicationRegisterQuery): Boolean =
+    override def filter(lar: LoanApplicationRegister): Boolean =
       lar.actionTakenType == 1 || lar.actionTakenType == 2 || lar.actionTakenType == 3 ||
         lar.actionTakenType == 4 || lar.actionTakenType == 5
     override def actionTaken: ActionTakenTypeEnum = ApplicationReceived
   }
   object OriginatedDisp extends DispositionType {
-    override def filter(lar: LoanApplicationRegisterQuery): Boolean = lar.actionTakenType == 1
+    override def filter(lar: LoanApplicationRegister): Boolean = lar.actionTakenType == 1
     override def actionTaken: ActionTakenTypeEnum = LoansOriginated
   }
   object ApprovedButNotAcceptedDisp extends DispositionType {
-    override def filter(lar: LoanApplicationRegisterQuery): Boolean = lar.actionTakenType == 2
+    override def filter(lar: LoanApplicationRegister): Boolean = lar.actionTakenType == 2
     override def actionTaken: ActionTakenTypeEnum = ApprovedButNotAccepted
   }
   object DeniedDisp extends DispositionType {
-    override def filter(lar: LoanApplicationRegisterQuery): Boolean = lar.actionTakenType == 3
+    override def filter(lar: LoanApplicationRegister): Boolean = lar.actionTakenType == 3
     override def actionTaken: ActionTakenTypeEnum = ApplicationsDenied
   }
   object WithdrawnDisp extends DispositionType {
-    override def filter(lar: LoanApplicationRegisterQuery): Boolean = lar.actionTakenType == 4
+    override def filter(lar: LoanApplicationRegister): Boolean = lar.actionTakenType == 4
     override def actionTaken: ActionTakenTypeEnum = ApplicationsWithdrawn
   }
   object ClosedDisp extends DispositionType {
-    override def filter(lar: LoanApplicationRegisterQuery): Boolean = lar.actionTakenType == 5
+    override def filter(lar: LoanApplicationRegister): Boolean = lar.actionTakenType == 5
     override def actionTaken: ActionTakenTypeEnum = ClosedForIncompleteness
   }
   object PurchasedDisp extends DispositionType {
-    override def filter(lar: LoanApplicationRegisterQuery): Boolean = lar.actionTakenType == 6
+    override def filter(lar: LoanApplicationRegister): Boolean = lar.actionTakenType == 6
     override def actionTaken: ActionTakenTypeEnum = LoanPurchased
   }
   object PreapprovalDeniedDisp extends DispositionType {
-    override def filter(lar: LoanApplicationRegisterQuery): Boolean = lar.actionTakenType == 7
+    override def filter(lar: LoanApplicationRegister): Boolean = lar.actionTakenType == 7
     override def actionTaken: ActionTakenTypeEnum = PreapprovalDenied
   }
   object PreapprovalApprovedDisp extends DispositionType {
-    override def filter(lar: LoanApplicationRegisterQuery): Boolean = lar.actionTakenType == 8
+    override def filter(lar: LoanApplicationRegister): Boolean = lar.actionTakenType == 8
     override def actionTaken: ActionTakenTypeEnum = PreapprovalApprovedButNotAccepted
   }
 

--- a/publication/src/main/scala/hmda/publication/reports/util/EthnicityUtil.scala
+++ b/publication/src/main/scala/hmda/publication/reports/util/EthnicityUtil.scala
@@ -2,45 +2,45 @@ package hmda.publication.reports.util
 
 import akka.NotUsed
 import akka.stream.scaladsl.Source
+import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.model.publication.reports.{ EthnicityBorrowerCharacteristic, EthnicityCharacteristic, EthnicityEnum }
 import hmda.model.publication.reports.EthnicityEnum._
 import hmda.publication.reports.util.DispositionType.DispositionType
 import hmda.publication.reports.util.ReportUtil.calculateDispositions
 import hmda.publication.reports.{ AS, EC, MAT }
-import hmda.query.model.filing.LoanApplicationRegisterQuery
 
 import scala.concurrent.Future
 
 object EthnicityUtil {
 
-  def filterEthnicity(larSource: Source[LoanApplicationRegisterQuery, NotUsed], ethnicity: EthnicityEnum): Source[LoanApplicationRegisterQuery, NotUsed] = {
+  def filterEthnicity(larSource: Source[LoanApplicationRegister, NotUsed], ethnicity: EthnicityEnum): Source[LoanApplicationRegister, NotUsed] = {
     ethnicity match {
       case HispanicOrLatino => larSource.filter { lar =>
-        lar.ethnicity == 1 &&
-          (lar.coEthnicity == 1 || coapplicantEthnicityNotProvided(lar))
+        lar.applicant.ethnicity == 1 &&
+          (lar.applicant.coEthnicity == 1 || coapplicantEthnicityNotProvided(lar))
       }
       case NotHispanicOrLatino => larSource.filter { lar =>
-        lar.ethnicity == 2 &&
-          (lar.coEthnicity == 2 || coapplicantEthnicityNotProvided(lar))
+        lar.applicant.ethnicity == 2 &&
+          (lar.applicant.coEthnicity == 2 || coapplicantEthnicityNotProvided(lar))
       }
       case Joint => larSource.filter { lar =>
-        (lar.ethnicity == 1 && lar.coEthnicity == 2) ||
-          (lar.ethnicity == 2 && lar.coEthnicity == 1)
+        (lar.applicant.ethnicity == 1 && lar.applicant.coEthnicity == 2) ||
+          (lar.applicant.ethnicity == 2 && lar.applicant.coEthnicity == 1)
       }
       case NotAvailable => larSource.filter { lar =>
-        lar.ethnicity == 3 || lar.ethnicity == 4
+        lar.applicant.ethnicity == 3 || lar.applicant.ethnicity == 4
       }
     }
   }
 
-  def coapplicantEthnicityNotProvided(lar: LoanApplicationRegisterQuery): Boolean = {
-    lar.coEthnicity == 3 ||
-      lar.coEthnicity == 4 ||
-      lar.coEthnicity == 5
+  def coapplicantEthnicityNotProvided(lar: LoanApplicationRegister): Boolean = {
+    lar.applicant.coEthnicity == 3 ||
+      lar.applicant.coEthnicity == 4 ||
+      lar.applicant.coEthnicity == 5
   }
 
   def ethnicityBorrowerCharacteristic[as: AS, mat: MAT, ec: EC](
-    larSource: Source[LoanApplicationRegisterQuery, NotUsed],
+    larSource: Source[LoanApplicationRegister, NotUsed],
     dispositions: List[DispositionType]
   ): Future[EthnicityBorrowerCharacteristic] = {
 

--- a/publication/src/main/scala/hmda/publication/reports/util/MinorityStatusUtil.scala
+++ b/publication/src/main/scala/hmda/publication/reports/util/MinorityStatusUtil.scala
@@ -2,40 +2,40 @@ package hmda.publication.reports.util
 
 import akka.NotUsed
 import akka.stream.scaladsl.Source
+import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.model.publication.reports._
 import hmda.model.publication.reports.MinorityStatusEnum.{ OtherIncludingHispanic, WhiteNonHispanic }
 import hmda.publication.reports.util.DispositionType.DispositionType
 import hmda.publication.reports.util.ReportUtil.calculateDispositions
 import hmda.publication.reports.{ AS, EC, MAT }
-import hmda.query.model.filing.LoanApplicationRegisterQuery
 
 import scala.concurrent.Future
 
 object MinorityStatusUtil {
 
-  def filterMinorityStatus(larSource: Source[LoanApplicationRegisterQuery, NotUsed], minorityStatus: MinorityStatusEnum): Source[LoanApplicationRegisterQuery, NotUsed] = {
+  def filterMinorityStatus(larSource: Source[LoanApplicationRegister, NotUsed], minorityStatus: MinorityStatusEnum): Source[LoanApplicationRegister, NotUsed] = {
     minorityStatus match {
       case WhiteNonHispanic => larSource.filter { lar =>
-        lar.ethnicity == 2 && lar.race1 == 5
+        lar.applicant.ethnicity == 2 && lar.applicant.race1 == 5
       }
       case OtherIncludingHispanic => larSource.filter { lar =>
-        lar.ethnicity == 1 && applicantRacesAllNonWhite(lar)
+        lar.applicant.ethnicity == 1 && applicantRacesAllNonWhite(lar)
       }
     }
   }
 
-  private def applicantRacesAllNonWhite(lar: LoanApplicationRegisterQuery): Boolean = {
-    val race1NonWhite = lar.race1 == 1 || lar.race1 == 2 || lar.race1 == 3 || lar.race1 == 4
+  private def applicantRacesAllNonWhite(lar: LoanApplicationRegister): Boolean = {
+    val race1NonWhite = lar.applicant.race1 == 1 || lar.applicant.race1 == 2 || lar.applicant.race1 == 3 || lar.applicant.race1 == 4
 
     race1NonWhite &&
-      lar.race2 != "5" &&
-      lar.race3 != "5" &&
-      lar.race4 != "5" &&
-      lar.race5 != "5"
+      lar.applicant.race2 != "5" &&
+      lar.applicant.race3 != "5" &&
+      lar.applicant.race4 != "5" &&
+      lar.applicant.race5 != "5"
   }
 
   def minorityStatusBorrowerCharacteristic[as: AS, mat: MAT, ec: EC](
-    larSource: Source[LoanApplicationRegisterQuery, NotUsed],
+    larSource: Source[LoanApplicationRegister, NotUsed],
     dispositions: List[DispositionType]
   ): Future[MinorityStatusBorrowerCharacteristic] = {
 

--- a/publication/src/main/scala/hmda/publication/reports/util/RaceUtil.scala
+++ b/publication/src/main/scala/hmda/publication/reports/util/RaceUtil.scala
@@ -2,46 +2,46 @@ package hmda.publication.reports.util
 
 import akka.NotUsed
 import akka.stream.scaladsl.Source
+import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.model.publication.reports.{ RaceBorrowerCharacteristic, RaceCharacteristic, RaceEnum }
 import hmda.model.publication.reports.RaceEnum._
 import hmda.publication.reports._
 import hmda.publication.reports.util.ReportUtil.calculateDispositions
 import hmda.publication.reports.util.DispositionType.DispositionType
-import hmda.query.model.filing.LoanApplicationRegisterQuery
 
 import scala.concurrent.Future
 
 object RaceUtil {
 
-  def filterRace(larSource: Source[LoanApplicationRegisterQuery, NotUsed], race: RaceEnum): Source[LoanApplicationRegisterQuery, NotUsed] = {
+  def filterRace(larSource: Source[LoanApplicationRegister, NotUsed], race: RaceEnum): Source[LoanApplicationRegister, NotUsed] = {
     race match {
       case AmericanIndianOrAlaskaNative =>
         larSource.filter { lar =>
-          lar.race1 == 1 && coApplicantNonWhite(lar) &&
-            (applicantRace2Thru5Blank(lar) || lar.race2 == "5")
+          lar.applicant.race1 == 1 && coApplicantNonWhite(lar) &&
+            (applicantRace2Thru5Blank(lar) || lar.applicant.race2 == "5")
         }
 
       case Asian =>
         larSource.filter { lar =>
-          lar.race1 == 2 && coApplicantNonWhite(lar) &&
-            (applicantRace2Thru5Blank(lar) || lar.race2 == "5")
+          lar.applicant.race1 == 2 && coApplicantNonWhite(lar) &&
+            (applicantRace2Thru5Blank(lar) || lar.applicant.race2 == "5")
         }
 
       case BlackOrAfricanAmerican =>
         larSource.filter { lar =>
-          lar.race1 == 3 && coApplicantNonWhite(lar) &&
-            (applicantRace2Thru5Blank(lar) || lar.race2 == "5")
+          lar.applicant.race1 == 3 && coApplicantNonWhite(lar) &&
+            (applicantRace2Thru5Blank(lar) || lar.applicant.race2 == "5")
         }
 
       case HawaiianOrPacific =>
         larSource.filter { lar =>
-          lar.race1 == 4 && coApplicantNonWhite(lar) &&
-            (applicantRace2Thru5Blank(lar) || lar.race2 == "5")
+          lar.applicant.race1 == 4 && coApplicantNonWhite(lar) &&
+            (applicantRace2Thru5Blank(lar) || lar.applicant.race2 == "5")
         }
 
       case White =>
         larSource.filter { lar =>
-          lar.race1 == 5 && applicantRace2Thru5Blank(lar) && coApplicantNonMinority(lar)
+          lar.applicant.race1 == 5 && applicantRace2Thru5Blank(lar) && coApplicantNonMinority(lar)
         }
 
       case TwoOrMoreMinority =>
@@ -54,75 +54,75 @@ object RaceUtil {
         }
 
       case NotProvided =>
-        larSource.filter(lar => lar.race1 == 6 || lar.race1 == 7)
+        larSource.filter(lar => lar.applicant.race1 == 6 || lar.applicant.race1 == 7)
 
     }
   }
 
-  private def applicantRace2Thru5Blank(lar: LoanApplicationRegisterQuery): Boolean = {
-    lar.race2 == "" &&
-      lar.race3 == "" &&
-      lar.race4 == "" &&
-      lar.race5 == ""
+  private def applicantRace2Thru5Blank(lar: LoanApplicationRegister): Boolean = {
+    lar.applicant.race2 == "" &&
+      lar.applicant.race3 == "" &&
+      lar.applicant.race4 == "" &&
+      lar.applicant.race5 == ""
   }
 
-  private def applicantWhite(lar: LoanApplicationRegisterQuery): Boolean = {
-    lar.race1 == 5 &&
-      lar.race2 == "" &&
-      lar.race3 == "" &&
-      lar.race4 == "" &&
-      lar.race5 == ""
+  private def applicantWhite(lar: LoanApplicationRegister): Boolean = {
+    lar.applicant.race1 == 5 &&
+      lar.applicant.race2 == "" &&
+      lar.applicant.race3 == "" &&
+      lar.applicant.race4 == "" &&
+      lar.applicant.race5 == ""
   }
 
-  private def coApplicantWhite(lar: LoanApplicationRegisterQuery): Boolean = {
-    lar.coRace1 == 5 &&
-      lar.coRace2 == "" &&
-      lar.coRace3 == "" &&
-      lar.coRace4 == "" &&
-      lar.coRace5 == ""
+  private def coApplicantWhite(lar: LoanApplicationRegister): Boolean = {
+    lar.applicant.coRace1 == 5 &&
+      lar.applicant.coRace2 == "" &&
+      lar.applicant.coRace3 == "" &&
+      lar.applicant.coRace4 == "" &&
+      lar.applicant.coRace5 == ""
   }
 
-  private def coApplicantNonWhite(lar: LoanApplicationRegisterQuery): Boolean = {
-    lar.coRace1 != 5 &&
-      lar.coRace2 != "5" &&
-      lar.coRace3 != "5" &&
-      lar.coRace4 != "5" &&
-      lar.coRace5 != "5"
+  private def coApplicantNonWhite(lar: LoanApplicationRegister): Boolean = {
+    lar.applicant.coRace1 != 5 &&
+      lar.applicant.coRace2 != "5" &&
+      lar.applicant.coRace3 != "5" &&
+      lar.applicant.coRace4 != "5" &&
+      lar.applicant.coRace5 != "5"
   }
 
-  private def coApplicantNonMinority(lar: LoanApplicationRegisterQuery): Boolean = {
-    val race1NonMinority = lar.coRace1 == 5 || lar.coRace1 == 6 || lar.coRace1 == 7 || lar.coRace1 == 8
+  private def coApplicantNonMinority(lar: LoanApplicationRegister): Boolean = {
+    val race1NonMinority = lar.applicant.coRace1 == 5 || lar.applicant.coRace1 == 6 || lar.applicant.coRace1 == 7 || lar.applicant.coRace1 == 8
     race1NonMinority &&
-      (lar.race2 == "5" || lar.race2 == "") &&
-      (lar.race3 == "5" || lar.race3 == "") &&
-      (lar.race4 == "5" || lar.race4 == "") &&
-      (lar.race5 == "5" || lar.race5 == "")
+      (lar.applicant.race2 == "5" || lar.applicant.race2 == "") &&
+      (lar.applicant.race3 == "5" || lar.applicant.race3 == "") &&
+      (lar.applicant.race4 == "5" || lar.applicant.race4 == "") &&
+      (lar.applicant.race5 == "5" || lar.applicant.race5 == "")
   }
 
-  private def applicantTwoOrMoreMinorities(lar: LoanApplicationRegisterQuery): Boolean = {
-    lar.race1 != 5 &&
-      ((lar.race2 != "" && lar.race2 != "5") ||
-        (lar.race3 != "" && lar.race3 != "5") ||
-        (lar.race4 != "" && lar.race4 != "5") ||
-        (lar.race5 != "" && lar.race5 != "5"))
+  private def applicantTwoOrMoreMinorities(lar: LoanApplicationRegister): Boolean = {
+    lar.applicant.race1 != 5 &&
+      ((lar.applicant.race2 != "" && lar.applicant.race2 != "5") ||
+        (lar.applicant.race3 != "" && lar.applicant.race3 != "5") ||
+        (lar.applicant.race4 != "" && lar.applicant.race4 != "5") ||
+        (lar.applicant.race5 != "" && lar.applicant.race5 != "5"))
   }
 
-  private def applicantOneOrMoreMinorities(lar: LoanApplicationRegisterQuery): Boolean = {
-    (lar.race1 == 1 || lar.race1 == 2 || lar.race1 == 3 || lar.race1 == 4) ||
-      (lar.race2 != "" && lar.race2 != "5") ||
-      (lar.race3 != "" && lar.race3 != "5") ||
-      (lar.race4 != "" && lar.race4 != "5") ||
-      (lar.race5 != "" && lar.race5 != "5")
+  private def applicantOneOrMoreMinorities(lar: LoanApplicationRegister): Boolean = {
+    (lar.applicant.race1 == 1 || lar.applicant.race1 == 2 || lar.applicant.race1 == 3 || lar.applicant.race1 == 4) ||
+      (lar.applicant.race2 != "" && lar.applicant.race2 != "5") ||
+      (lar.applicant.race3 != "" && lar.applicant.race3 != "5") ||
+      (lar.applicant.race4 != "" && lar.applicant.race4 != "5") ||
+      (lar.applicant.race5 != "" && lar.applicant.race5 != "5")
   }
-  private def coApplicantOneOrMoreMinorities(lar: LoanApplicationRegisterQuery): Boolean = {
-    (lar.coRace1 == 1 || lar.coRace1 == 2 || lar.coRace1 == 3 || lar.coRace1 == 4) ||
-      (lar.coRace2 != "" && lar.coRace2 != "5") ||
-      (lar.coRace3 != "" && lar.coRace3 != "5") ||
-      (lar.coRace4 != "" && lar.coRace4 != "5") ||
-      (lar.coRace5 != "" && lar.coRace5 != "5")
+  private def coApplicantOneOrMoreMinorities(lar: LoanApplicationRegister): Boolean = {
+    (lar.applicant.coRace1 == 1 || lar.applicant.coRace1 == 2 || lar.applicant.coRace1 == 3 || lar.applicant.coRace1 == 4) ||
+      (lar.applicant.coRace2 != "" && lar.applicant.coRace2 != "5") ||
+      (lar.applicant.coRace3 != "" && lar.applicant.coRace3 != "5") ||
+      (lar.applicant.coRace4 != "" && lar.applicant.coRace4 != "5") ||
+      (lar.applicant.coRace5 != "" && lar.applicant.coRace5 != "5")
   }
 
-  def raceBorrowerCharacteristic[as: AS, mat: MAT, ec: EC](larSource: Source[LoanApplicationRegisterQuery, NotUsed], dispositions: List[DispositionType]): Future[RaceBorrowerCharacteristic] = {
+  def raceBorrowerCharacteristic[as: AS, mat: MAT, ec: EC](larSource: Source[LoanApplicationRegister, NotUsed], dispositions: List[DispositionType]): Future[RaceBorrowerCharacteristic] = {
 
     val larsAlaskan = filterRace(larSource, AmericanIndianOrAlaskaNative)
     val larsAsian = filterRace(larSource, Asian)

--- a/publication/src/test/scala/hmda/publication/reports/aggregate/A52Spec.scala
+++ b/publication/src/test/scala/hmda/publication/reports/aggregate/A52Spec.scala
@@ -8,8 +8,6 @@ import hmda.model.fi.lar.{ LarGenerators, LoanApplicationRegister }
 import hmda.model.publication.reports.ActionTakenTypeEnum._
 import hmda.model.publication.reports.ApplicantIncomeEnum.LessThan50PercentOfMSAMedian
 import hmda.model.publication.reports.{ EthnicityBorrowerCharacteristic, MSAReport, MinorityStatusBorrowerCharacteristic, RaceBorrowerCharacteristic }
-import hmda.query.model.filing.LoanApplicationRegisterQuery
-import hmda.query.repository.filing.LarConverter._
 import org.scalacheck.Gen
 import org.scalatest.{ AsyncWordSpec, BeforeAndAfterAll, MustMatchers }
 
@@ -33,9 +31,8 @@ class A52Spec extends AsyncWordSpec with MustMatchers with LarGenerators with Be
     lar.copy(geography = geo, loan = loan)
   }
 
-  val source: Source[LoanApplicationRegisterQuery, NotUsed] = Source
+  val source: Source[LoanApplicationRegister, NotUsed] = Source
     .fromIterator(() => lars.toIterator)
-    .map(lar => toLoanApplicationRegisterQuery(lar))
 
   val expectedDispositions = List(ApplicationReceived, LoansOriginated, ApprovedButNotAccepted, ApplicationsDenied, ApplicationsWithdrawn, ClosedForIncompleteness)
 

--- a/publication/src/test/scala/hmda/publication/reports/aggregate/A53Spec.scala
+++ b/publication/src/test/scala/hmda/publication/reports/aggregate/A53Spec.scala
@@ -8,8 +8,6 @@ import hmda.model.fi.lar.{ LarGenerators, LoanApplicationRegister }
 import hmda.model.publication.reports.ActionTakenTypeEnum._
 import hmda.model.publication.reports.ApplicantIncomeEnum.LessThan50PercentOfMSAMedian
 import hmda.model.publication.reports.{ EthnicityBorrowerCharacteristic, MSAReport, MinorityStatusBorrowerCharacteristic, RaceBorrowerCharacteristic }
-import hmda.query.model.filing.LoanApplicationRegisterQuery
-import hmda.query.repository.filing.LarConverter._
 import org.scalacheck.Gen
 import org.scalatest.{ AsyncWordSpec, BeforeAndAfterAll, MustMatchers }
 
@@ -33,9 +31,8 @@ class A53Spec extends AsyncWordSpec with MustMatchers with LarGenerators with Be
     lar.copy(geography = geo, loan = loan)
   }
 
-  val source: Source[LoanApplicationRegisterQuery, NotUsed] = Source
+  val source: Source[LoanApplicationRegister, NotUsed] = Source
     .fromIterator(() => lars.toIterator)
-    .map(lar => toLoanApplicationRegisterQuery(lar))
 
   val expectedDispositions = List(ApplicationReceived, LoansOriginated, ApprovedButNotAccepted, ApplicationsDenied, ApplicationsWithdrawn, ClosedForIncompleteness)
 

--- a/publication/src/test/scala/hmda/publication/reports/disclosure/D51Spec.scala
+++ b/publication/src/test/scala/hmda/publication/reports/disclosure/D51Spec.scala
@@ -8,8 +8,6 @@ import hmda.model.fi.lar.{ LarGenerators, LoanApplicationRegister }
 import hmda.model.publication.reports.ActionTakenTypeEnum._
 import hmda.model.publication.reports.ApplicantIncomeEnum.LessThan50PercentOfMSAMedian
 import hmda.model.publication.reports.{ EthnicityBorrowerCharacteristic, MSAReport, MinorityStatusBorrowerCharacteristic, RaceBorrowerCharacteristic }
-import hmda.query.model.filing.LoanApplicationRegisterQuery
-import hmda.query.repository.filing.LarConverter._
 import org.scalacheck.Gen
 import org.scalatest.{ AsyncWordSpec, BeforeAndAfterAll, MustMatchers }
 
@@ -37,9 +35,8 @@ class D51Spec extends AsyncWordSpec with MustMatchers with LarGenerators with Be
     lar.copy(respondentId = respId, geography = geo, loan = loan)
   }
 
-  val source: Source[LoanApplicationRegisterQuery, NotUsed] = Source
+  val source: Source[LoanApplicationRegister, NotUsed] = Source
     .fromIterator(() => lars.toIterator)
-    .map(lar => toLoanApplicationRegisterQuery(lar))
 
   val expectedDispositions = List(ApplicationReceived, LoansOriginated, ApprovedButNotAccepted, ApplicationsDenied, ApplicationsWithdrawn, ClosedForIncompleteness)
 

--- a/publication/src/test/scala/hmda/publication/reports/disclosure/D52Spec.scala
+++ b/publication/src/test/scala/hmda/publication/reports/disclosure/D52Spec.scala
@@ -8,8 +8,6 @@ import hmda.model.fi.lar.{ LarGenerators, LoanApplicationRegister }
 import hmda.model.publication.reports.ActionTakenTypeEnum._
 import hmda.model.publication.reports.ApplicantIncomeEnum.LessThan50PercentOfMSAMedian
 import hmda.model.publication.reports.{ EthnicityBorrowerCharacteristic, MSAReport, MinorityStatusBorrowerCharacteristic, RaceBorrowerCharacteristic }
-import hmda.query.model.filing.LoanApplicationRegisterQuery
-import hmda.query.repository.filing.LarConverter._
 import org.scalacheck.Gen
 import org.scalatest.{ AsyncWordSpec, BeforeAndAfterAll, MustMatchers }
 
@@ -36,9 +34,8 @@ class D52Spec extends AsyncWordSpec with MustMatchers with LarGenerators with Be
     lar.copy(respondentId = respId, geography = geo, loan = loan)
   }
 
-  val source: Source[LoanApplicationRegisterQuery, NotUsed] = Source
+  val source: Source[LoanApplicationRegister, NotUsed] = Source
     .fromIterator(() => lars.toIterator)
-    .map(lar => toLoanApplicationRegisterQuery(lar))
 
   val expectedDispositions = List(ApplicationReceived, LoansOriginated, ApprovedButNotAccepted, ApplicationsDenied, ApplicationsWithdrawn, ClosedForIncompleteness)
 

--- a/publication/src/test/scala/hmda/publication/reports/disclosure/D53Spec.scala
+++ b/publication/src/test/scala/hmda/publication/reports/disclosure/D53Spec.scala
@@ -8,8 +8,6 @@ import hmda.model.fi.lar.{ LarGenerators, LoanApplicationRegister }
 import hmda.model.publication.reports.ActionTakenTypeEnum._
 import hmda.model.publication.reports.ApplicantIncomeEnum.LessThan50PercentOfMSAMedian
 import hmda.model.publication.reports.{ EthnicityBorrowerCharacteristic, MSAReport, MinorityStatusBorrowerCharacteristic, RaceBorrowerCharacteristic }
-import hmda.query.model.filing.LoanApplicationRegisterQuery
-import hmda.query.repository.filing.LarConverter._
 import org.scalacheck.Gen
 import org.scalatest.{ AsyncWordSpec, BeforeAndAfterAll, MustMatchers }
 
@@ -36,9 +34,8 @@ class D53Spec extends AsyncWordSpec with MustMatchers with LarGenerators with Be
     lar.copy(respondentId = respId, geography = geo, loan = loan)
   }
 
-  val source: Source[LoanApplicationRegisterQuery, NotUsed] = Source
+  val source: Source[LoanApplicationRegister, NotUsed] = Source
     .fromIterator(() => lars.toIterator)
-    .map(lar => toLoanApplicationRegisterQuery(lar))
 
   val expectedDispositions = List(ApplicationReceived, LoansOriginated, ApprovedButNotAccepted, ApplicationsDenied, ApplicationsWithdrawn, ClosedForIncompleteness)
 

--- a/publication/src/test/scala/hmda/publication/reports/national/N52Spec.scala
+++ b/publication/src/test/scala/hmda/publication/reports/national/N52Spec.scala
@@ -9,8 +9,6 @@ import hmda.model.fi.lar.{ LarGenerators, LoanApplicationRegister }
 import hmda.model.publication.reports.ActionTakenTypeEnum._
 import hmda.model.publication.reports.ApplicantIncomeEnum.LessThan50PercentOfMSAMedian
 import hmda.model.publication.reports.{ EthnicityBorrowerCharacteristic, MinorityStatusBorrowerCharacteristic, RaceBorrowerCharacteristic }
-import hmda.query.model.filing.LoanApplicationRegisterQuery
-import hmda.query.repository.filing.LarConverter._
 import org.scalacheck.Gen
 import org.scalatest.{ AsyncWordSpec, BeforeAndAfterAll, MustMatchers }
 
@@ -35,9 +33,8 @@ class N52Spec extends AsyncWordSpec with MustMatchers with LarGenerators with Be
     lar.copy(geography = geo, loan = loan)
   }
 
-  val source: Source[LoanApplicationRegisterQuery, NotUsed] = Source
+  val source: Source[LoanApplicationRegister, NotUsed] = Source
     .fromIterator(() => lars.toIterator)
-    .map(lar => toLoanApplicationRegisterQuery(lar))
 
   val expectedDispositions = List(ApplicationReceived, LoansOriginated, ApprovedButNotAccepted, ApplicationsDenied, ApplicationsWithdrawn, ClosedForIncompleteness)
 

--- a/publication/src/test/scala/hmda/publication/reports/util/ApplicantSpecUtil.scala
+++ b/publication/src/test/scala/hmda/publication/reports/util/ApplicantSpecUtil.scala
@@ -5,8 +5,6 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Source
 import hmda.model.fi.lar.{ Applicant, LarGenerators, LoanApplicationRegister }
-import hmda.query.model.filing.LoanApplicationRegisterQuery
-import hmda.query.repository.filing.LarConverter._
 
 trait ApplicantSpecUtil extends LarGenerators {
 
@@ -21,8 +19,7 @@ trait ApplicantSpecUtil extends LarGenerators {
     }
   }
 
-  def source(lars: List[LoanApplicationRegister]): Source[LoanApplicationRegisterQuery, NotUsed] = Source
+  def source(lars: List[LoanApplicationRegister]): Source[LoanApplicationRegister, NotUsed] = Source
     .fromIterator(() => lars.toIterator)
-    .map(lar => toLoanApplicationRegisterQuery(lar))
 
 }

--- a/publication/src/test/scala/hmda/publication/reports/util/ReportUtilSpec.scala
+++ b/publication/src/test/scala/hmda/publication/reports/util/ReportUtilSpec.scala
@@ -6,7 +6,6 @@ import akka.stream.scaladsl.Source
 import hmda.model.fi.lar.LarGenerators
 import hmda.model.publication.reports.MSAReport
 import hmda.publication.reports.util.ReportUtil._
-import hmda.query.repository.filing.LarConverter._
 import org.scalatest.{ AsyncWordSpec, MustMatchers }
 
 class ReportUtilSpec extends AsyncWordSpec with MustMatchers with LarGenerators {
@@ -45,8 +44,6 @@ class ReportUtilSpec extends AsyncWordSpec with MustMatchers with LarGenerators 
       // Activity Year is the same year as Action Taken Date. This is enforced by edit S270
       val lars = larListGen.sample.get.map(_.copy(actionTakenDate = 20090822))
       val src = Source.fromIterator(() => lars.toIterator)
-        .map(lar => toLoanApplicationRegisterQuery(lar))
-
       calculateYear(src).map(_ mustBe 2009)
     }
   }

--- a/query/src/main/resources/application.conf
+++ b/query/src/main/resources/application.conf
@@ -22,6 +22,9 @@ hmda {
     fetch.size = 32
     group.size = 1000
   }
+  lar {
+    table = "lars2017"
+  }
 }
 
 //TODO: configure database access for Keycloak

--- a/query/src/main/scala/hmda/query/HmdaProjectionQuery.scala
+++ b/query/src/main/scala/hmda/query/HmdaProjectionQuery.scala
@@ -2,7 +2,7 @@ package hmda.query
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
-import hmda.query.projections.filing.FilingCassandraProjection
+import hmda.query.projections.filing.SubmissionCassandraProjection
 import hmda.query.projections.institutions.InstitutionCassandraProjection
 
 object HmdaProjectionQuery {
@@ -12,7 +12,7 @@ object HmdaProjectionQuery {
     val institutionProjection = new InstitutionCassandraProjection(system, materializer)
     institutionProjection.startUp()
 
-    val filingProjection = new FilingCassandraProjection(system, materializer)
+    val filingProjection = new SubmissionCassandraProjection(system, materializer)
     filingProjection.startUp()
   }
 

--- a/query/src/main/scala/hmda/query/projections/filing/SubmissionCassandraProjection.scala
+++ b/query/src/main/scala/hmda/query/projections/filing/SubmissionCassandraProjection.scala
@@ -9,24 +9,22 @@ import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.persistence.messages.events.processing.CommonHmdaValidatorEvents.LarValidated
 import hmda.query.repository.filing.FilingCassandraRepository
 import hmda.persistence.processing.HmdaQuery._
-import hmda.query.model.filing.LoanApplicationRegisterQuery
-import hmda.query.repository.filing.LarConverter._
 
-class FilingCassandraProjection(sys: ActorSystem, mat: ActorMaterializer) extends FilingCassandraRepository {
+class SubmissionCassandraProjection(sys: ActorSystem, mat: ActorMaterializer) extends FilingCassandraRepository {
 
   def startUp(): Unit = {
     createKeyspace()
     createTable()
+    projectLarData()
+  }
 
+  def projectLarData(): Unit = {
     val source: Source[LoanApplicationRegister, NotUsed] = liveEvents("HmdaFiling-2017").map {
       case LarValidated(lar, _) => lar
     }
-    val sink = CassandraSink[LoanApplicationRegisterQuery](parallelism = 2, preparedStatement, statementBinder)
+    val sink = CassandraSink[LoanApplicationRegister](parallelism = 2, preparedStatement, statementBinder)
     source
-      .map { lar =>
-        val queryLar = toLoanApplicationRegisterQuery(lar)
-        queryLar.copy(institutionId = queryLar.id, period = "2017")
-      }
+      .map { e => println(e); e }
       .to(sink).run()
   }
 

--- a/query/src/test/scala/hmda/query/repository/filing/FilingCassandraRepositorySpec.scala
+++ b/query/src/test/scala/hmda/query/repository/filing/FilingCassandraRepositorySpec.scala
@@ -3,13 +3,11 @@ package hmda.query.repository.filing
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{ Sink, Source }
-import hmda.model.fi.lar.LarGenerators
+import hmda.model.fi.lar.{ LarGenerators, LoanApplicationRegister }
 import hmda.model.institution.Agency
-import hmda.query.model.filing.LoanApplicationRegisterQuery
 import hmda.query.repository.CassandraRepositorySpec
-import hmda.query.repository.filing.LarConverter._
 
-class FilingCassandraRepositorySpec extends CassandraRepositorySpec[LoanApplicationRegisterQuery] with FilingCassandraRepository with LarGenerators {
+class FilingCassandraRepositorySpec extends CassandraRepositorySpec[LoanApplicationRegister] with FilingCassandraRepository with LarGenerators {
 
   override def beforeAll(): Unit = {
     createKeyspace()
@@ -28,7 +26,6 @@ class FilingCassandraRepositorySpec extends CassandraRepositorySpec[LoanApplicat
       val lars = lar100ListGen.sample.get.map(x => x.copy(agencyCode = 9))
       val source = Source
         .fromIterator(() => lars.toIterator)
-        .map(lar => toLoanApplicationRegisterQuery(lar))
       insertData(source)
       val readF = readData(100).runWith(Sink.seq)
       readF.map { lars =>


### PR DESCRIPTION
Changes `Cassandra` repository to use `LoanApplicationRegister` instead of `LoanApplicationRegisterQuery`. Updates all downstream dependencies