### PR TITLE
Akka typed

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,7 @@ lazy val commonDeps = Seq(logback, scalaTest, scalaCheck)
 lazy val akkaDeps = Seq(akkaSlf4J,
   akkaCluster,
   akkaTyped,
+  akkaClusterTyped,
   akkaStream,
   akkaManagement,
   akkaManagementClusterBootstrap,

--- a/common-api/src/main/scala/hmda/messages/CommonMessages.scala
+++ b/common-api/src/main/scala/hmda/messages/CommonMessages.scala
@@ -2,5 +2,5 @@ package hmda.messages
 
 object CommonMessages {
   sealed trait Message
-  case object StopActor extends Message
+  final case object StopActor extends Message
 }

--- a/hmda/src/main/scala/hmda/HmdaPlatform.scala
+++ b/hmda/src/main/scala/hmda/HmdaPlatform.scala
@@ -1,6 +1,6 @@
 package hmda
 
-import akka.actor.ActorSystem
+import akka.{actor => untyped}
 import akka.cluster.Cluster
 import akka.management.AkkaManagement
 import akka.management.cluster.bootstrap.ClusterBootstrap
@@ -11,6 +11,8 @@ import hmda.persistence.HmdaPersistence
 import hmda.query.HmdaQuery
 import hmda.validation.HmdaValidation
 import org.slf4j.LoggerFactory
+import akka.actor.typed.scaladsl.adapter._
+import hmda.publication.HmdaPublication
 
 object HmdaPlatform extends App {
 
@@ -44,7 +46,8 @@ object HmdaPlatform extends App {
   }
 
   implicit val system =
-    ActorSystem(clusterConfig.getString("hmda.cluster.name"), clusterConfig)
+    untyped.ActorSystem(clusterConfig.getString("hmda.cluster.name"),
+                        clusterConfig)
 
   implicit val mat = ActorMaterializer()
   implicit val cluster = Cluster(system)
@@ -55,13 +58,16 @@ object HmdaPlatform extends App {
   }
 
   //Start Persistence
-  system.actorOf(HmdaPersistence.props, HmdaPersistence.name)
+  system.spawn(HmdaPersistence.behavior, HmdaPersistence.name)
 
   //Start Query
-  system.actorOf(HmdaQuery.props, HmdaQuery.name)
+  system.spawn(HmdaQuery.behavior, HmdaQuery.name)
 
   //Start Validation
-  system.actorOf(HmdaValidation.props, HmdaValidation.name)
+  system.spawn(HmdaValidation.behavior, HmdaValidation.name)
+
+  //Start Publication
+  system.spawn(HmdaPublication.behavior, HmdaPublication.name)
 
   //Start API
   system.actorOf(HmdaApi.props, HmdaApi.name)

--- a/hmda/src/main/scala/hmda/api/http/HmdaAdminApi.scala
+++ b/hmda/src/main/scala/hmda/api/http/HmdaAdminApi.scala
@@ -13,9 +13,11 @@ import scala.concurrent.{ExecutionContext, Future}
 
 object HmdaAdminApi {
   def props: Props = Props(new HmdaAdminApi)
+  final val adminApiName = "hmda-admin-api"
 }
 
 class HmdaAdminApi extends HttpServer with BaseHttpApi {
+  import HmdaAdminApi._
 
   val config = ConfigFactory.load()
 
@@ -24,7 +26,7 @@ class HmdaAdminApi extends HttpServer with BaseHttpApi {
   override implicit val ec: ExecutionContext = context.dispatcher
   override val log = Logging(system, getClass)
 
-  override val name: String = "hmda-admin-api"
+  override val name: String = adminApiName
   override val host: String = config.getString("hmda.http.adminHost")
   override val port: Int = config.getInt("hmda.http.adminPort")
 

--- a/hmda/src/main/scala/hmda/api/http/HmdaApi.scala
+++ b/hmda/src/main/scala/hmda/api/http/HmdaApi.scala
@@ -10,9 +10,11 @@ object HmdaApi {
 
 class HmdaApi extends HmdaActor {
 
-  val filingApi = context.actorOf(HmdaFilingApi.props)
-  val adminApi = context.actorOf(HmdaAdminApi.props)
-  val publicApi = context.actorOf(HmdaPublicApi.props)
-  val wsApi = context.actorOf(HmdaWSApi.props)
+  val filingApi =
+    context.actorOf(HmdaFilingApi.props, HmdaFilingApi.filingApiName)
+  val adminApi = context.actorOf(HmdaAdminApi.props, HmdaAdminApi.adminApiName)
+  val publicApi =
+    context.actorOf(HmdaPublicApi.props, HmdaPublicApi.publicApiName)
+  val wsApi = context.actorOf(HmdaWSApi.props, HmdaWSApi.wsApiName)
 
 }

--- a/hmda/src/main/scala/hmda/api/http/HmdaFilingApi.scala
+++ b/hmda/src/main/scala/hmda/api/http/HmdaFilingApi.scala
@@ -13,9 +13,12 @@ import scala.concurrent.{ExecutionContext, Future}
 
 object HmdaFilingApi {
   def props: Props = Props(new HmdaFilingApi)
+  final val filingApiName = "hmda-filing-api"
 }
 
 class HmdaFilingApi extends HttpServer with BaseHttpApi {
+  import HmdaFilingApi._
+
   val config = ConfigFactory.load()
 
   override implicit val system: ActorSystem = context.system
@@ -23,7 +26,7 @@ class HmdaFilingApi extends HttpServer with BaseHttpApi {
   override implicit val ec: ExecutionContext = context.dispatcher
   override val log = Logging(system, getClass)
 
-  override val name: String = "hmda-filing-api"
+  override val name: String = filingApiName
   override val host: String = config.getString("hmda.http.filingHost")
   override val port: Int = config.getInt("hmda.http.filingPort")
 

--- a/hmda/src/main/scala/hmda/api/http/HmdaPublicApi.scala
+++ b/hmda/src/main/scala/hmda/api/http/HmdaPublicApi.scala
@@ -21,6 +21,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 object HmdaPublicApi {
   def props: Props = Props(new HmdaPublicApi)
+  final val publicApiName = "hmda-public-api"
 }
 
 class HmdaPublicApi
@@ -30,6 +31,8 @@ class HmdaPublicApi
     with LarValidationHttpApi
     with HmdaFileValidationHttpApi {
 
+  import HmdaPublicApi._
+
   val config = ConfigFactory.load()
 
   override implicit val system: ActorSystem = context.system
@@ -37,7 +40,7 @@ class HmdaPublicApi
   override implicit val ec: ExecutionContext = context.dispatcher
   override val log = Logging(system, getClass)
 
-  override val name: String = "hmda-public-api"
+  override val name: String = publicApiName
   override val host: String = config.getString("hmda.http.publicHost")
   override val port: Int = config.getInt("hmda.http.publicPort")
   override val timeout: Timeout = Timeout(

--- a/hmda/src/main/scala/hmda/api/http/HmdaWSApi.scala
+++ b/hmda/src/main/scala/hmda/api/http/HmdaWSApi.scala
@@ -13,9 +13,11 @@ import scala.concurrent.{ExecutionContext, Future}
 
 object HmdaWSApi {
   def props: Props = Props(new HmdaWSApi)
+  final val wsApiName = "hmda-ws-api"
 }
 
 class HmdaWSApi extends HttpServer with BaseWsApi {
+  import HmdaWSApi._
 
   val config = ConfigFactory.load()
 
@@ -24,7 +26,7 @@ class HmdaWSApi extends HttpServer with BaseWsApi {
   override implicit val ec: ExecutionContext = context.dispatcher
   override val log = Logging(system, getClass)
 
-  override val name: String = "hmda-ws-api"
+  override val name: String = wsApiName
   override val host: String = config.getString("hmda.ws.host")
   override val port: Int = config.getInt("hmda.ws.port")
 

--- a/hmda/src/main/scala/hmda/persistence/HmdaPersistence.scala
+++ b/hmda/src/main/scala/hmda/persistence/HmdaPersistence.scala
@@ -1,14 +1,34 @@
 package hmda.persistence
 
-import akka.actor.Props
-import hmda.actor.HmdaActor
+import akka.actor.typed.{Behavior, PostStop, PreRestart}
+import akka.actor.typed.scaladsl.Behaviors
 
 object HmdaPersistence {
+
   final val name = "HmdaPersistence"
-  def props: Props = Props(new HmdaPersistence)
-}
-class HmdaPersistence extends HmdaActor {
-  override def receive = super.receive orElse {
-    case _ =>
-  }
+
+  sealed trait HmdaPersistenceMessage
+  case object StopHmdaPersistence extends HmdaPersistenceMessage
+
+  val behavior: Behavior[HmdaPersistenceMessage] =
+    Behaviors.setup { ctx =>
+      ctx.log.info(s"Actor started at ${ctx.self.path}")
+      Behaviors
+        .receive[HmdaPersistenceMessage] {
+          case (_, msg) =>
+            msg match {
+              case StopHmdaPersistence =>
+                Behaviors.stopped
+            }
+        }
+        .receiveSignal {
+          case (ctx, PreRestart) =>
+            ctx.log.info(s"Actor restarted at ${ctx.self.path}")
+            Behaviors.same
+          case (ctx, PostStop) =>
+            ctx.log.info(s"Actor stopped at ${ctx.self.path}")
+            Behaviors.same
+        }
+    }
+
 }

--- a/hmda/src/main/scala/hmda/publication/HmdaPublication.scala
+++ b/hmda/src/main/scala/hmda/publication/HmdaPublication.scala
@@ -1,15 +1,34 @@
 package hmda.publication
 
-import akka.actor.Props
-import hmda.actor.HmdaActor
+import akka.actor.typed.{Behavior, PostStop, PreRestart}
+import akka.actor.typed.scaladsl.Behaviors
 
 object HmdaPublication {
-  final val name = "HmdaPublication"
-  def props: Props = Props(new HmdaPublication)
-}
 
-class HmdaPublication extends HmdaActor {
-  override def receive = super.receive orElse {
-    case _ =>
-  }
+  final val name = "HmdaPublication"
+
+  sealed trait HmdaPublicationMessage
+  case object StopHmdaPublication extends HmdaPublicationMessage
+
+  val behavior: Behavior[HmdaPublicationMessage] =
+    Behaviors.setup { ctx =>
+      ctx.log.info(s"Actor started at ${ctx.self.path}")
+      Behaviors
+        .receive[HmdaPublicationMessage] {
+          case (_, msg) =>
+            msg match {
+              case StopHmdaPublication =>
+                Behaviors.stopped
+            }
+        }
+        .receiveSignal {
+          case (ctx, PreRestart) =>
+            ctx.log.info(s"Actor restarted at ${ctx.self.path}")
+            Behaviors.same
+          case (ctx, PostStop) =>
+            ctx.log.info(s"Actor stopped at ${ctx.self.path}")
+            Behaviors.same
+        }
+    }
+
 }

--- a/hmda/src/main/scala/hmda/query/HmdaQuery.scala
+++ b/hmda/src/main/scala/hmda/query/HmdaQuery.scala
@@ -1,15 +1,33 @@
 package hmda.query
 
-import akka.actor.Props
-import hmda.actor.HmdaActor
+import akka.actor.typed.{Behavior, PostStop, PreRestart}
+import akka.actor.typed.scaladsl.Behaviors
 
 object HmdaQuery {
-  final val name = "HmdaQuery"
-  val props: Props = Props(new HmdaQuery)
-}
 
-class HmdaQuery extends HmdaActor {
-  override def receive = super.receive orElse {
-    case _ =>
-  }
+  final val name = "HmdaQuery"
+
+  sealed trait HmdaQueryMessage
+  case object StopHmdaQuery extends HmdaQueryMessage
+
+  val behavior: Behavior[HmdaQueryMessage] =
+    Behaviors.setup { ctx =>
+      ctx.log.info(s"Actor started at ${ctx.self.path}")
+      Behaviors
+        .receive[HmdaQueryMessage] {
+          case (_, msg) =>
+            msg match {
+              case StopHmdaQuery =>
+                Behaviors.stopped
+            }
+        }
+        .receiveSignal {
+          case (ctx, PreRestart) =>
+            ctx.log.info(s"Actor restarted at ${ctx.self.path}")
+            Behaviors.same
+          case (ctx, PostStop) =>
+            ctx.log.info(s"Actor stopped at ${ctx.self.path}")
+            Behaviors.same
+        }
+    }
 }

--- a/hmda/src/main/scala/hmda/validation/HmdaValidation.scala
+++ b/hmda/src/main/scala/hmda/validation/HmdaValidation.scala
@@ -1,15 +1,34 @@
 package hmda.validation
 
-import akka.actor.Props
-import hmda.actor.HmdaActor
+import akka.actor.typed.{Behavior, PostStop, PreRestart}
+import akka.actor.typed.scaladsl.Behaviors
 
 object HmdaValidation {
-  final val name = "HmdaValidation"
-  def props: Props = Props(new HmdaValidation)
-}
 
-class HmdaValidation extends HmdaActor {
-  override def receive = super.receive orElse {
-    case _ =>
-  }
+  final val name = "HmdaValidation"
+
+  sealed trait HmdaValidationMessage
+  case object StopHmdaValidation extends HmdaValidationMessage
+
+  val behavior: Behavior[HmdaValidationMessage] =
+    Behaviors.setup { ctx =>
+      ctx.log.info(s"Actor started at ${ctx.self.path}")
+      Behaviors
+        .receive[HmdaValidationMessage] {
+          case (_, msg) =>
+            msg match {
+              case StopHmdaValidation =>
+                Behaviors.stopped
+            }
+        }
+        .receiveSignal {
+          case (ctx, PreRestart) =>
+            ctx.log.info(s"Actor restarted at ${ctx.self.path}")
+            Behaviors.same
+          case (ctx, PostStop) =>
+            ctx.log.info(s"Actor stopped at ${ctx.self.path}")
+            Behaviors.same
+        }
+    }
+
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,6 +14,7 @@ object Dependencies {
   lazy val akkaSlf4J = "com.typesafe.akka" %% "akka-slf4j" % Version.akka
   lazy val akkaTyped = "com.typesafe.akka" %% "akka-actor-typed" % Version.akka
   lazy val akkaCluster = "com.typesafe.akka" %% "akka-cluster" % Version.akka
+  lazy val akkaClusterTyped = "com.typesafe.akka" %% "akka-cluster-typed" % Version.akka
   lazy val akkaClusterSharding = "com.typesafe.akka" %% "akka-cluster-sharding" % Version.akka
   lazy val akkaPersistence = "com.typesafe.akka" %% "akka-persistence" % Version.akka
   lazy val akkaStream = "com.typesafe.akka" %% "akka-stream" % Version.akka

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   val scalaCheck = "org.scalacheck" %% "scalacheck" % Version.scalaCheck % "test"
   val logback = "ch.qos.logback" % "logback-classic" % Version.logback
   lazy val akkaSlf4J = "com.typesafe.akka" %% "akka-slf4j" % Version.akka
-  lazy val akkaTyped = "com.typesafe.akka" %% "akka-typed" % Version.akka
+  lazy val akkaTyped = "com.typesafe.akka" %% "akka-actor-typed" % Version.akka
   lazy val akkaCluster = "com.typesafe.akka" %% "akka-cluster" % Version.akka
   lazy val akkaClusterSharding = "com.typesafe.akka" %% "akka-cluster-sharding" % Version.akka
   lazy val akkaPersistence = "com.typesafe.akka" %% "akka-persistence" % Version.akka

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,12 +1,12 @@
 object Version {
 
   val logback    = "1.2.1"
-  val scalaTest  = "3.0.1"
-  val scalaCheck = "1.13.4"
-  val akka = "2.5.8"
-  val akkaHttp = "10.1.0-RC1"
-  val akkaHttpJson = "1.19.0"
-  val akkaClusterManagement = "0.8.0"
-  val circe = "0.9.0"
+  val scalaTest  = "3.0.5"
+  val scalaCheck = "1.14.0"
+  val akka = "2.5.12"
+  val akkaHttp = "10.1.1"
+  val akkaHttpJson = "1.20.0"
+  val akkaClusterManagement = "0.12.0"
+  val circe = "0.9.3"
 
 }


### PR DESCRIPTION
Closes #1616

Refactors top level actors (except APIs) to use [Akka Typed](https://doc.akka.io/docs/akka/current/typed/index.html). Other PRs are going to build on this one, and actors written from this point on will most likely be `Typed Actors`. Given the change in programming style and new concepts, I'm putting this PR out there so others can familiarize themselves with the new APIs. 