### PR TITLE
Faster validation

### DIFF
--- a/persistence/src/main/resources/application.conf
+++ b/persistence/src/main/resources/application.conf
@@ -15,6 +15,7 @@ hmda {
   }
   actor-flow-parallelism = 4
   processing.parallelism = 3
+  processing.parallelism = ${?HMDA_PROCESSING_PARALLELISM}
   edits.demoMode = false
   edits.demoMode = ${?EDITS_DEMO_MODE}
   journal.snapshot.counter = 1000

--- a/persistence/src/main/resources/application.conf
+++ b/persistence/src/main/resources/application.conf
@@ -14,6 +14,7 @@ hmda {
     timeout = 5
   }
   actor-flow-parallelism = 4
+  processing.parallelism = 3
   edits.demoMode = false
   edits.demoMode = ${?EDITS_DEMO_MODE}
   journal.snapshot.counter = 1000

--- a/persistence/src/main/scala/hmda/persistence/processing/HmdaFileValidator.scala
+++ b/persistence/src/main/scala/hmda/persistence/processing/HmdaFileValidator.scala
@@ -106,6 +106,7 @@ class HmdaFileValidator(supervisor: ActorRef, validationStats: ActorRef, submiss
 
   val config = ConfigFactory.load()
   val duration = config.getInt("hmda.actor-lookup-timeout")
+  val processingParallelism = config.getInt("hmda.processing.parallelism")
 
   implicit val timeout = Timeout(duration.seconds)
 
@@ -162,7 +163,7 @@ class HmdaFileValidator(supervisor: ActorRef, validationStats: ActorRef, submiss
         .map(e => e.asInstanceOf[LarParsed].lar)
 
       larSource
-        .via(balancer(validate(ctx, self), 3))
+        .via(balancer(validate(ctx, self), processingParallelism))
         .map {
           case Right(_) => //do nothing
           case Left(errors) => LarValidationErrors(errors.list.toList)

--- a/persistence/src/main/scala/hmda/persistence/processing/HmdaFileValidator.scala
+++ b/persistence/src/main/scala/hmda/persistence/processing/HmdaFileValidator.scala
@@ -27,10 +27,10 @@ import hmda.persistence.processing.HmdaQuery._
 import hmda.persistence.messages.events.processing.CommonHmdaValidatorEvents._
 import hmda.persistence.messages.events.processing.HmdaFileParserEvents.{ LarParsed, TsParsed }
 import hmda.persistence.messages.events.processing.HmdaFileValidatorEvents._
-import hmda.persistence.messages.events.validation.SubmissionLarStatsEvents.{ MacroStatsUpdated, SubmittedLarsUpdated }
+import hmda.persistence.messages.events.validation.SubmissionLarStatsEvents.MacroStatsUpdated
 import hmda.persistence.model.HmdaSupervisorActor.FindActorByName
 import hmda.persistence.processing.SubmissionManager.GetActorRef
-import hmda.validation.stats.SubmissionLarStats.{ CountSubmittedLarsInSubmission, PersistStatsForMacroEdits }
+import hmda.validation.stats.SubmissionLarStats.PersistStatsForMacroEdits
 import hmda.validation.stats.ValidationStats.AddSubmissionTaxId
 import hmda.validation.stats.SubmissionLarStats
 import HmdaFileWorker._
@@ -168,16 +168,6 @@ class HmdaFileValidator(supervisor: ActorRef, validationStats: ActorRef, submiss
           case Left(errors) => LarValidationErrors(errors.list.toList)
         }
         .runWith(Sink.actorRef(self, ValidateMacro(larSource, replyTo)))
-
-    //      larSource.map { lar =>
-    //        self ! lar
-    //        validateLar(lar, ctx).toEither
-    //      }
-    //        .map {
-    //          case Right(_) => // do nothing
-    //          case Left(errors) => LarValidationErrors(errors.list.toList)
-    //        }
-    //        .runWith(Sink.actorRef(self, ValidateMacro(larSource, replyTo)))
 
     case ValidateAggregate(ts) =>
       performAsyncChecks(ts, ctx)

--- a/persistence/src/main/scala/hmda/persistence/processing/HmdaFileWorker.scala
+++ b/persistence/src/main/scala/hmda/persistence/processing/HmdaFileWorker.scala
@@ -1,0 +1,118 @@
+package hmda.persistence.processing
+
+import java.io.File
+import java.time.Instant
+import java.time.format.DateTimeFormatter
+
+import akka.{ Done, NotUsed }
+import akka.actor.{ Actor, ActorRef, ActorSystem, Props }
+import akka.stream.{ ActorMaterializer, FlowShape }
+import akka.stream.scaladsl.{ Balance, FileIO, Flow, Framing, GraphDSL, Merge, Sink, Source }
+import akka.util.ByteString
+import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.validation.ValidationError
+import hmda.parser.fi.lar.LarCsvParser
+import hmda.persistence.messages.CommonMessages.Command
+//import hmda.persistence.processing.HmdaFileWorker.TestActor.FinishedLarValidation
+import hmda.validation.context.ValidationContext
+import hmda.validation.engine.LarValidationErrors
+import hmda.validation.engine.lar.LarEngine
+
+import scala.concurrent.{ ExecutionContext, Future }
+import scalaz.ValidationNel
+
+object HmdaFileWorker extends LarEngine {
+
+  //  implicit val system: ActorSystem = ActorSystem("validation-worker")
+  //  implicit val ec: ExecutionContext = system.dispatcher
+  //  implicit val mat: ActorMaterializer = ActorMaterializer()
+
+  //  def main(args: Array[String]): Unit = {
+  //
+  //    val ctx = ValidationContext(None, None)
+  //
+  //    if (args.length < 1) {
+  //      println("Please provide a file")
+  //      System.exit(0)
+  //    }
+  //
+  //    val file = new File(args(0))
+  //
+  //    val replyTo = system.actorOf(TestActor.props)
+  //
+  //    val source = FileIO.fromPath(file.toPath)
+  //
+  //    val framing: Flow[ByteString, ByteString, NotUsed] = {
+  //      Framing.delimiter(ByteString("\n"), maximumFrameLength = 65536, allowTruncation = true)
+  //    }
+  //
+  //    val larSource: Source[LoanApplicationRegister, Any] =
+  //      source
+  //        .via(framing)
+  //        .drop(1)
+  //        .map(_.utf8String)
+  //        .map(s => LarCsvParser(s).getOrElse(LoanApplicationRegister()))
+  //
+  //    println(s"Start Time: ${Instant.now().toString}")
+  //    processValidation(larSource, ctx, replyTo, FinishedLarValidation)
+  //
+  //  }
+
+  def validate(ctx: ValidationContext, replyTo: ActorRef) = {
+    Flow[LoanApplicationRegister]
+      .map { lar =>
+        replyTo ! lar
+        validateLar(lar, ctx).toEither
+      }
+  }
+  //
+  //  def processValidation(larSource: Source[LoanApplicationRegister, Any], ctx: ValidationContext, replyTo: ActorRef, endMessage: Command): NotUsed = {
+  //    val validated: Flow[LoanApplicationRegister, LarValidation, NotUsed] =
+  //      Flow[LoanApplicationRegister]
+  //        .map { lar =>
+  //          replyTo ! lar
+  //          validateLar(lar, ctx)
+  //        }
+  //
+  //    larSource
+  //      .via(balancer(validated, 3))
+  //      .runWith(Sink.actorRef(replyTo, FinishedLarValidation))
+  //
+  //  }
+
+  def balancer[In, Out](worker: Flow[In, Out, Any], workerCount: Int): Flow[In, Out, NotUsed] = {
+    import GraphDSL.Implicits._
+
+    Flow.fromGraph(GraphDSL.create() { implicit b =>
+      val balancer = b.add(Balance[In](workerCount, waitForAllDownstreams = true))
+      val merge = b.add(Merge[Out](workerCount))
+
+      for (_ <- 1 to workerCount) {
+        balancer ~> worker.async ~> merge
+      }
+
+      FlowShape(balancer.in, merge.out)
+    })
+  }
+
+  //  object TestActor {
+  //
+  //    case object FinishedLarValidation extends Command
+  //
+  //    def props: Props = Props[TestActor]
+  //  }
+  //
+  //  class TestActor extends Actor {
+  //    override def receive: Receive = {
+  //      case larValidation: ValidationNel[ValidationError, LoanApplicationRegister] =>
+  //
+  //      case lar: LoanApplicationRegister =>
+  //        println(lar)
+  //
+  //      case FinishedLarValidation =>
+  //        println(s"End Time: ${Instant.now().toString}")
+  //
+  //    }
+  //  }
+
+}

--- a/persistence/src/main/scala/hmda/persistence/processing/HmdaFileWorker.scala
+++ b/persistence/src/main/scala/hmda/persistence/processing/HmdaFileWorker.scala
@@ -1,62 +1,14 @@
 package hmda.persistence.processing
 
-import java.io.File
-import java.time.Instant
-import java.time.format.DateTimeFormatter
-
-import akka.{ Done, NotUsed }
-import akka.actor.{ Actor, ActorRef, ActorSystem, Props }
-import akka.stream.{ ActorMaterializer, FlowShape }
-import akka.stream.scaladsl.{ Balance, FileIO, Flow, Framing, GraphDSL, Merge, Sink, Source }
-import akka.util.ByteString
+import akka.NotUsed
+import akka.actor.ActorRef
+import akka.stream.FlowShape
+import akka.stream.scaladsl.{ Balance, Flow, GraphDSL, Merge }
 import hmda.model.fi.lar.LoanApplicationRegister
-import hmda.model.validation.ValidationError
-import hmda.parser.fi.lar.LarCsvParser
-import hmda.persistence.messages.CommonMessages.Command
-//import hmda.persistence.processing.HmdaFileWorker.TestActor.FinishedLarValidation
 import hmda.validation.context.ValidationContext
-import hmda.validation.engine.LarValidationErrors
 import hmda.validation.engine.lar.LarEngine
 
-import scala.concurrent.{ ExecutionContext, Future }
-import scalaz.ValidationNel
-
 object HmdaFileWorker extends LarEngine {
-
-  //  implicit val system: ActorSystem = ActorSystem("validation-worker")
-  //  implicit val ec: ExecutionContext = system.dispatcher
-  //  implicit val mat: ActorMaterializer = ActorMaterializer()
-
-  //  def main(args: Array[String]): Unit = {
-  //
-  //    val ctx = ValidationContext(None, None)
-  //
-  //    if (args.length < 1) {
-  //      println("Please provide a file")
-  //      System.exit(0)
-  //    }
-  //
-  //    val file = new File(args(0))
-  //
-  //    val replyTo = system.actorOf(TestActor.props)
-  //
-  //    val source = FileIO.fromPath(file.toPath)
-  //
-  //    val framing: Flow[ByteString, ByteString, NotUsed] = {
-  //      Framing.delimiter(ByteString("\n"), maximumFrameLength = 65536, allowTruncation = true)
-  //    }
-  //
-  //    val larSource: Source[LoanApplicationRegister, Any] =
-  //      source
-  //        .via(framing)
-  //        .drop(1)
-  //        .map(_.utf8String)
-  //        .map(s => LarCsvParser(s).getOrElse(LoanApplicationRegister()))
-  //
-  //    println(s"Start Time: ${Instant.now().toString}")
-  //    processValidation(larSource, ctx, replyTo, FinishedLarValidation)
-  //
-  //  }
 
   def validate(ctx: ValidationContext, replyTo: ActorRef) = {
     Flow[LoanApplicationRegister]
@@ -65,20 +17,6 @@ object HmdaFileWorker extends LarEngine {
         validateLar(lar, ctx).toEither
       }
   }
-  //
-  //  def processValidation(larSource: Source[LoanApplicationRegister, Any], ctx: ValidationContext, replyTo: ActorRef, endMessage: Command): NotUsed = {
-  //    val validated: Flow[LoanApplicationRegister, LarValidation, NotUsed] =
-  //      Flow[LoanApplicationRegister]
-  //        .map { lar =>
-  //          replyTo ! lar
-  //          validateLar(lar, ctx)
-  //        }
-  //
-  //    larSource
-  //      .via(balancer(validated, 3))
-  //      .runWith(Sink.actorRef(replyTo, FinishedLarValidation))
-  //
-  //  }
 
   def balancer[In, Out](worker: Flow[In, Out, Any], workerCount: Int): Flow[In, Out, NotUsed] = {
     import GraphDSL.Implicits._
@@ -94,25 +32,5 @@ object HmdaFileWorker extends LarEngine {
       FlowShape(balancer.in, merge.out)
     })
   }
-
-  //  object TestActor {
-  //
-  //    case object FinishedLarValidation extends Command
-  //
-  //    def props: Props = Props[TestActor]
-  //  }
-  //
-  //  class TestActor extends Actor {
-  //    override def receive: Receive = {
-  //      case larValidation: ValidationNel[ValidationError, LoanApplicationRegister] =>
-  //
-  //      case lar: LoanApplicationRegister =>
-  //        println(lar)
-  //
-  //      case FinishedLarValidation =>
-  //        println(s"End Time: ${Instant.now().toString}")
-  //
-  //    }
-  //  }
 
 }

--- a/persistence/src/main/scala/hmda/persistence/processing/HmdaFileWorker.scala
+++ b/persistence/src/main/scala/hmda/persistence/processing/HmdaFileWorker.scala
@@ -5,12 +5,15 @@ import akka.actor.ActorRef
 import akka.stream.FlowShape
 import akka.stream.scaladsl.{ Balance, Flow, GraphDSL, Merge }
 import hmda.model.fi.lar.LoanApplicationRegister
+import hmda.model.validation.ValidationError
 import hmda.validation.context.ValidationContext
 import hmda.validation.engine.lar.LarEngine
 
+import scalaz.NonEmptyList
+
 object HmdaFileWorker extends LarEngine {
 
-  def validate(ctx: ValidationContext, replyTo: ActorRef) = {
+  def validate(ctx: ValidationContext, replyTo: ActorRef): Flow[LoanApplicationRegister, Either[NonEmptyList[ValidationError], LoanApplicationRegister], NotUsed] = {
     Flow[LoanApplicationRegister]
       .map { lar =>
         replyTo ! lar


### PR DESCRIPTION
**Note**: I had to change the `HmdaFileValidatorSpec` test in order to account for parallel, asynchronous validation of edits. The results are the same as previously, but the `List` results don't have their contents ordered the same way