### PR TITLE
Reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,18 +248,27 @@ After the test is run, some statistics will be presented on the screen. To furth
 
 1. Ensure you have a Docker Machine with sufficient resources, as described in the [Docker](#docker) section above.
 
-1. Clone [hmda-platform-ui](https://github.com/cfpb/hmda-platform-ui) and
-    [hmda-platform-auth](https://github.com/cfpb/hmda-platform-auth) into the same
+1. Clone [hmda-platform-ui](https://github.com/cfpb/hmda-platform-ui), 
+    [hmda-platform-auth](https://github.com/cfpb/hmda-platform-auth), and [hmda-pub-ui](https://github.com/cfpb/hmda-pub-ui) into the same
     directory as hmda-platform.
 
         ~/dev/hmda-project$ ls -l
         drwxr-xr-x  22 lortone  staff   748B Jul 27 16:28 hmda-platform/
         drwxr-xr-x  25 lortone  staff   850B Jul 25 17:13 hmda-platform-ui/
         drwxr-xr-x  23 lortone  staff   796B Jul 28 17:15 hmda-platform-auth/
+        drwxr-xr-x  23 lortone  staff   796B Jul 28 17:15 hmda-pub-ui/
 
 1. Build hmda-platform-ui
 
         cd hmda-platform-ui && \
+        yarn && \
+        cd ..
+
+    **Note:** This requires [yarn](https://yarnpkg.com/lang/en/docs/install/) to be installed.
+
+1. Build hmda-pub-ui
+
+        cd hmda-pub-ui && \
         yarn && \
         cd ..
 
@@ -307,16 +316,17 @@ After the test is run, some statistics will be presented on the screen. To furth
 
     1. Submit a HMDA filing.  Several sample files can be found [here](https://github.com/cfpb/hmda-platform/tree/master/parser/jvm/src/test/resources/txt).
 
+1. To view the publication UI (hmda-pub-ui) go to http://192.168.99.100/reports.
+
 ##### Updating an existing system
 
-If you've updated any of the hmda-platform services, and would like to see those
-changes reflected in the Docker Compose setup, the simplest way to do this is to
-rebuild everything from scratch.  The following command should be executed from
-within the `hmda-platform` directory.
+If you've updated any of the hmda-platform services, and would like to see those changes reflected in the Docker Compose setup, the simplest way to do this is to rebuild everything from scratch.  The following command should be executed from within the `hmda-platform` directory.
 
     docker-compose stop -t0 && \
     docker-compose rm -vf && \
     cd ../hmda-platform-ui && \
+    yarn && \
+    cd ../hmda-pub-ui && \
     yarn && \
     cd ../hmda-platform && \
     sbt clean assembly && \
@@ -328,15 +338,16 @@ within the `hmda-platform` directory.
 
 When running the full stack via Docker Compose, the following services are available:
 
-| Service                | URL                                 |
-|------------------------|-------------------------------------|
-| Filing UI              | https://192.168.99.100              |
-| Filing API (Unsecured) | http://192.168.99.100:8080          |
-| Filing API (Secured)   | https://192.168.99.100:4443/hmda/   |
-| Admin API              | http://192.168.99.100:8081          |
-| Public API             | https://192.168.99.100:4443/public/ |
-| Keycloak               | https://192.168.99.100:8443         |
-| MailDev                | https://192.168.99.100:8443/mail/   |
+| Service                | URL                                  |
+|------------------------|--------------------------------------|
+| Filing UI              | https://192.168.99.100               |
+| Filing API (Unsecured) | http://192.168.99.100:8080           |
+| Filing API (Secured)   | https://192.168.99.100:4443/hmda/    |
+| Reports UI             | https://192.168.99.100:8443/reports/ |
+| Admin API              | http://192.168.99.100:8081           |
+| Public API             | https://192.168.99.100:4443/public/  |
+| Keycloak               | https://192.168.99.100:8443          |
+| MailDev                | https://192.168.99.100:8443/mail/    |
 
 #### Development conveniences
 
@@ -345,10 +356,11 @@ When running the full stack via Docker Compose, the following services are avail
 For convenience when doing development on the UI, Auth setup, and API, the `docker-compose` file uses a `volumes` which mounts
 
 - the ui's `dist/` directory into the `hmda-platform-ui` container,
+- the publication ui's `reports/` directory into the `hmda-pub-ui` container,
 - the `hmda.jar` into `hmda-platform` container,
 - and the `hmda` themes directory in the auth repo into the `keycloak` container.
 
-This means you can make changes to the UI, Keycloak theme, or API and (in most cases) view them without needing to rebuild their respective containers.
+This means you can make changes to the UI, publication UI, Keycloak theme, or API and (in most cases) view them without needing to rebuild their respective containers.
 
 In order to view changes in the API you need to rebuild the jar and then restart the container:
 
@@ -362,7 +374,7 @@ docker-compose up
 To allow continued rebuilding of the front-end, you can run the following:
 
 ```shell
-# from the hmda-platform-ui directory
+# from the hmda-platform-ui and/or hmda-pub-ui directory
 npm run watch
 ```
 
@@ -383,4 +395,5 @@ We use GitHub issues in this repository to track features, bugs, and enhancement
   - https://github.com/cfpb/hmda-pilot
 2. Related projects
   - https://github.com/cfpb/hmda-platform-ui
+  - https://github.com/cfpb/hmda-pub-ui
   - https://github.com/cfpb/hmda-platform-auth

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,10 +31,7 @@ services:
     restart: always
 
   ui:
-    build:
-      context: ../hmda-platform-ui
-      args:
-        SKIP_JS_BUILD: 1
+    build: ../hmda-platform-ui
     depends_on:
       - api
       - auth_proxy
@@ -52,20 +49,14 @@ services:
       FORCE_SSL: 'true' # redirect 80 to 443
 
   reports_ui:
-    build:
-      context: ../hmda-pub-ui
-      args:
-        SKIP_JS_BUILD: 1
+    build: ../hmda-pub-ui
     depends_on:
       - api
-      - auth_proxy
-      - keycloak
     volumes:
       - ../hmda-pub-ui/reports:/usr/src/app/reports
     environment:
       APP_URL: https://192.168.99.100
       HMDA_API: https://192.168.99.100:4443/hmda
-      KEYCLOAK_URL: https://192.168.99.100:8443/auth/realms/hmda
       # lb settings
       VIRTUAL_HOST: 'http://*:80/reports/*, https://*:443/reports/*'
       VIRTUAL_HOST_WEIGHT: 1 # make sure this wins over the app UI
@@ -96,7 +87,6 @@ services:
       VIRTUAL_HOST_WEIGHT: 0
     volumes:
       - '../hmda-platform-auth/keycloak/themes/hmda:/opt/jboss/keycloak/themes/hmda'
-    #  - '../hmda-platform-auth/keycloak/import:/opt/jboss/import'
 
     # Set action to "export" to dump Keycloak realm data
     command: './docker-entrypoint.sh'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,7 @@ services:
       KEYCLOAK_URL: https://192.168.99.100:8443/auth/realms/hmda
       # lb settings
       VIRTUAL_HOST: 'http://*:80/*, https://*:443/*'
+      VIRTUAL_HOST_WEIGHT: 0
       EXCLUDE_PORTS: '443' # use lb's ssl instead of ui's nginx
       FORCE_SSL: 'true' # redirect 80 to 443
 
@@ -60,13 +61,14 @@ services:
       - auth_proxy
       - keycloak
     volumes:
-      - ../hmda-pub-ui/dist:/usr/src/app/reports
+      - ../hmda-pub-ui/reports:/usr/src/app/reports
     environment:
       APP_URL: https://192.168.99.100
       HMDA_API: https://192.168.99.100:4443/hmda
       KEYCLOAK_URL: https://192.168.99.100:8443/auth/realms/hmda
       # lb settings
       VIRTUAL_HOST: 'http://*:80/reports/*, https://*:443/reports/*'
+      VIRTUAL_HOST_WEIGHT: 1 # make sure this wins over the app UI
       EXCLUDE_PORTS: '443' # use lb's ssl instead of ui's nginx
       FORCE_SSL: 'true' # redirect 80 to 443
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,7 @@ services:
       # lb settings
       VIRTUAL_HOST: 'http://*:80/reports/*, https://*:443/reports/*'
       VIRTUAL_HOST_WEIGHT: 1 # make sure this wins over the app UI
+      EXTRA_SETTINGS: 'reqirep  "^([^ :]*)\ /reports//?(.*)" "\1\ /\2"'
       EXCLUDE_PORTS: '443' # use lb's ssl instead of ui's nginx
       FORCE_SSL: 'true' # redirect 80 to 443
 
@@ -171,6 +172,7 @@ services:
       - keycloak
       - mail_dev
       - ui
+      - reports_ui
     environment:
       # EXTRA_GLOBAL_SETTINGS: 'debug' # enable for request logging
       # Default SSL cert for ALL services served by lb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,26 @@ services:
       EXCLUDE_PORTS: '443' # use lb's ssl instead of ui's nginx
       FORCE_SSL: 'true' # redirect 80 to 443
 
+  reports_ui:
+    build:
+      context: ../hmda-pub-ui
+      args:
+        SKIP_JS_BUILD: 1
+    depends_on:
+      - api
+      - auth_proxy
+      - keycloak
+    volumes:
+      - ../hmda-pub-ui/dist:/usr/src/app/reports
+    environment:
+      APP_URL: https://192.168.99.100
+      HMDA_API: https://192.168.99.100:4443/hmda
+      KEYCLOAK_URL: https://192.168.99.100:8443/auth/realms/hmda
+      # lb settings
+      VIRTUAL_HOST: 'http://*:80/reports/*, https://*:443/reports/*'
+      EXCLUDE_PORTS: '443' # use lb's ssl instead of ui's nginx
+      FORCE_SSL: 'true' # redirect 80 to 443
+
   keycloak:
     build: ../hmda-platform-auth/keycloak
     environment:


### PR DESCRIPTION
__Depends on https://github.com/cfpb/hmda-pub-ui/pull/1.__

Includes `/reports/` as part of the compose setup using the hmda-pub-ui repo.

---

### Testing

You can use the setup in [this PR on the hmda-pub-ui repo](https://github.com/cfpb/hmda-pub-ui/pull/1) (`docker` branch).

Once you've built the publication project and having a running container, you should be able to view `https://192.168.99.100:8443/reports/` to see the reports UI.

_Does some other minor clean up too._