### PR TITLE
Dynamic LAR/TS

### DIFF
--- a/census/src/main/scala/hmda/census/model/TractLookup.scala
+++ b/census/src/main/scala/hmda/census/model/TractLookup.scala
@@ -10,7 +10,7 @@ import scala.util.{ Success, Try }
 // file: FFIEC Census flat file for the 2017 HMDA collection year
 
 object TractLookup extends CbsaResourceUtils {
-  val values: Set[Tract] = {
+  val valuesExtended: Set[TractExtended] = {
     val lines = resourceLines("/ffiec_census_fields.txt", "ISO-8859-1")
 
     lines.drop(1).map { line =>
@@ -19,30 +19,48 @@ object TractLookup extends CbsaResourceUtils {
       val stateFips2010 = values(2)
       val countyFips2010 = values(3)
       val tractFips2010 = values(4)
+      val ffiecMfi = Try(values(5).toInt).getOrElse(0)
+      val totalPersons = Try(values(6).toInt).getOrElse(0)
       val minorityPopulation = Try(values(7).toDouble).getOrElse(0.0)
+      val ownerOccupied = Try(values(8).toInt).getOrElse(0)
+      val oneToFour = Try(values(9).toInt).getOrElse(0)
       val tractMfiToMsaPercent = Try(values(11).toDouble).getOrElse(100.0)
       val medianYearHomesBuilt = Try(values(12).toInt) match {
         case Success(value) => Some(2015 - value)
         case _ => None
       }
 
-      Tract(
+      TractExtended(
         stateFips2010,
         countyFips2010,
         tractFips2010,
         tractFips2010.slice(0, 4) + "." + tractFips2010.slice(4, 6),
         stateFips2010 + countyFips2010,
         msa,
+        ffiecMfi,
+        totalPersons,
+        ownerOccupied,
+        oneToFour,
         minorityPopulation,
         tractMfiToMsaPercent,
         medianYearHomesBuilt
       )
     }.toSet
   }
+  val values: Set[Tract] = valuesExtended.map(_.toTract)
 
   def forLar(lar: LoanApplicationRegister, possibleValues: Set[Tract] = values): Option[Tract] = {
     val geo = lar.geography
     possibleValues.find { t =>
+      t.tractDec == geo.tract &&
+        t.state == geo.state &&
+        t.county == geo.county
+    }
+  }
+
+  def forLarExtended(lar: LoanApplicationRegister): Option[TractExtended] = {
+    val geo = lar.geography
+    valuesExtended.find { t =>
       t.tractDec == geo.tract &&
         t.state == geo.state &&
         t.county == geo.county
@@ -61,3 +79,28 @@ case class Tract(
   tractMfiPercentageOfMsaMfi: Double = 0.0,
   medianYearHomesBuilt: Option[Int] = None
 )
+
+case class TractExtended(
+  state: String = "",
+  county: String = "",
+  tract: String = "",
+  tractDec: String = "",
+  key: String = "",
+  msa: String = "",
+  ffiecMfi: Int = 0,
+  totalPersons: Int = 0,
+  ownerOccupied: Int = 0,
+  oneToFourUnits: Int = 0,
+  minorityPopulationPercent: Double = 0.0,
+  tractMfiPercentageOfMsaMfi: Double = 0.0,
+  medianYearHomesBuilt: Option[Int] = None
+) {
+  def toTract = Tract(state, county, tract,
+    tractDec, key, msa, minorityPopulationPercent,
+    tractMfiPercentageOfMsaMfi, medianYearHomesBuilt)
+  def toCSV = {
+    val mPPString = BigDecimal(minorityPopulationPercent).setScale(2, BigDecimal.RoundingMode.HALF_UP).toDouble
+    val tMfiPString = BigDecimal(tractMfiPercentageOfMsaMfi).setScale(2, BigDecimal.RoundingMode.HALF_UP).toDouble
+    s"$totalPersons|$mPPString|$ffiecMfi|$tMfiPString|$ownerOccupied|$oneToFourUnits"
+  }
+}

--- a/census/src/main/scala/hmda/census/model/TractLookup.scala
+++ b/census/src/main/scala/hmda/census/model/TractLookup.scala
@@ -81,19 +81,19 @@ case class Tract(
 )
 
 case class TractExtended(
-  state: String = "",
-  county: String = "",
-  tract: String = "",
-  tractDec: String = "",
-  key: String = "",
-  msa: String = "",
-  ffiecMfi: Int = 0,
-  totalPersons: Int = 0,
-  ownerOccupied: Int = 0,
-  oneToFourUnits: Int = 0,
-  minorityPopulationPercent: Double = 0.0,
-  tractMfiPercentageOfMsaMfi: Double = 0.0,
-  medianYearHomesBuilt: Option[Int] = None
+    state: String = "",
+    county: String = "",
+    tract: String = "",
+    tractDec: String = "",
+    key: String = "",
+    msa: String = "",
+    ffiecMfi: Int = 0,
+    totalPersons: Int = 0,
+    ownerOccupied: Int = 0,
+    oneToFourUnits: Int = 0,
+    minorityPopulationPercent: Double = 0.0,
+    tractMfiPercentageOfMsaMfi: Double = 0.0,
+    medianYearHomesBuilt: Option[Int] = None
 ) {
   def toTract = Tract(state, county, tract,
     tractDec, key, msa, minorityPopulationPercent,

--- a/census/src/main/scala/hmda/census/model/TractLookup.scala
+++ b/census/src/main/scala/hmda/census/model/TractLookup.scala
@@ -98,9 +98,13 @@ case class TractExtended(
   def toTract = Tract(state, county, tract,
     tractDec, key, msa, minorityPopulationPercent,
     tractMfiPercentageOfMsaMfi, medianYearHomesBuilt)
+
   def toCSV = {
     val mPPString = BigDecimal(minorityPopulationPercent).setScale(2, BigDecimal.RoundingMode.HALF_UP).toDouble
     val tMfiPString = BigDecimal(tractMfiPercentageOfMsaMfi).setScale(2, BigDecimal.RoundingMode.HALF_UP).toDouble
-    s"$totalPersons|$mPPString|$ffiecMfi|$tMfiPString|$ownerOccupied|$oneToFourUnits"
+    if(state == "" || county == "" || tract == "")
+      "|||||"
+    else
+      s"$totalPersons|$mPPString|$ffiecMfi|$tMfiPString|$ownerOccupied|$oneToFourUnits"
   }
 }

--- a/census/src/main/scala/hmda/census/model/TractLookup.scala
+++ b/census/src/main/scala/hmda/census/model/TractLookup.scala
@@ -102,7 +102,7 @@ case class TractExtended(
   def toCSV = {
     val mPPString = BigDecimal(minorityPopulationPercent).setScale(2, BigDecimal.RoundingMode.HALF_UP).toDouble
     val tMfiPString = BigDecimal(tractMfiPercentageOfMsaMfi).setScale(2, BigDecimal.RoundingMode.HALF_UP).toDouble
-    if(state == "" || county == "" || tract == "")
+    if (state == "" || county == "" || tract == "")
       "|||||"
     else
       s"$totalPersons|$mPPString|$ffiecMfi|$tMfiPString|$ownerOccupied|$oneToFourUnits"

--- a/model/shared/src/main/scala/hmda/model/fi/ts/TransmittalSheet.scala
+++ b/model/shared/src/main/scala/hmda/model/fi/ts/TransmittalSheet.scala
@@ -55,6 +55,14 @@ case class TransmittalSheet(
       s"|${parent.zipCode}|${contact.name}|${contact.phone}|${contact.fax}|${contact.email}"
   }
 
+  def toCSVModified: String = {
+    s"$id|${respondent.id}|$agencyCode|$timestamp|$activityYear" +
+      s"|$taxId|$totalLines|${respondent.name}|${respondent.address}" +
+      s"|${respondent.city}|${respondent.state}|${respondent.zipCode}" +
+      s"|${parent.name}|${parent.address}|${parent.city}|${parent.state}" +
+      s"|${parent.zipCode}"
+  }
+
   /**
    * NOTE:  The DAT file format is not supported by CFPB
    */

--- a/model/shared/src/main/scala/hmda/model/fi/ts/TransmittalSheet.scala
+++ b/model/shared/src/main/scala/hmda/model/fi/ts/TransmittalSheet.scala
@@ -56,7 +56,7 @@ case class TransmittalSheet(
   }
 
   def toCSVModified: String = {
-    s"$id|${respondent.id}|$agencyCode|$timestamp|$activityYear" +
+    s"$id|${respondent.id}|$agencyCode|$activityYear" +
       s"|$taxId|$totalLines|${respondent.name}|${respondent.address}" +
       s"|${respondent.city}|${respondent.state}|${respondent.zipCode}" +
       s"|${parent.name}|${parent.address}|${parent.city}|${parent.state}" +

--- a/publication/src/main/resources/application.conf
+++ b/publication/src/main/resources/application.conf
@@ -27,16 +27,17 @@ akka {
       }
       DynamicLARRegulator {
         description = "Publish dynamic LAR data on a schedule"
-        //expression = "0 */2 * ? * *"
-        expression = "0 30 23 ? * SUN"
+        //expression = "00 40 14 ? * *"
+        expression = "0 30 1 ? * MON"
       }
       DynamicTSRegulator {
         description = "Publish dynamic TS data on a schedule"
-        //expression = "0 */2 * ? * *"
-        expression = "0 0 23 ? * SUN"
+        //expression = "0 */5 * ? * *"
+        expression = "0 0 1 ? * MON"
       }
     }
   }
+  http.server.request-timeout=20800s
 }
 
 hmda {

--- a/publication/src/main/resources/application.conf
+++ b/publication/src/main/resources/application.conf
@@ -21,7 +21,12 @@ akka {
         expression = "00 00 22 ? * *"
       }
       PanelRegulator {
-        description = "Publish LAR regulator data on a schedule"
+        description = "Publish Panel regulator data on a schedule"
+        //expression = "*/30 * * ? * *"
+        expression = "00 00 22 ? * *"
+      }
+      DynamicRegulator {
+        description = "Publish Panel regulator data on a schedule"
         //expression = "*/30 * * ? * *"
         expression = "00 00 22 ? * *"
       }
@@ -51,6 +56,8 @@ hmda {
     }
     year = 2017
     year = ${?PUBLICATION_YEAR}
+    filtered-respondent-ids="Bank0_RID,Bank1_RID,480266459,1467,3378018,18944,473619422"
+    filtered-respondend-ids= ${?FILTERED_RESPONDENT_IDS}
   }
 
 }

--- a/publication/src/main/resources/application.conf
+++ b/publication/src/main/resources/application.conf
@@ -25,10 +25,15 @@ akka {
         //expression = "*/30 * * ? * *"
         expression = "00 00 22 ? * *"
       }
-      DynamicRegulator {
-        description = "Publish Panel regulator data on a schedule"
-        //expression = "*/30 * * ? * *"
-        expression = "00 00 22 ? * *"
+      DynamicLARRegulator {
+        description = "Publish dynamic LAR data on a schedule"
+        expression = "0 */2 * ? * *"
+        //expression = "0 30 23 ? * SUN"
+      }
+      DynamicTSRegulator {
+        description = "Publish dynamic TS data on a schedule"
+        expression = "0 */2 * ? * *"
+        //expression = "0 0 23 ? * SUN"
       }
     }
   }

--- a/publication/src/main/resources/application.conf
+++ b/publication/src/main/resources/application.conf
@@ -27,13 +27,13 @@ akka {
       }
       DynamicLARRegulator {
         description = "Publish dynamic LAR data on a schedule"
-        expression = "0 */2 * ? * *"
-        //expression = "0 30 23 ? * SUN"
+        //expression = "0 */2 * ? * *"
+        expression = "0 30 23 ? * SUN"
       }
       DynamicTSRegulator {
         description = "Publish dynamic TS data on a schedule"
-        expression = "0 */2 * ? * *"
-        //expression = "0 0 23 ? * SUN"
+        //expression = "0 */2 * ? * *"
+        expression = "0 0 23 ? * SUN"
       }
     }
   }

--- a/publication/src/main/scala/hmda/publication/regulator/lar/RegulatorLarPublisher.scala
+++ b/publication/src/main/scala/hmda/publication/regulator/lar/RegulatorLarPublisher.scala
@@ -107,7 +107,7 @@ class RegulatorLarPublisher extends HmdaActor with LoanApplicationRegisterCassan
     val baseString = toModifiedLar(lar).toCSV
     val key = lar.geography.tract + lar.geography.county + lar.geography.state
     val tract = tractMap.getOrElse(key, "|||||")
-    baseString + "|" + tract
+    baseString + "|" + tract + "\n"
   }
 
   def filterTestBanks: Flow[LoanApplicationRegister, LoanApplicationRegister, NotUsed] = {

--- a/publication/src/main/scala/hmda/publication/regulator/lar/RegulatorLarPublisher.scala
+++ b/publication/src/main/scala/hmda/publication/regulator/lar/RegulatorLarPublisher.scala
@@ -20,7 +20,6 @@ import hmda.model.fi.lar.LoanApplicationRegister
 import hmda.census.model.TractLookup._
 import hmda.persistence.model.HmdaActor
 import hmda.publication.regulator.messages._
-import hmda.query.model.filing.ModifiedLoanApplicationRegister
 import hmda.query.repository.filing.LarConverter._
 import hmda.query.repository.filing.LoanApplicationRegisterCassandraRepository
 
@@ -34,6 +33,7 @@ object RegulatorLarPublisher {
 class RegulatorLarPublisher extends HmdaActor with LoanApplicationRegisterCassandraRepository {
 
   QuartzSchedulerExtension(system).schedule("LARRegulator", self, PublishRegulatorData)
+  QuartzSchedulerExtension(system).schedule("DynamicRegulator", self, PublishDynamicData)
 
   val decider: Decider = { e =>
     log.error("Unhandled error in stream", e)
@@ -81,7 +81,6 @@ class RegulatorLarPublisher extends HmdaActor with LoanApplicationRegisterCassan
       source.runWith(s3Sink)
 
     case PublishDynamicData =>
-      val now = LocalDateTime.now()
       val fileName = "lar.txt"
       log.info(s"Uploading $fileName to S3")
       val s3Sink = s3Client.multipartUpload(

--- a/publication/src/main/scala/hmda/publication/regulator/messages.scala
+++ b/publication/src/main/scala/hmda/publication/regulator/messages.scala
@@ -2,4 +2,5 @@ package hmda.publication.regulator
 
 object messages {
   case object PublishRegulatorData
+  case object PublishDynamicData
 }

--- a/publication/src/main/scala/hmda/publication/regulator/ts/RegulatorTsPublisher.scala
+++ b/publication/src/main/scala/hmda/publication/regulator/ts/RegulatorTsPublisher.scala
@@ -28,7 +28,7 @@ object RegulatorTsPublisher {
 class RegulatorTsPublisher extends HmdaActor with TransmittalSheetCassandraRepository {
 
   QuartzSchedulerExtension(system).schedule("TSRegulator", self, PublishRegulatorData)
-  QuartzSchedulerExtension(system).schedule("DynamicRegulator", self, PublishDynamicData)
+  QuartzSchedulerExtension(system).schedule("DynamicTSRegulator", self, PublishDynamicData)
 
   val decider: Decider = { e =>
     log.error("Unhandled error in stream", e)
@@ -45,6 +45,7 @@ class RegulatorTsPublisher extends HmdaActor with TransmittalSheetCassandraRepos
   val secretAccess = config.getString("hmda.publication.aws.secret-access-key ")
   val region = config.getString("hmda.publication.aws.region")
   val bucket = config.getString("hmda.publication.aws.private-bucket")
+  val publicBucket = config.getString("hmda.publication.aws.public-bucket")
   val environment = config.getString("hmda.publication.aws.environment")
   val filteredRespondentIds = config.getString("hmda.publication.filtered-respondent-ids").split(",")
 
@@ -76,9 +77,9 @@ class RegulatorTsPublisher extends HmdaActor with TransmittalSheetCassandraRepos
 
     case PublishDynamicData =>
       val fileName = "ts.txt"
-      log.info(s"Uploading $fileName to S3")
+      log.info(s"Uploading $fileName to $environment/dynamic-data/$fileName")
       val s3Sink = s3Client.multipartUpload(
-        bucket,
+        publicBucket,
         s"$environment/dynamic-data/$fileName",
         ContentType(MediaTypes.`text/csv`, HttpCharsets.`UTF-8`),
         S3Headers(ServerSideEncryption.AES256)


### PR DESCRIPTION
Publishes the modified TS and modified LAR + tract data to the public S3 bucket weekly.  The current schedule published TS data at 11PM on Sunday and LAR data at 11:30PM.  The files are written to `/dynamic-data/lar.txt` and `/dynamic-data/ts.txt` and are overwritten each week.

Closes #1581 
Closes #1603 
