### PR TITLE
Project LAR data to query side when submission is signed

### DIFF
--- a/cluster/src/main/resources/application.conf
+++ b/cluster/src/main/resources/application.conf
@@ -40,7 +40,11 @@ akka {
 
   }
 
-  extensions = ["de.heikoseeberger.constructr.ConstructrExtension", "akka.cluster.client.ClusterClientReceptionist"]
+  extensions = [
+    "de.heikoseeberger.constructr.ConstructrExtension",
+    "akka.cluster.client.ClusterClientReceptionist",
+    "akka.cluster.pubsub.DistributedPubSub"
+  ]
 
 }
 

--- a/cluster/src/main/scala/hmda/cluster/HmdaPlatform.scala
+++ b/cluster/src/main/scala/hmda/cluster/HmdaPlatform.scala
@@ -132,6 +132,8 @@ object HmdaPlatform extends App {
     val institutionViewF = (querySupervisorProxy ? FindActorByName(InstitutionView.name)).mapTo[ActorRef]
     institutionViewF.map(actorRef => loadDemoData(supervisorProxy, actorRef))
 
+    HmdaProjectionQuery.startUp(system)
+
     (querySupervisorProxy ? FindSignedEventQuerySubscriber)
       .mapTo[ActorRef]
       .map(a => log.info(s"Started submission signed event subscriber validator at ${a.path}"))

--- a/cluster/src/main/scala/hmda/cluster/HmdaPlatform.scala
+++ b/cluster/src/main/scala/hmda/cluster/HmdaPlatform.scala
@@ -23,6 +23,8 @@ import hmda.validation.ValidationStats
 import hmda.cluster.HmdaConfig._
 import hmda.persistence.demo.DemoData
 import hmda.persistence.messages.CommonMessages._
+import hmda.query.HmdaQuerySupervisor.FindSignedEventQuerySubscriber
+import hmda.query.projections.filing.SubmissionSignedEventQuerySubscriber
 
 import scala.concurrent.duration._
 
@@ -130,6 +132,11 @@ object HmdaPlatform extends App {
     val institutionViewF = (querySupervisorProxy ? FindActorByName(InstitutionView.name)).mapTo[ActorRef]
     institutionViewF.map(actorRef => loadDemoData(supervisorProxy, actorRef))
     //HmdaProjectionQuery.startUp(system)
+
+    (querySupervisorProxy ? FindSignedEventQuerySubscriber)
+      .mapTo[ActorRef]
+      .map(a => log.info(s"Started submission signed event subscriber validator at ${a.path}"))
+
   }
 
   //Start Publication

--- a/cluster/src/main/scala/hmda/cluster/HmdaPlatform.scala
+++ b/cluster/src/main/scala/hmda/cluster/HmdaPlatform.scala
@@ -131,7 +131,6 @@ object HmdaPlatform extends App {
 
     val institutionViewF = (querySupervisorProxy ? FindActorByName(InstitutionView.name)).mapTo[ActorRef]
     institutionViewF.map(actorRef => loadDemoData(supervisorProxy, actorRef))
-    //HmdaProjectionQuery.startUp(system)
 
     (querySupervisorProxy ? FindSignedEventQuerySubscriber)
       .mapTo[ActorRef]

--- a/model/shared/src/main/scala/hmda/model/fi/lar/LoanApplicationRegister.scala
+++ b/model/shared/src/main/scala/hmda/model/fi/lar/LoanApplicationRegister.scala
@@ -22,6 +22,24 @@ case class LoanApplicationRegister(
     lienStatus: Int = 0
 ) extends HasControlNumber with HmdaFileRow with StringPaddingUtils {
 
+  def isEmpty: Boolean = {
+    this.id == 0 &&
+      this.respondentId == "" &&
+      this.agencyCode == 0 &&
+      this.loan == Loan("", "", 0, 0, 0, 0, 0) &&
+      this.preapprovals == 0 &&
+      this.actionTakenType == 0 &&
+      this.actionTakenDate == 0 &&
+      this.geography == Geography("", "", "", "") &&
+      this.applicant == Applicant(0, 0, 0, "", "", "", "", 0, "", "", "", "", 0, 0, "") &&
+      this.purchaserType == 0 &&
+      this.denial == Denial("", "", "") &&
+      this.rateSpread == "" &&
+      this.hoepaStatus == 0 &&
+      this.lienStatus == 0
+
+  }
+
   override def valueOf(field: String): Any = {
     LarFieldMapping.mapping(this).getOrElse(field, "error: field name mismatch")
   }

--- a/persistence-model/src/main/protobuf/PubSubEvents.proto
+++ b/persistence-model/src/main/protobuf/PubSubEvents.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+option java_package = "hmda.persistence.model.serialization";
+option optimize_for = SPEED;
+
+import "SubmissionEvents.proto";
+
+message SubmissionSignedPubSubMessage {
+    SubmissionIdMessage submissionId = 1;
+}

--- a/persistence-model/src/main/resources/application-dev.conf
+++ b/persistence-model/src/main/resources/application-dev.conf
@@ -14,7 +14,7 @@ akka {
       submissionFSM = "hmda.persistence.serialization.submission.SubmissionFSMProtobufSerializer"
       validator = "hmda.persistence.serialization.validation.HmdaFileValidatorProtobufSerializer"
       validationStats = "hmda.persistence.serialization.validation.ValidationStatsProtobufSerializer"
-
+      pubsub = "hmda.persistence.serialization.pubsub.PubSubEventsProtobufSerializer"
     }
     serialization-bindings {
       "hmda.persistence.messages.events.institutions.InstitutionEvents$InstitutionCreated" = institution
@@ -64,6 +64,7 @@ akka {
       "hmda.persistence.messages.commands.filing.FilingCommands$CreateFiling" = filing
       "hmda.persistence.messages.commands.filing.FilingCommands$UpdateFilingStatus" = filing
       "hmda.persistence.messages.commands.filing.FilingCommands$GetFilingByPeriod" = filing
+      "hmda.persistence.messages.events.pubsub.PubSubEvents$SubmissionSignedPubSub" = pubsub
     }
   }
   persistence {

--- a/persistence-model/src/main/resources/application.conf
+++ b/persistence-model/src/main/resources/application.conf
@@ -14,6 +14,7 @@ akka {
       submissionFSM = "hmda.persistence.serialization.submission.SubmissionFSMProtobufSerializer"
       validator = "hmda.persistence.serialization.validation.HmdaFileValidatorProtobufSerializer"
       validationStats = "hmda.persistence.serialization.validation.ValidationStatsProtobufSerializer"
+      pubsub = "hmda.persistence.serialization.pubsub.PubSubEventsProtobufSerializer"
     }
     serialization-bindings {
       "hmda.persistence.messages.events.institutions.InstitutionEvents$InstitutionCreated" = institution
@@ -63,6 +64,7 @@ akka {
       "hmda.persistence.messages.commands.filing.FilingCommands$CreateFiling" = filing
       "hmda.persistence.messages.commands.filing.FilingCommands$UpdateFilingStatus" = filing
       "hmda.persistence.messages.commands.filing.FilingCommands$GetFilingByPeriod" = filing
+      "hmda.persistence.messages.events.pubsub.PubSubEvents$SubmissionSignedPubSub" = pubsub
     }
   }
   persistence {

--- a/persistence-model/src/main/scala/hmda/persistence/messages/events/processing/PubSubEvents.scala
+++ b/persistence-model/src/main/scala/hmda/persistence/messages/events/processing/PubSubEvents.scala
@@ -1,0 +1,7 @@
+package hmda.persistence.messages.events.processing
+
+import hmda.model.fi.SubmissionId
+
+object PubSubEvents {
+  case class SubmissionSigned(submissionId: SubmissionId)
+}

--- a/persistence-model/src/main/scala/hmda/persistence/messages/events/processing/PubSubEvents.scala
+++ b/persistence-model/src/main/scala/hmda/persistence/messages/events/processing/PubSubEvents.scala
@@ -3,5 +3,5 @@ package hmda.persistence.messages.events.processing
 import hmda.model.fi.SubmissionId
 
 object PubSubEvents {
-  case class SubmissionSigned(submissionId: SubmissionId)
+  case class SubmissionSignedPubSub(submissionId: SubmissionId)
 }

--- a/persistence-model/src/main/scala/hmda/persistence/messages/events/pubsub/PubSubEvents.scala
+++ b/persistence-model/src/main/scala/hmda/persistence/messages/events/pubsub/PubSubEvents.scala
@@ -1,4 +1,4 @@
-package hmda.persistence.messages.events.processing
+package hmda.persistence.messages.events.pubsub
 
 import hmda.model.fi.SubmissionId
 

--- a/persistence-model/src/main/scala/hmda/persistence/processing/PubSubTopics.scala
+++ b/persistence-model/src/main/scala/hmda/persistence/processing/PubSubTopics.scala
@@ -1,0 +1,5 @@
+package hmda.persistence.processing
+
+object PubSubTopics {
+  val submissionSigned = "SubmissionSigned"
+}

--- a/persistence-model/src/main/scala/hmda/persistence/serialization/pubsub/PubSubEventsProtobufConverter.scala
+++ b/persistence-model/src/main/scala/hmda/persistence/serialization/pubsub/PubSubEventsProtobufConverter.scala
@@ -1,19 +1,19 @@
 package hmda.persistence.serialization.pubsub
 
-import hmda.persistence.messages.events.processing.PubSubEvents.SubmissionSigned
+import hmda.persistence.messages.events.processing.PubSubEvents.SubmissionSignedPubSub
 import hmda.persistence.model.serialization.PubSubEvents.SubmissionSignedPubSubMessage
 import hmda.persistence.model.serialization.SubmissionEvents.SubmissionIdMessage
 import hmda.persistence.serialization.submission.SubmissionProtobufConverter._
 
 object PubSubEventsProtobufConverter {
-  def submissionSignedPubSubToProtobuf(obj: SubmissionSigned): SubmissionSignedPubSubMessage = {
+  def submissionSignedPubSubToProtobuf(obj: SubmissionSignedPubSub): SubmissionSignedPubSubMessage = {
     SubmissionSignedPubSubMessage(
       submissionId = Some(SubmissionIdMessage(obj.submissionId.institutionId, obj.submissionId.period, obj.submissionId.sequenceNumber))
     )
   }
 
-  def submissionSignedPubSubFromProtobuf(msg: SubmissionSignedPubSubMessage): SubmissionSigned = {
-    SubmissionSigned(
+  def submissionSignedPubSubFromProtobuf(msg: SubmissionSignedPubSubMessage): SubmissionSignedPubSub = {
+    SubmissionSignedPubSub(
       submissionId = submissionIdFromProtobuf(msg.submissionId.getOrElse(SubmissionIdMessage()))
     )
   }

--- a/persistence-model/src/main/scala/hmda/persistence/serialization/pubsub/PubSubEventsProtobufConverter.scala
+++ b/persistence-model/src/main/scala/hmda/persistence/serialization/pubsub/PubSubEventsProtobufConverter.scala
@@ -1,6 +1,6 @@
 package hmda.persistence.serialization.pubsub
 
-import hmda.persistence.messages.events.processing.PubSubEvents.SubmissionSignedPubSub
+import hmda.persistence.messages.events.pubsub.PubSubEvents.SubmissionSignedPubSub
 import hmda.persistence.model.serialization.PubSubEvents.SubmissionSignedPubSubMessage
 import hmda.persistence.model.serialization.SubmissionEvents.SubmissionIdMessage
 import hmda.persistence.serialization.submission.SubmissionProtobufConverter._

--- a/persistence-model/src/main/scala/hmda/persistence/serialization/pubsub/PubSubEventsProtobufConverter.scala
+++ b/persistence-model/src/main/scala/hmda/persistence/serialization/pubsub/PubSubEventsProtobufConverter.scala
@@ -1,0 +1,20 @@
+package hmda.persistence.serialization.pubsub
+
+import hmda.persistence.messages.events.processing.PubSubEvents.SubmissionSigned
+import hmda.persistence.model.serialization.PubSubEvents.SubmissionSignedPubSubMessage
+import hmda.persistence.model.serialization.SubmissionEvents.SubmissionIdMessage
+import hmda.persistence.serialization.submission.SubmissionProtobufConverter._
+
+object PubSubEventsProtobufConverter {
+  def submissionSignedPubSubToProtobuf(obj: SubmissionSigned): SubmissionSignedPubSubMessage = {
+    SubmissionSignedPubSubMessage(
+      submissionId = Some(SubmissionIdMessage(obj.submissionId.institutionId, obj.submissionId.period, obj.submissionId.sequenceNumber))
+    )
+  }
+
+  def submissionSignedPubSubFromProtobuf(msg: SubmissionSignedPubSubMessage): SubmissionSigned = {
+    SubmissionSigned(
+      submissionId = submissionIdFromProtobuf(msg.submissionId.getOrElse(SubmissionIdMessage()))
+    )
+  }
+}

--- a/persistence-model/src/main/scala/hmda/persistence/serialization/pubsub/PubSubEventsProtobufSerializer.scala
+++ b/persistence-model/src/main/scala/hmda/persistence/serialization/pubsub/PubSubEventsProtobufSerializer.scala
@@ -1,0 +1,24 @@
+package hmda.persistence.serialization.pubsub
+
+import akka.serialization.SerializerWithStringManifest
+import hmda.persistence.messages.events.processing.PubSubEvents.SubmissionSignedPubSub
+import hmda.persistence.model.serialization.PubSubEvents.SubmissionSignedPubSubMessage
+import hmda.persistence.serialization.pubsub.PubSubEventsProtobufConverter._
+
+class PubSubEventsProtobufSerializer extends SerializerWithStringManifest {
+  override def identifier: Int = 1010
+
+  override def manifest(o: AnyRef) = o.getClass.getName
+
+  final val SubmissionSignedPubSubManifest = classOf[SubmissionSignedPubSub].getName
+
+  override def toBinary(o: AnyRef) = o match {
+    case evt: SubmissionSignedPubSub => submissionSignedPubSubToProtobuf(evt).toByteArray
+    case msg: Any => throw new RuntimeException(s"Cannot serialize this message: ${msg.toString}")
+  }
+
+  override def fromBinary(bytes: Array[Byte], manifest: String) = manifest match {
+    case SubmissionSignedPubSubManifest =>
+      submissionSignedPubSubFromProtobuf(SubmissionSignedPubSubMessage.parseFrom(bytes))
+  }
+}

--- a/persistence-model/src/main/scala/hmda/persistence/serialization/pubsub/PubSubEventsProtobufSerializer.scala
+++ b/persistence-model/src/main/scala/hmda/persistence/serialization/pubsub/PubSubEventsProtobufSerializer.scala
@@ -1,7 +1,7 @@
 package hmda.persistence.serialization.pubsub
 
 import akka.serialization.SerializerWithStringManifest
-import hmda.persistence.messages.events.processing.PubSubEvents.SubmissionSignedPubSub
+import hmda.persistence.messages.events.pubsub.PubSubEvents.SubmissionSignedPubSub
 import hmda.persistence.model.serialization.PubSubEvents.SubmissionSignedPubSubMessage
 import hmda.persistence.serialization.pubsub.PubSubEventsProtobufConverter._
 

--- a/persistence-model/src/test/scala/hmda/persistence/serialization/pubsub/PubSubEventsProtobufConverterSpec.scala
+++ b/persistence-model/src/test/scala/hmda/persistence/serialization/pubsub/PubSubEventsProtobufConverterSpec.scala
@@ -3,7 +3,7 @@ package hmda.persistence.serialization.pubsub
 import org.scalatest.{ MustMatchers, PropSpec }
 import org.scalatest.prop.PropertyChecks
 import hmda.model.institution.SubmissionGenerators._
-import hmda.persistence.messages.events.processing.PubSubEvents.SubmissionSignedPubSub
+import hmda.persistence.messages.events.pubsub.PubSubEvents.SubmissionSignedPubSub
 import hmda.persistence.model.serialization.PubSubEvents.SubmissionSignedPubSubMessage
 import hmda.persistence.serialization.pubsub.PubSubEventsProtobufConverter._
 

--- a/persistence-model/src/test/scala/hmda/persistence/serialization/pubsub/PubSubEventsProtobufConverterSpec.scala
+++ b/persistence-model/src/test/scala/hmda/persistence/serialization/pubsub/PubSubEventsProtobufConverterSpec.scala
@@ -3,7 +3,7 @@ package hmda.persistence.serialization.pubsub
 import org.scalatest.{ MustMatchers, PropSpec }
 import org.scalatest.prop.PropertyChecks
 import hmda.model.institution.SubmissionGenerators._
-import hmda.persistence.messages.events.processing.PubSubEvents.SubmissionSigned
+import hmda.persistence.messages.events.processing.PubSubEvents.SubmissionSignedPubSub
 import hmda.persistence.model.serialization.PubSubEvents.SubmissionSignedPubSubMessage
 import hmda.persistence.serialization.pubsub.PubSubEventsProtobufConverter._
 
@@ -11,9 +11,9 @@ class PubSubEventsProtobufConverterSpec extends PropSpec with PropertyChecks wit
 
   property("Submission Signed pubsub event must serialize to protobuf and back") {
     forAll(submissionIdGen) { submissionId =>
-      val submissionSigned = SubmissionSigned(submissionId)
+      val submissionSigned = SubmissionSignedPubSub(submissionId)
       val protobuf = submissionSignedPubSubToProtobuf(submissionSigned).toByteArray
-      submissionSignedPubSubFromProtobuf(SubmissionSignedPubSubMessage.parseFrom(protobuf)) mustBe SubmissionSigned(submissionId)
+      submissionSignedPubSubFromProtobuf(SubmissionSignedPubSubMessage.parseFrom(protobuf)) mustBe SubmissionSignedPubSub(submissionId)
     }
   }
 }

--- a/persistence-model/src/test/scala/hmda/persistence/serialization/pubsub/PubSubEventsProtobufConverterSpec.scala
+++ b/persistence-model/src/test/scala/hmda/persistence/serialization/pubsub/PubSubEventsProtobufConverterSpec.scala
@@ -1,0 +1,19 @@
+package hmda.persistence.serialization.pubsub
+
+import org.scalatest.{ MustMatchers, PropSpec }
+import org.scalatest.prop.PropertyChecks
+import hmda.model.institution.SubmissionGenerators._
+import hmda.persistence.messages.events.processing.PubSubEvents.SubmissionSigned
+import hmda.persistence.model.serialization.PubSubEvents.SubmissionSignedPubSubMessage
+import hmda.persistence.serialization.pubsub.PubSubEventsProtobufConverter._
+
+class PubSubEventsProtobufConverterSpec extends PropSpec with PropertyChecks with MustMatchers {
+
+  property("Submission Signed pubsub event must serialize to protobuf and back") {
+    forAll(submissionIdGen) { submissionId =>
+      val submissionSigned = SubmissionSigned(submissionId)
+      val protobuf = submissionSignedPubSubToProtobuf(submissionSigned).toByteArray
+      submissionSignedPubSubFromProtobuf(SubmissionSignedPubSubMessage.parseFrom(protobuf)) mustBe SubmissionSigned(submissionId)
+    }
+  }
+}

--- a/persistence-model/src/test/scala/hmda/persistence/serialization/pubsub/PubSubEventsProtobufSerializerSpec.scala
+++ b/persistence-model/src/test/scala/hmda/persistence/serialization/pubsub/PubSubEventsProtobufSerializerSpec.scala
@@ -1,0 +1,19 @@
+package hmda.persistence.serialization.pubsub
+
+import org.scalatest.{ MustMatchers, PropSpec }
+import org.scalatest.prop.PropertyChecks
+import hmda.model.institution.SubmissionGenerators._
+import hmda.persistence.messages.events.processing.PubSubEvents.SubmissionSignedPubSub
+
+class PubSubEventsProtobufSerializerSpec extends PropSpec with PropertyChecks with MustMatchers {
+
+  val serializer = new PubSubEventsProtobufSerializer()
+
+  property("Submission Signed PubSub messages must be serialized to binary and back") {
+    forAll(submissionIdGen) { submissionId =>
+      val msg = SubmissionSignedPubSub(submissionId)
+      val protobuf = serializer.toBinary(msg)
+      serializer.fromBinary(protobuf, serializer.SubmissionSignedPubSubManifest) mustBe msg
+    }
+  }
+}

--- a/persistence-model/src/test/scala/hmda/persistence/serialization/pubsub/PubSubEventsProtobufSerializerSpec.scala
+++ b/persistence-model/src/test/scala/hmda/persistence/serialization/pubsub/PubSubEventsProtobufSerializerSpec.scala
@@ -3,7 +3,7 @@ package hmda.persistence.serialization.pubsub
 import org.scalatest.{ MustMatchers, PropSpec }
 import org.scalatest.prop.PropertyChecks
 import hmda.model.institution.SubmissionGenerators._
-import hmda.persistence.messages.events.processing.PubSubEvents.SubmissionSignedPubSub
+import hmda.persistence.messages.events.pubsub.PubSubEvents.SubmissionSignedPubSub
 
 class PubSubEventsProtobufSerializerSpec extends PropSpec with PropertyChecks with MustMatchers {
 

--- a/persistence/src/main/scala/hmda/persistence/processing/SubmissionManager.scala
+++ b/persistence/src/main/scala/hmda/persistence/processing/SubmissionManager.scala
@@ -3,6 +3,8 @@ package hmda.persistence.processing
 import java.util.concurrent.TimeUnit
 
 import akka.actor.{ ActorRef, ActorSystem, Props, ReceiveTimeout }
+import akka.cluster.pubsub.DistributedPubSub
+import akka.cluster.pubsub.DistributedPubSubMediator.Publish
 import akka.pattern.ask
 import akka.util.Timeout
 import com.typesafe.config.ConfigFactory
@@ -12,6 +14,7 @@ import hmda.persistence.institutions.FilingPersistence.UpdateFilingStatus
 import hmda.persistence.HmdaSupervisor.{ FindFilings, FindHmdaFiling, FindSubmissions }
 import hmda.persistence.institutions.SubmissionPersistence.AddSubmissionFileName
 import hmda.persistence.messages.CommonMessages.{ Command, GetState, Shutdown }
+import hmda.persistence.messages.events.processing.PubSubEvents.SubmissionSigned
 import hmda.persistence.model.HmdaActor
 import hmda.persistence.processing.HmdaFileParser.ReadHmdaRawFile
 import hmda.persistence.processing.HmdaFileValidator.ValidationStarted
@@ -65,6 +68,8 @@ class SubmissionManager(validationStats: ActorRef, submissionId: SubmissionId) e
     .withDispatcher("persistence-dispatcher"))
   val filingPersistence = (supervisor ? FindFilings(FilingPersistence.name, submissionId.institutionId)).mapTo[ActorRef]
   val submissionPersistence = (supervisor ? FindSubmissions(SubmissionPersistence.name, submissionId.institutionId, submissionId.period)).mapTo[ActorRef]
+
+  val mediator = DistributedPubSub(context.system).mediator
 
   var uploaded: Int = 0
 
@@ -131,6 +136,7 @@ class SubmissionManager(validationStats: ActorRef, submissionId: SubmissionId) e
       result.map { r =>
         if (r.isDefined) updateFilingStatus(Completed)
         originalSender ! r
+        mediator ! Publish(PubSubTopics.submissionSigned, SubmissionSigned(submissionId))
       }
 
     case GetActorRef(name) => name match {

--- a/persistence/src/main/scala/hmda/persistence/processing/SubmissionManager.scala
+++ b/persistence/src/main/scala/hmda/persistence/processing/SubmissionManager.scala
@@ -14,7 +14,7 @@ import hmda.persistence.messages.commands.filing.FilingCommands._
 import hmda.persistence.HmdaSupervisor.{ FindFilings, FindHmdaFiling, FindSubmissions }
 import hmda.persistence.institutions.SubmissionPersistence.AddSubmissionFileName
 import hmda.persistence.messages.CommonMessages.{ Command, GetState, Shutdown }
-import hmda.persistence.messages.events.processing.PubSubEvents.SubmissionSignedPubSub
+import hmda.persistence.messages.events.pubsub.PubSubEvents.SubmissionSignedPubSub
 import hmda.persistence.model.HmdaActor
 import hmda.persistence.processing.HmdaFileParser.ReadHmdaRawFile
 import hmda.persistence.processing.HmdaFileValidator.ValidationStarted

--- a/persistence/src/main/scala/hmda/persistence/processing/SubmissionManager.scala
+++ b/persistence/src/main/scala/hmda/persistence/processing/SubmissionManager.scala
@@ -14,7 +14,7 @@ import hmda.persistence.messages.commands.filing.FilingCommands._
 import hmda.persistence.HmdaSupervisor.{ FindFilings, FindHmdaFiling, FindSubmissions }
 import hmda.persistence.institutions.SubmissionPersistence.AddSubmissionFileName
 import hmda.persistence.messages.CommonMessages.{ Command, GetState, Shutdown }
-import hmda.persistence.messages.events.processing.PubSubEvents.SubmissionSigned
+import hmda.persistence.messages.events.processing.PubSubEvents.SubmissionSignedPubSub
 import hmda.persistence.model.HmdaActor
 import hmda.persistence.processing.HmdaFileParser.ReadHmdaRawFile
 import hmda.persistence.processing.HmdaFileValidator.ValidationStarted
@@ -136,7 +136,7 @@ class SubmissionManager(validationStats: ActorRef, submissionId: SubmissionId) e
       result.map { r =>
         if (r.isDefined) updateFilingStatus(Completed)
         originalSender ! r
-        mediator ! Publish(PubSubTopics.submissionSigned, SubmissionSigned(submissionId))
+        mediator ! Publish(PubSubTopics.submissionSigned, SubmissionSignedPubSub(submissionId))
       }
 
     case GetActorRef(name) => name match {

--- a/query/src/main/scala/hmda/query/projections/filing/SubmissionCassandraProjection.scala
+++ b/query/src/main/scala/hmda/query/projections/filing/SubmissionCassandraProjection.scala
@@ -1,31 +1,14 @@
 package hmda.query.projections.filing
 
-import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
-import akka.stream.alpakka.cassandra.scaladsl.CassandraSink
-import akka.stream.scaladsl.Source
-import hmda.model.fi.lar.LoanApplicationRegister
-import hmda.persistence.messages.events.processing.CommonHmdaValidatorEvents.LarValidated
 import hmda.query.repository.filing.FilingCassandraRepository
-import hmda.persistence.processing.HmdaQuery._
 
 class SubmissionCassandraProjection(sys: ActorSystem, mat: ActorMaterializer) extends FilingCassandraRepository {
 
   def startUp(): Unit = {
     createKeyspace()
     createTable()
-    //projectLarData()
-  }
-
-  def projectLarData(): Unit = {
-    val source: Source[LoanApplicationRegister, NotUsed] = liveEvents("HmdaFiling-2017").map {
-      case LarValidated(lar, _) => lar
-    }
-    val sink = CassandraSink[LoanApplicationRegister](parallelism = 2, preparedStatement, statementBinder)
-    source
-      .map { e => println(e); e }
-      .to(sink).run()
   }
 
   override implicit def system: ActorSystem = sys

--- a/query/src/main/scala/hmda/query/projections/filing/SubmissionSignedEventQuerySubscriber.scala
+++ b/query/src/main/scala/hmda/query/projections/filing/SubmissionSignedEventQuerySubscriber.scala
@@ -1,0 +1,34 @@
+package hmda.query.projections.filing
+
+import akka.actor.Props
+import akka.cluster.pubsub.DistributedPubSub
+import akka.cluster.pubsub.DistributedPubSubMediator.{ Subscribe, SubscribeAck }
+import hmda.persistence.messages.events.processing.PubSubEvents.SubmissionSigned
+import hmda.persistence.model.HmdaActor
+import hmda.persistence.processing.PubSubTopics
+
+object SubmissionSignedEventQuerySubscriber {
+  val name = "SubmissionSignedEventQuerySubscriber"
+  def props(): Props = Props(new SubmissionSignedEventQuerySubscriber())
+}
+
+class SubmissionSignedEventQuerySubscriber() extends HmdaActor {
+
+  val mediator = DistributedPubSub(context.system).mediator
+
+  mediator ! Subscribe(PubSubTopics.submissionSigned, self)
+
+  def receive: Receive = {
+
+    case s: String =>
+      log.info("Got {}", s)
+
+    case SubscribeAck(Subscribe(PubSubTopics.submissionSigned, None, `self`)) =>
+      log.info(s"Subscribed to ${PubSubTopics.submissionSigned}")
+
+    case SubmissionSigned(submissionId) =>
+      log.info(s"Received submission signed event with submission id: ${submissionId.toString}")
+
+    case _ => //do nothing
+  }
+}

--- a/query/src/main/scala/hmda/query/projections/filing/SubmissionSignedEventQuerySubscriber.scala
+++ b/query/src/main/scala/hmda/query/projections/filing/SubmissionSignedEventQuerySubscriber.scala
@@ -6,7 +6,7 @@ import akka.cluster.pubsub.DistributedPubSubMediator.{ Subscribe, SubscribeAck }
 import akka.stream.ActorMaterializer
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.persistence.messages.events.processing.CommonHmdaValidatorEvents.LarValidated
-import hmda.persistence.messages.events.processing.PubSubEvents.SubmissionSigned
+import hmda.persistence.messages.events.processing.PubSubEvents.SubmissionSignedPubSub
 import hmda.persistence.model.HmdaActor
 import hmda.persistence.processing.PubSubTopics
 import hmda.persistence.processing.HmdaQuery._
@@ -34,7 +34,7 @@ class SubmissionSignedEventQuerySubscriber() extends HmdaActor with FilingCassan
     case SubscribeAck(Subscribe(PubSubTopics.submissionSigned, None, `self`)) =>
       repositoryLog.info(s"Subscribed to ${PubSubTopics.submissionSigned}")
 
-    case SubmissionSigned(submissionId) =>
+    case SubmissionSignedPubSub(submissionId) =>
       repositoryLog.info(s"Received submission signed event with submission id: ${submissionId.toString}")
       val persistenceId = s"HmdaFileValidator-$submissionId"
       val larSource = events(persistenceId).map {

--- a/query/src/main/scala/hmda/query/projections/filing/SubmissionSignedEventQuerySubscriber.scala
+++ b/query/src/main/scala/hmda/query/projections/filing/SubmissionSignedEventQuerySubscriber.scala
@@ -6,7 +6,7 @@ import akka.cluster.pubsub.DistributedPubSubMediator.{ Subscribe, SubscribeAck }
 import akka.stream.ActorMaterializer
 import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.persistence.messages.events.processing.CommonHmdaValidatorEvents.LarValidated
-import hmda.persistence.messages.events.processing.PubSubEvents.SubmissionSignedPubSub
+import hmda.persistence.messages.events.pubsub.PubSubEvents.SubmissionSignedPubSub
 import hmda.persistence.model.HmdaActor
 import hmda.persistence.processing.PubSubTopics
 import hmda.persistence.processing.HmdaQuery._

--- a/query/src/main/scala/hmda/query/projections/filing/SubmissionSignedEventQuerySubscriber.scala
+++ b/query/src/main/scala/hmda/query/projections/filing/SubmissionSignedEventQuerySubscriber.scala
@@ -1,18 +1,24 @@
 package hmda.query.projections.filing
 
-import akka.actor.Props
+import akka.actor.{ ActorSystem, Props }
 import akka.cluster.pubsub.DistributedPubSub
 import akka.cluster.pubsub.DistributedPubSubMediator.{ Subscribe, SubscribeAck }
+import akka.stream.ActorMaterializer
+import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.persistence.messages.events.processing.CommonHmdaValidatorEvents.LarValidated
 import hmda.persistence.messages.events.processing.PubSubEvents.SubmissionSigned
 import hmda.persistence.model.HmdaActor
 import hmda.persistence.processing.PubSubTopics
+import hmda.persistence.processing.HmdaQuery._
+import akka.stream.alpakka.cassandra.scaladsl.CassandraSink
+import hmda.query.repository.filing.FilingCassandraRepository
 
 object SubmissionSignedEventQuerySubscriber {
   val name = "SubmissionSignedEventQuerySubscriber"
   def props(): Props = Props(new SubmissionSignedEventQuerySubscriber())
 }
 
-class SubmissionSignedEventQuerySubscriber() extends HmdaActor {
+class SubmissionSignedEventQuerySubscriber() extends HmdaActor with FilingCassandraRepository {
 
   val mediator = DistributedPubSub(context.system).mediator
 
@@ -21,14 +27,27 @@ class SubmissionSignedEventQuerySubscriber() extends HmdaActor {
   def receive: Receive = {
 
     case s: String =>
-      log.info("Got {}", s)
+      repositoryLog.info("Got {}", s)
 
     case SubscribeAck(Subscribe(PubSubTopics.submissionSigned, None, `self`)) =>
-      log.info(s"Subscribed to ${PubSubTopics.submissionSigned}")
+      repositoryLog.info(s"Subscribed to ${PubSubTopics.submissionSigned}")
 
     case SubmissionSigned(submissionId) =>
-      log.info(s"Received submission signed event with submission id: ${submissionId.toString}")
+      repositoryLog.info(s"Received submission signed event with submission id: ${submissionId.toString}")
+      val persistenceId = s"HmdaFileValidator-$submissionId"
+      val larSource = events(persistenceId).map {
+        case LarValidated(lar, _) => lar
+      }
+
+      val sink = CassandraSink[LoanApplicationRegister](parallelism = 2, preparedStatement, statementBinder)
+      larSource
+        .map { lar => repositoryLog.info(lar.toCSV); lar }
+        .to(sink).run()
 
     case _ => //do nothing
   }
+
+  override implicit def system: ActorSystem = context.system
+
+  override implicit def materializer: ActorMaterializer = ActorMaterializer()
 }

--- a/query/src/main/scala/hmda/query/repository/CassandraRepository.scala
+++ b/query/src/main/scala/hmda/query/repository/CassandraRepository.scala
@@ -21,7 +21,7 @@ trait CassandraRepository[A] {
   implicit val ec: ExecutionContext
   implicit val scheduler: Scheduler
 
-  val log = LoggerFactory.getLogger("CassandraRepository")
+  val repositoryLog = LoggerFactory.getLogger("CassandraRepository")
 
   val keyspace = cassandraKeyspace
 
@@ -29,7 +29,7 @@ trait CassandraRepository[A] {
 
   @tailrec
   private def retry[T](n: Int)(fn: => T): Try[T] = {
-    log.info("*********ATTEMPTING CONNECTION TO CASSANDRA QUERY CLUSTER********")
+    repositoryLog.info("*********ATTEMPTING CONNECTION TO CASSANDRA QUERY CLUSTER********")
     Try { fn } match {
       case x: Success[T] => x
       case _ if n > 1 =>

--- a/query/src/main/scala/hmda/query/repository/filing/FilingCassandraRepository.scala
+++ b/query/src/main/scala/hmda/query/repository/filing/FilingCassandraRepository.scala
@@ -63,7 +63,7 @@ trait FilingCassandraRepository extends CassandraRepository[LoanApplicationRegis
 
   val statementBinder = (lar: LoanApplicationRegister, statement: PreparedStatement) =>
     statement.bind(
-      lar.id.toString,
+      lar.loan.id + lar.respondentId + lar.agencyCode,
       lar.respondentId,
       new Integer(lar.agencyCode),
       lar.loan.id,


### PR DESCRIPTION
Closes #1282

**Important Note**: this improves on the previous model by only projecting into the `lars2017` table when a submission is signed, as opposed to every time a submission is validated. It still doesn't address deleting previously signed submissions, so it does not fully address resubmissions. This [ticket](https://github.com/cfpb/hmda-platform/issues/1320) has been created for that.

This PR uses the [DistributedPubSub](https://doc.akka.io/docs/akka/current/scala/cluster-usage.html?_ga=2.72327060.605812294.1510233192-1301779606.1510233191#distributed-publish-subscribe) extension from `Akka` to deliver events across the cluster, and implements a publish / subscribe model to trigger actions based on subscribing to different topics (in this case, only the `SubmissionSignedPubSub` event is listened to in the `SubmissionSignedEventQuerySubscriber` class, but the model can be extended to other events).

To test, open a terminal and run the cluster with the `api` and `persistence` roles. On another terminal window, run the `query` and `publication` roles. Go through a normal submission process and upon signing, you should see logs written in the terminal with the `query` role displaying details about the `LAR` inserted into `Cassandra`. To check that data has been loaded correctly the following query can be used:

```shell
cqlsh> select count(*) from hmda_query.lars2017;  
```