### PR TITLE
Add DisclosureBW

### DIFF
--- a/publication/src/main/resources/reports-metadata.txt
+++ b/publication/src/main/resources/reports-metadata.txt
@@ -8,6 +8,7 @@ DA1W,Disclosure,A1W,,"Disposition of applications and loan sales by loan type, 1
 DA2W,Disclosure,A2W,,"Disposition of applications and loan sales by loan type, manufactured homes"
 DA3W,Disclosure,A3W,,"Disposition of applications and loan sales by loan type, multifamily housing"
 DB,Disclosure,B,,"Loan pricing information for conventional loans by incidence and level"
+DBW,Disclosure,BW,,"Loan pricing information for conventional loans by incidence and level"
 D51,Disclosure,5-1,Received;Originated;ApprovedButNotAccepted;Denied;Withdrawn;Closed,"Disposition of applications for FHA, FSA/RHS, and VA home-purchase loans, 1- to 4-family and manufactured home dwellings, by income, race and ethnicity of applicant"
 D52,Disclosure,5-2,Received;Originated;ApprovedButNotAccepted;Denied;Withdrawn;Closed,"Disposition of Applications for Conventional Home-Purchase Loans, 1-to-4 Family and Manufactured Home Dwellings, by Income, Race, and Ethnicity of Applicant"
 D53,Disclosure,5-3,Received;Originated;ApprovedButNotAccepted;Denied;Withdrawn;Closed,"Disposition of Applications to Refinance Loans on 1-to-4 Family and Manufactured Home Dwellings, by Income, Race, and Ethnicity of Applicant"

--- a/publication/src/main/scala/hmda/publication/reports/disclosure/DisclosureB.scala
+++ b/publication/src/main/scala/hmda/publication/reports/disclosure/DisclosureB.scala
@@ -40,13 +40,12 @@ trait DisclosureB extends DisclosureReport {
 
     val metaData = ReportsMetaDataLookup.values(reportId)
 
-    val lars = larSource
-      .filter(lar => lar.geography.msa != "NA")
-      .filter { lar =>
-        if (reportId == "DB") lar.geography.msa.toInt == fipsCode
-        else true
-      }
-      .filter(filters)
+    val lars = larSource.filter { lar =>
+        if (reportId == "DB") {
+          lar.geography.msa.toInt == fipsCode &&
+           lar.geography.msa != "NA"
+        } else true
+      }.filter(filters)
 
     val singleFamily = lars.filter(lar => lar.loan.propertyType == 1)
     val manufactured = lars.filter(lar => lar.loan.propertyType == 2)

--- a/publication/src/main/scala/hmda/publication/reports/disclosure/DisclosureReportPublisher.scala
+++ b/publication/src/main/scala/hmda/publication/reports/disclosure/DisclosureReportPublisher.scala
@@ -77,7 +77,7 @@ class DisclosureReportPublisher(supervisor: ActorRef) extends HmdaActor with Loa
     D11_1, D11_2, D11_3, D11_4, D11_5, D11_6, D11_7, D11_8, D11_9, D11_10,
     A1, A2, A3,
     A1W, A2W, A3W,
-    DiscB
+    DiscB, DiscBW
   )
 
   override def receive: Receive = {

--- a/publication/src/test/scala/hmda/publication/reports/disclosure/DisclosureBSpec.scala
+++ b/publication/src/test/scala/hmda/publication/reports/disclosure/DisclosureBSpec.scala
@@ -79,4 +79,16 @@ class DisclosureBSpec extends AsyncWordSpec with MustMatchers
     }
   }
 
+  "Generate a Disclosure BW report" in {
+    DiscBW.generate(source, fips, inst).map { result =>
+      result.report.parseJson.asJsObject.getFields("table", "description", "respondentId", "institutionName") match {
+        case Seq(JsString(table), JsString(desc), JsString(resp), JsString(instName)) =>
+          table mustBe "BW"
+          desc mustBe description
+          resp mustBe "65656"
+          instName mustBe "Grand Junction Mortgage Co."
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
Closes #1308 

@nickgrippin I thought it over and realized I agree with your previous approach. It works just fine to generate the nationwide reports with the rest of the disclosure reports (i.e. once per msa). Sorry to be changing my mind so often 😬 

We can optimize for better performance/less duplication of effort in the future if we want. I made #1514 as a reminder for that task.