### PR TITLE
Q030 fix

### DIFF
--- a/api/src/test/scala/hmda/api/http/ValidationErrorConverterSpec.scala
+++ b/api/src/test/scala/hmda/api/http/ValidationErrorConverterSpec.scala
@@ -80,7 +80,7 @@ class ValidationErrorConverterSpec extends WordSpec with MustMatchers with Valid
     "convert edits to CSV" in {
       val csvResults: Seq[String] = validationErrorsToCsvResults(validationState).split("\n")
 
-      csvResults.length mustBe 14
+      csvResults.length mustBe 18
       csvResults.head mustBe "editType, editId, loanId"
       csvResults(1) mustBe "Syntactical, S020, Transmittal Sheet"
       csvResults.last mustBe "Macro, Q029, "

--- a/persistence/src/test/scala/hmda/persistence/processing/HmdaFileValidatorSpec.scala
+++ b/persistence/src/test/scala/hmda/persistence/processing/HmdaFileValidatorSpec.scala
@@ -120,7 +120,12 @@ class HmdaFileValidatorSpec extends ActorSpec with BeforeAndAfterEach with HmdaF
           ValidityValidationError("4977566612", "V555", false),
           ValidityValidationError("4977566612", "V560", false)
         ),
-        Nil,
+        List(
+          QualityValidationError("8299422144", "Q030", false),
+          QualityValidationError("9471480396", "Q030", false),
+          QualityValidationError("2185751599", "Q030", false),
+          QualityValidationError("4977566612", "Q030", false)
+        ),
         qualityVerified = false,
         List(
           MacroValidationError("Q008"),

--- a/validation/src/main/scala/hmda/validation/engine/lar/quality/LarQualityEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/lar/quality/LarQualityEngine.scala
@@ -23,7 +23,7 @@ trait LarQualityEngine extends LarCommonEngine with ValidationApi {
       Q025,
       Q027,
       Q029,
-      Q030.inContext(ctx),
+      Q030,
       Q032,
       Q035,
       Q036,

--- a/validation/src/main/scala/hmda/validation/rules/lar/quality/Q030.scala
+++ b/validation/src/main/scala/hmda/validation/rules/lar/quality/Q030.scala
@@ -1,48 +1,20 @@
 package hmda.validation.rules.lar.quality
 
-import hmda.model.fi.lar.{ Geography, LoanApplicationRegister }
-import hmda.model.institution.Institution
-import hmda.validation.context.ValidationContext
+import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.validation.dsl.PredicateCommon._
-import hmda.validation.dsl.PredicateGeo._
 import hmda.validation.dsl.PredicateSyntax._
-import hmda.validation.dsl.{ Failure, Result, Success }
-import hmda.validation.rules.{ EditCheck, IfInstitutionPresentIn }
+import hmda.validation.dsl.Result
+import hmda.validation.rules.EditCheck
 
-class Q030 private (institution: Institution) extends EditCheck[LoanApplicationRegister] {
+object Q030 extends EditCheck[LoanApplicationRegister] {
   override def name: String = "Q030"
 
   override def apply(lar: LoanApplicationRegister): Result = {
     when(lar.actionTakenType is containedIn(1 to 6)) {
-      val geo: Geography = lar.geography
-      (geo, institution.cra) match {
-        case (Geography("NA", "NA", "NA", "NA"), false) => Success()
-        case (Geography(_, "NA", _, _), _) => Failure()
-        case (Geography(_, _, "NA", _), _) => Failure()
-        case _ =>
-          when(institution.cra is false) {
-            when(geo is smallCounty) {
-              geo.tract is "NA"
-            }
-          } and when(geo.tract is "NA") {
-            geo is smallCounty // and therefore also a valid state/county combination; no need to check again.
-          } and when(geo.msa not "NA") {
-            (geo is validStateCountyMsaCombination) and
-              when(geo.tract not "NA") {
-                geo is validCompleteCombination
-              }
-          } and when(geo.msa is "NA") {
-            when(geo.tract not "NA") {
-              geo is validStateCountyTractCombination
-            }
-          }
-      }
+      (lar.geography.msa not "NA") and
+        (lar.geography.tract not "NA") and
+        (lar.geography.county not "NA") and
+        (lar.geography.state not "NA")
     }
-  }
-}
-
-object Q030 {
-  def inContext(context: ValidationContext): EditCheck[LoanApplicationRegister] = {
-    IfInstitutionPresentIn(context) { new Q030(_) }
   }
 }

--- a/validation/src/test/scala/hmda/validation/rules/lar/quality/Q030Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/quality/Q030Spec.scala
@@ -22,9 +22,17 @@ class Q030Spec extends LarEditCheckSpec {
   }
 
   property("fails when action taken is in range and geography is NA") {
-    forAll(larGen, Gen.choose(1, 6)) { (lar, i) =>
-      val invalidGeo = Geography("NA", "NA", "NA", "NA")
-      val invalidLar = lar.copy(actionTakenType = i, geography = invalidGeo)
+    val geoGen = Gen.oneOf[Geography](
+      Geography("NA", "NA", "NA", "NA"),
+      Geography("NA", "NA", "NA", "1"),
+      Geography("NA", "NA", "1", "2"),
+      Geography("NA", "1", "2", "3"),
+      Geography("1", "NA", "2", "3"),
+      Geography("1", "2", "NA", "3"),
+      Geography("1", "2", "3", "NA")
+    )
+    forAll(larGen, Gen.choose(1, 6), geoGen) { (lar, i, g) =>
+      val invalidLar = lar.copy(actionTakenType = i, geography = g)
       invalidLar.mustFail
     }
   }

--- a/validation/src/test/scala/hmda/validation/rules/lar/quality/Q030Spec.scala
+++ b/validation/src/test/scala/hmda/validation/rules/lar/quality/Q030Spec.scala
@@ -1,210 +1,33 @@
 package hmda.validation.rules.lar.quality
 
-import hmda.model.fi.lar.{ Geography, LarGenerators, LoanApplicationRegister }
-import hmda.model.institution.ExternalIdType.UndeterminedExternalId
-import hmda.model.institution._
-import hmda.validation.context.ValidationContext
-import hmda.validation.dsl.{ Failure, Success }
+import hmda.model.fi.lar.{ Geography, LoanApplicationRegister }
+import hmda.validation.rules.EditCheck
+import hmda.validation.rules.lar.LarEditCheckSpec
 import org.scalacheck.Gen
-import org.scalatest.{ Assertion, MustMatchers, WordSpec }
-import org.scalatest.prop.{ PropertyChecks, TableFor1 }
 
-class Q030Spec extends WordSpec with PropertyChecks with LarGenerators with MustMatchers {
-
-  val respondent = Respondent(ExternalId("", UndeterminedExternalId), "some bank", "", "", "")
-  val parent = Parent("", 0, "some parent", "", "")
-  val topHolder = TopHolder(-1, "", "", "", "")
-
-  val craFI = Institution("123", Agency.CFPB, 2017, InstitutionType.Bank, cra = true, Set(), Set(), respondent, hmdaFilerFlag = false, parent, 0, 0, topHolder)
-  val nonCraFI = craFI.copy(cra = false)
-  val craOrNot = Table("CRA", craFI, nonCraFI)
-
-  "Q030" when {
-    "action taken type is 7 or 8 (preapproval)" must {
-      val actionTaken = Gen.oneOf(7, 8)
-      "pass" in {
-        forAll(craOrNot) { implicit fi =>
-          forAll(larGen, actionTaken) { (lar, action) =>
-            lar.copy(actionTakenType = action).mustPass
-          }
-        }
-      }
-    }
-
-    "action taken is 1-6" when {
-      val actionTaken = Gen.oneOf(1 to 6)
-      val larGen = for {
-        lar <- super.larGen
-        action <- actionTaken
-      } yield lar.copy(actionTakenType = action)
-
-      val smallCountyInMSA: Geography = Geography("10100", "46", "045", "9621.00")
-      val smallCountyOutsideMSA: Geography = Geography("NA", "47", "109", "9307.00")
-      val largeCountyInMSA = Geography("13820", "01", "117", "0304.08")
-      val largeCountyOutsideMSA = Geography("NA", "27", "097", "7804.00")
-      val someOtherMSA = "48300"
-      val someOtherState = "55"
-      val someOtherTract = "7424.02"
-
-      "institution is NOT a CRA reporter" when {
-        implicit val fi = nonCraFI
-        "all 4 geography fields are NA" must {
-          val geo = Geography("NA", "NA", "NA", "NA")
-          "pass" in {
-            geo.mustPass
-          }
-        }
-        "county is present and small" when {
-          "tract is NA" must {
-            "pass" in {
-              smallCountyInMSA.withoutTract.mustPass
-              smallCountyOutsideMSA.withoutTract.mustPass
-            }
-          }
-          "tract is present (and matches)" must {
-            "fail" in {
-              smallCountyInMSA.mustFail
-              smallCountyOutsideMSA.mustFail
-            }
-          }
-        }
-      }
-      "institution is a CRA reporter" when {
-        implicit val fi = craFI
-        "all 4 geography fields are NA" must {
-          val geo = Geography("NA", "NA", "NA", "NA")
-          "fail" in {
-            geo.mustFail
-          }
-        }
-        "state or county is NA (no matter what else is true)" must {
-          "fail" in {
-            forAll(larGen) { (lar) =>
-              whenever(lar.geography.state == "NA" || lar.geography.county == "NA") {
-                lar.mustFail
-              }
-            }
-          }
-        }
-        "county is present and small" when {
-          "tract is NA" must {
-            "pass" in {
-              smallCountyInMSA.withoutTract.mustPass
-              smallCountyOutsideMSA.withoutTract.mustPass
-            }
-          }
-          "tract is present (and matches)" must {
-            "pass" in {
-              smallCountyInMSA.mustPass
-              smallCountyOutsideMSA.mustPass
-            }
-          }
-        }
-      }
-
-      "property MSA/MD is present" when {
-        "tract is NA" when {
-          "MSA/MD, state and county match" must {
-            "pass" in {
-              smallCountyInMSA.withoutTract.mustPass(craOrNot)
-            }
-          }
-          "MSA/MD, state and county do not match" must {
-            "fail" in {
-              smallCountyInMSA.withoutTract.copy(msa = someOtherMSA).mustFail(craOrNot)
-            }
-          }
-          "county is large" must {
-            "fail" in {
-              largeCountyInMSA.withoutTract.mustFail(craOrNot)
-            }
-          }
-        }
-        "tract is present" when {
-          "MSA/MD, state, county, and tract match" must {
-            "pass" in {
-              largeCountyInMSA.mustPass(craOrNot)
-            }
-          }
-          "MSA/MD, state, county, and tract do not match" must {
-            "fail" in {
-              smallCountyInMSA.copy(tract = someOtherTract).mustFail(craOrNot)
-            }
-          }
-        }
-      }
-
-      "property MSA/MD is NA" when {
-        "tract is NA" when {
-          "state and county match" must {
-            "pass" in {
-              smallCountyOutsideMSA.withoutTract.mustPass(craOrNot)
-            }
-          }
-          "state and county do not match" must {
-            "fail" in {
-              smallCountyOutsideMSA.withoutTract.copy(state = someOtherState).mustFail(craOrNot)
-            }
-          }
-          "county is large" must {
-            "fail" in {
-              largeCountyOutsideMSA.withoutTract.mustFail(craOrNot)
-            }
-          }
-        }
-        "tract is present" when {
-          "state, county, and tract match" must {
-            "pass" in {
-              largeCountyOutsideMSA.mustPass(craOrNot)
-            }
-          }
-          "state, county, and tract do not match" must {
-            "fail" in {
-              smallCountyOutsideMSA.copy(state = someOtherState).mustFail(craOrNot)
-              smallCountyOutsideMSA.copy(tract = someOtherTract).mustFail(craOrNot)
-            }
-          }
-        }
-      }
-
-      {
-        val msaOrNot = Gen.oneOf("13820", "NA")
-        val tractOrNot = Gen.oneOf("0304.08", "NA")
-
-        "state is present but county is NA" must {
-          forAll(craOrNot) { implicit fi: Institution =>
-            s"fail when CRA is ${fi.cra}" in {
-              forAll(msaOrNot, tractOrNot) { (msa, tract) =>
-                Geography(msa, "01", "NA", tract).mustFail
-              }
-            }
-          }
-        }
-        "county is present but state is NA" must {
-          forAll(craOrNot) { implicit fi: Institution =>
-            s"fail when CRA is ${fi.cra}" in {
-              forAll(msaOrNot, tractOrNot) { (msa, tract) =>
-                Geography(msa, "NA", "117", tract).mustFail
-              }
-            }
-          }
-        }
-      }
-
-      implicit class GeoChecker(geo: Geography) {
-        def mustFail(implicit fi: Institution) = forAll(larGen) { lar => lar.copy(geography = geo).mustFail }
-        def mustPass(implicit fi: Institution) = forAll(larGen) { lar => lar.copy(geography = geo).mustPass }
-        def withoutTract = geo.copy(tract = "NA")
-        def mustFail(fiGen: TableFor1[Institution]): Assertion = forAll(fiGen) { fi => geo.mustFail(fi) }
-        def mustPass(fiGen: TableFor1[Institution]): Assertion = forAll(fiGen) { fi => geo.mustPass(fi) }
-      }
+class Q030Spec extends LarEditCheckSpec {
+  property("passes when action take is not in range") {
+    forAll(larGen, Gen.choose(7, 9)) { (lar, i) =>
+      val validLar = lar.copy(actionTakenType = i)
+      validLar.mustPass
     }
   }
 
-  implicit class LarChecker(lar: LoanApplicationRegister) {
-    def mustFail(implicit fi: Institution) = check(lar, fi) mustBe a[Failure]
-    def mustPass(implicit fi: Institution) = check(lar, fi) mustBe a[Success]
-    def check(lar: LoanApplicationRegister, fi: Institution) = Q030.inContext(ValidationContext(Some(fi), None)).apply(lar)
+  property("passes when action taken is in range and geography is not NA") {
+    forAll(larGen, Gen.choose(1, 6), stringOfN(3, Gen.alphaChar)) { (lar, i, geo) =>
+      val validGeo = Geography(geo, geo, geo, geo)
+      val validLar = lar.copy(actionTakenType = i, geography = validGeo)
+      validLar.mustPass
+    }
   }
 
+  property("fails when action taken is in range and geography is NA") {
+    forAll(larGen, Gen.choose(1, 6)) { (lar, i) =>
+      val invalidGeo = Geography("NA", "NA", "NA", "NA")
+      val invalidLar = lar.copy(actionTakenType = i, geography = invalidGeo)
+      invalidLar.mustFail
+    }
+  }
+
+  override def check: EditCheck[LoanApplicationRegister] = Q030
 }


### PR DESCRIPTION
This fix offloads the logic of determining the CRA status of an Institution to the filer, allowing them to confirm that the information is correct or fix the LAR with a new upload.

Closes #1324 