### PR TITLE
Add partial TS parse/validation public API implementation

### DIFF
--- a/api-model/src/main/scala/hmda/api/protocol/fi/ts/TsProtocol.scala
+++ b/api-model/src/main/scala/hmda/api/protocol/fi/ts/TsProtocol.scala
@@ -1,0 +1,11 @@
+package hmda.api.protocol.fi.ts
+
+import hmda.model.fi.ts._
+import spray.json.DefaultJsonProtocol
+
+trait TsProtocol extends DefaultJsonProtocol {
+  implicit val contactFormat = jsonFormat4(Contact.apply)
+  implicit val parentFormat = jsonFormat5(Parent.apply)
+  implicit val respondentFormat = jsonFormat6(Respondent.apply)
+  implicit val tsFormat = jsonFormat9(TransmittalSheet.apply)
+}

--- a/api/src/main/scala/hmda/api/HmdaPublicApi.scala
+++ b/api/src/main/scala/hmda/api/HmdaPublicApi.scala
@@ -10,7 +10,7 @@ import akka.stream.ActorMaterializer
 import akka.util.Timeout
 import com.typesafe.config.ConfigFactory
 import hmda.api.http.public.RateSpreadHttpApi
-import hmda.api.http.{ BaseHttpApi, SingleLarValidationHttpApi }
+import hmda.api.http.{ BaseHttpApi, SingleLarValidationHttpApi, SingleTsValidationHttpApi }
 import hmda.api.http.public.{ InstitutionSearchPaths, ULIHttpApi }
 import hmda.persistence.model.HmdaSupervisorActor.FindActorByName
 import akka.http.scaladsl.server.Directives._
@@ -28,6 +28,7 @@ class HmdaPublicApi(supervisor: ActorRef)
     with InstitutionSearchPaths
     with RateSpreadHttpApi
     with SingleLarValidationHttpApi
+    with SingleTsValidationHttpApi
     with ULIHttpApi {
 
   val config = ConfigFactory.load()
@@ -53,6 +54,7 @@ class HmdaPublicApi(supervisor: ActorRef)
       institutionSearchPath(institutionPersistenceF) ~
       uliHttpRoutes ~
       larRoutes(supervisor) ~
+      tsRoutes(supervisor) ~
       rateSpreadRoutes(supervisor)
 
   override val http: Future[ServerBinding] = Http(system).bindAndHandle(

--- a/api/src/main/scala/hmda/api/http/public/SingleTsValidationHttpApi.scala
+++ b/api/src/main/scala/hmda/api/http/public/SingleTsValidationHttpApi.scala
@@ -1,0 +1,119 @@
+package hmda.api.http
+
+import akka.actor.{ ActorRef, ActorSystem }
+import akka.event.LoggingAdapter
+import akka.http.scaladsl.marshalling.ToResponseMarshallable
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+import akka.stream.ActorMaterializer
+import akka.util.Timeout
+import akka.pattern.ask
+import hmda.api.model.SingleValidationErrorResult
+import hmda.api.protocol.fi.ts.TsProtocol
+import hmda.api.protocol.processing.ParserResultsProtocol
+import hmda.api.protocol.validation.ValidationResultProtocol
+import hmda.model.fi.ts.TransmittalSheet
+import hmda.model.validation.{ Quality, Syntactical, ValidationErrorType, Validity }
+import hmda.parser.fi.ts.TsCsvParser
+import hmda.persistence.model.HmdaSupervisorActor.FindActorByName
+import hmda.persistence.processing.SingleTsValidation
+import hmda.persistence.processing.SingleTsValidation.{ CheckAll, CheckQuality, CheckSyntactical, CheckValidity }
+import hmda.validation.context.ValidationContext
+import hmda.validation.engine._
+
+import scala.concurrent.ExecutionContext
+import scala.util.{ Failure, Success }
+
+trait SingleTsValidationHttpApi extends TsProtocol with ValidationResultProtocol with HmdaCustomDirectives with ParserResultsProtocol {
+
+  implicit val system: ActorSystem
+  implicit val materializer: ActorMaterializer
+  val log: LoggingAdapter
+  implicit val ec: ExecutionContext
+  implicit val timeout: Timeout
+
+  // ts/parse
+  val parseTsRoute =
+    path("parse") {
+      timedPost { _ =>
+        entity(as[String]) { s =>
+          TsCsvParser(s) match {
+            case Right(ts) => complete(ToResponseMarshallable(ts))
+            case Left(errors) => complete(ToResponseMarshallable(StatusCodes.BadRequest -> errors))
+          }
+        }
+      }
+    }
+
+  // ts/validate
+  def validateTsRoute(supervisor: ActorRef) =
+    path("validate") {
+      parameters('check.as[String] ? "all") { (checkType) =>
+        timedPost { uri =>
+          entity(as[TransmittalSheet]) { ts =>
+            validateRoute(supervisor, ts, checkType, uri)
+          }
+        }
+      }
+    }
+
+  // ts/parseAndValidate
+  def parseAndValidateTsRoute(supervisor: ActorRef) =
+    path("parseAndValidate") {
+      parameters('check.as[String] ? "all") { (checkType) =>
+        timedPost { uri =>
+          entity(as[String]) { s =>
+            TsCsvParser(s) match {
+              case Right(ts) => validateRoute(supervisor, ts, checkType, uri)
+              case Left(errors) => complete(ToResponseMarshallable(StatusCodes.BadRequest -> errors))
+            }
+          }
+        }
+      }
+    }
+
+  def validateRoute(supervisor: ActorRef, ts: TransmittalSheet, checkType: String, uri: Uri) = {
+    val ftsValidation = (supervisor ? FindActorByName(SingleTsValidation.name)).mapTo[ActorRef]
+    val vContext = ValidationContext(None, None)
+    val checkMessage = checkType match {
+      case "syntactical" => CheckSyntactical(ts, vContext)
+      case "validity" => CheckValidity(ts, vContext)
+      case "quality" => CheckQuality(ts, vContext)
+      case _ => CheckAll(ts, vContext)
+    }
+    val fValidationErrors = for {
+      tsValidation <- ftsValidation
+      ve <- (tsValidation ? checkMessage).mapTo[ValidationErrors]
+    } yield ve
+
+    onComplete(fValidationErrors) {
+      case Success(validationErrors) =>
+        complete(ToResponseMarshallable(aggregateTsErrors(validationErrors)))
+      case Failure(error) =>
+        completeWithInternalError(uri, error)
+
+    }
+  }
+
+  def aggregateTsErrors(validationErrors: ValidationErrors): SingleValidationErrorResult = {
+    val errors = validationErrors.errors.groupBy(_.errorType)
+    def allOfType(errorType: ValidationErrorType): Seq[String] = {
+      errors.getOrElse(errorType, List()).map(e => e.ruleName)
+    }
+
+    SingleValidationErrorResult(
+      ValidationErrorsSummary(allOfType(Syntactical)),
+      ValidationErrorsSummary(allOfType(Validity)),
+      ValidationErrorsSummary(allOfType(Quality))
+    )
+  }
+
+  def tsRoutes(supervisor: ActorRef) =
+    encodeResponse {
+      pathPrefix("ts") {
+        parseTsRoute ~ validateTsRoute(supervisor) ~ parseAndValidateTsRoute(supervisor)
+      }
+    }
+
+}

--- a/persistence/src/main/scala/hmda/persistence/HmdaSupervisor.scala
+++ b/persistence/src/main/scala/hmda/persistence/HmdaSupervisor.scala
@@ -72,6 +72,9 @@ class HmdaSupervisor(validationStats: ActorRef) extends HmdaSupervisorActor {
     case id @ SingleLarValidation.name =>
       val actor = context.actorOf(SingleLarValidation.props.withDispatcher("persistence-dispatcher"), id)
       supervise(actor, id)
+    case id @ SingleTsValidation.name =>
+      val actor = context.actorOf(SingleTsValidation.props.withDispatcher("persistence-dispatcher"), id)
+      supervise(actor, id)
     case id @ InstitutionPersistence.name =>
       val actor = context.actorOf(InstitutionPersistence.props.withDispatcher("persistence-dispatcher"), id)
       supervise(actor, id)

--- a/persistence/src/main/scala/hmda/persistence/processing/SingleTsValidation.scala
+++ b/persistence/src/main/scala/hmda/persistence/processing/SingleTsValidation.scala
@@ -1,0 +1,48 @@
+package hmda.persistence.processing
+
+import akka.actor.{ Actor, ActorLogging, ActorRef, ActorSystem, Props }
+import hmda.model.fi.ts.TransmittalSheet
+import hmda.validation.context.ValidationContext
+import hmda.validation.engine.ts.TsEngine
+import scala.concurrent.ExecutionContext
+
+object SingleTsValidation {
+  val name = "TsValidation"
+
+  def props: Props = Props(new SingleTsValidation)
+
+  case class CheckAll(ts: TransmittalSheet, ctx: ValidationContext)
+  case class CheckSyntactical(ts: TransmittalSheet, ctx: ValidationContext)
+  case class CheckValidity(ts: TransmittalSheet, ctx: ValidationContext)
+  case class CheckQuality(ts: TransmittalSheet, ctx: ValidationContext)
+  case object FinishChecks
+
+  def createSingleTsValidator(system: ActorSystem): ActorRef = {
+    system.actorOf(SingleTsValidation.props.withDispatcher("persistence-dispatcher"), s"$name")
+  }
+
+}
+
+class SingleTsValidation extends Actor with ActorLogging with TsEngine {
+  import SingleTsValidation._
+  implicit val ec: ExecutionContext = context.dispatcher
+
+  override def receive: Receive = {
+    case CheckSyntactical(ts, ctx) =>
+      log.debug(s"Checking syntactical on TS: ${ts.toCSV}")
+      sender() ! validationErrors(ts, ctx, checkSyntactical)
+    case CheckValidity(ts, ctx) =>
+      log.debug(s"Checking validity on TS: ${ts.toCSV}")
+      sender() ! validationErrors(ts, ctx, checkValidity)
+    case CheckQuality(ts, ctx) =>
+      log.debug(s"Checking quality on TS: ${ts.toCSV}")
+      sender() ! validationErrors(ts, ctx, checkQuality)
+    case CheckAll(ts, ctx) =>
+      log.debug(s"Checking all edits on TS: ${ts.toCSV}")
+      sender() ! validationErrors(ts, ctx, validateTs)
+
+    case _ =>
+      log.error(s"Unsupported message sent to ${self.path}")
+  }
+
+}

--- a/validation/src/main/scala/hmda/validation/engine/ts/TsCommonEngine.scala
+++ b/validation/src/main/scala/hmda/validation/engine/ts/TsCommonEngine.scala
@@ -2,6 +2,8 @@ package hmda.validation.engine.ts
 
 import hmda.model.fi.ts.TransmittalSheet
 import hmda.model.validation.ValidationError
+import hmda.validation.context.ValidationContext
+import hmda.validation.engine.{ TsValidationErrors, ValidationErrors }
 
 import scala.concurrent.ExecutionContext
 import scalaz._
@@ -9,4 +11,12 @@ import scalaz._
 trait TsCommonEngine {
   type TsValidation = ValidationNel[ValidationError, TransmittalSheet]
   implicit val ec: ExecutionContext
+
+  def validationErrors(ts: TransmittalSheet, ctx: ValidationContext, f: (TransmittalSheet, ValidationContext) => TsValidation): ValidationErrors = {
+    val validation = f(ts, ctx)
+    validation match {
+      case scalaz.Success(_) => TsValidationErrors(Nil)
+      case scalaz.Failure(errors) => TsValidationErrors(errors.list.toList)
+    }
+  }
 }


### PR DESCRIPTION
I ended up creating a dumb local implementation of a public HTTP API endpoint for single Transmittal record parsing and validating to help me locally test submission generations. Note that this has no tests, and is almost a verbatim copy of the LAR API implementation. 

My Scala-fu is near-zero (so there's a good chance this is useless), but I figured I might as well share this in the unlikely scenario it actually does shave off some time for creating a proper implementation. Feel free to close this pull request with or without using any of its content.

Thanks!

refs #1493