### PR TITLE
S3 Headers

### DIFF
--- a/publication/src/main/scala/hmda/publication/regulator/lar/RegulatorLarPublisher.scala
+++ b/publication/src/main/scala/hmda/publication/regulator/lar/RegulatorLarPublisher.scala
@@ -91,7 +91,7 @@ class RegulatorLarPublisher extends HmdaActor with LoanApplicationRegisterCassan
         publicBucket,
         s"$environment/dynamic-data/$fileName",
         ContentType(MediaTypes.`text/csv`, HttpCharsets.`UTF-8`),
-        S3Headers(ServerSideEncryption.AES256)
+        S3Headers(Map("Content-Disposition" -> s"attachment; filename=$fileName;"))
       )
 
       val source = readData(fetchSize)

--- a/publication/src/main/scala/hmda/publication/regulator/ts/RegulatorTsPublisher.scala
+++ b/publication/src/main/scala/hmda/publication/regulator/ts/RegulatorTsPublisher.scala
@@ -83,7 +83,7 @@ class RegulatorTsPublisher extends HmdaActor with TransmittalSheetCassandraRepos
         publicBucket,
         s"$environment/dynamic-data/$fileName",
         ContentType(MediaTypes.`text/csv`, HttpCharsets.`UTF-8`),
-        S3Headers(ServerSideEncryption.AES256)
+        S3Headers(Map("Content-Disposition" -> s"attachment; filename=$fileName;"))
       )
 
       val source = readData(fetchSize)


### PR DESCRIPTION
Adds the `attachment` file type to the dynamic data publication process.

Shoutout to Kenneth for figuring out the correct headers!