### PR TITLE
Load APOR data every day

### DIFF
--- a/persistence/src/main/resources/application.conf
+++ b/persistence/src/main/resources/application.conf
@@ -13,7 +13,8 @@ akka {
       AporCalculator {
         description = "Retrieve APOR tables from S3 on a schedule"
         //expression = "*/30 * * ? * *"
-        expression = "0 0 23 ? * THU"
+        expression = "0 0 23 ? * *"
+        expression = ${?APOR_DATA_LOAD_SCHEDULE}
       }
     }
   }


### PR DESCRIPTION
As we discussed in standup today, this PR:

- sets the APOR ingestion to happen at 11pm Eastern every day (rather than every Thursday)
- Allows overriding the cron schedule with an environment variable (`APOR_DATA_LOAD_SCHEDULE`)

Once this is merged, remember to:
 - [ ] Remove `-Dakka.quartz.schedules.AporCalculator.expression="[expression]"` from production settings.