### PR TITLE
Change How Configs are Merged to Allow for Runtime Overrides

### DIFF
--- a/hmda/src/main/resources/application-dcos.conf
+++ b/hmda/src/main/resources/application-dcos.conf
@@ -1,16 +1,8 @@
-include "application.conf"
-
 akka {
 
   remote {
     netty.tcp {
       hostname = ${?HOST}
-      port = 2551
-      port = ${?APP_PORT}
-
-      bind-hostname = 0.0.0.0
-      bind-port = 2551
-      bind-port = ${APP_PORT}
     }
   }
 
@@ -20,11 +12,6 @@ akka {
       # This defines the interface to use.
       # InetAddress.getLocalHost.getHostAddress is used not overriden or empty
       hostname = ${?HOST}
-      port = 8558
-      port = ${?PORT_19999}
-
-      bind-hostname = 0.0.0.0
-      bind-port = 8558
     }
 
     cluster.bootstrap {

--- a/hmda/src/main/resources/application-dcos.conf
+++ b/hmda/src/main/resources/application-dcos.conf
@@ -38,13 +38,6 @@ akka {
         effective-name= ${?SERVICE_NAME}
       }
 
-      # Configured how we communicate with the contact point once it is discovered
-      contact-point {
-        # If no port is discovered along with the host/ip of a contact point this port will be used as fallback
-        fallback-port = 8558
-        fallback-port = ${?PORT_19999}
-      }
-
     }
 
   }

--- a/hmda/src/main/resources/application-dev.conf
+++ b/hmda/src/main/resources/application-dev.conf
@@ -1,5 +1,3 @@
-include "application.conf"
-
 akka {
 
   cluster {

--- a/hmda/src/main/resources/application-kubernetes.conf
+++ b/hmda/src/main/resources/application-kubernetes.conf
@@ -19,9 +19,6 @@ akka {
   }
 
   management {
-    http {
-      port = 8558
-    }
 
     cluster.bootstrap {
 

--- a/hmda/src/main/resources/application-kubernetes.conf
+++ b/hmda/src/main/resources/application-kubernetes.conf
@@ -33,12 +33,6 @@ akka {
         stable-margin = 5 seconds
       }
 
-      contact-point {
-        # currently this port HAS TO be the same as the `akka.management.http.port`
-        # it would not have to be once we implement the SRV record watching, since then we could potentially
-        # get the ports from the DNS records.
-        fallback-port = 8558
-      }
     }
   }
 }

--- a/hmda/src/main/resources/application-kubernetes.conf
+++ b/hmda/src/main/resources/application-kubernetes.conf
@@ -1,5 +1,3 @@
-include "hmda.conf"
-
 akka {
 
   loglevel = INFO

--- a/hmda/src/main/resources/application.conf
+++ b/hmda/src/main/resources/application.conf
@@ -49,6 +49,13 @@ akka {
       bind-hostname = 0.0.0.0
       bind-port = 8558
     }
+    cluster.bootstrap {
+      contact-point {
+        # If no port is discovered along with the host/ip of a contact point this port will be used as fallback
+        fallback-port = 8558
+        fallback-port = ${?PORT_19999}
+      }
+    }
   }
 
 }

--- a/hmda/src/main/scala/hmda/HmdaPlatform.scala
+++ b/hmda/src/main/scala/hmda/HmdaPlatform.scala
@@ -57,7 +57,7 @@ object HmdaPlatform extends App {
 
   implicit val system =
     untyped.ActorSystem(mergedConfig.getString("hmda.cluster.name"),
-      mergedConfig)
+                        mergedConfig)
 
   implicit val typedSystem = system.toTyped
 

--- a/hmda/src/main/scala/hmda/HmdaPlatform.scala
+++ b/hmda/src/main/scala/hmda/HmdaPlatform.scala
@@ -55,10 +55,6 @@ object HmdaPlatform extends App {
 
   val mergedConfig = clusterConfig.withFallback(config)
 
-  log.info(s"Config: $config.root().render()")
-  log.info(s"Cluster Config: $clusterConfig.root().render()")
-  log.info(s"Merged Config: $mergedConfig.root().render()")
-
   implicit val system =
     untyped.ActorSystem(mergedConfig.getString("hmda.cluster.name"),
       mergedConfig)

--- a/hmda/src/main/scala/hmda/HmdaPlatform.scala
+++ b/hmda/src/main/scala/hmda/HmdaPlatform.scala
@@ -53,9 +53,15 @@ object HmdaPlatform extends App {
     case _ => config
   }
 
+  val mergedConfig = clusterConfig.withFallback(config)
+
+  log.info(s"Config: $config.root().render()")
+  log.info(s"Cluster Config: $clusterConfig.root().render()")
+  log.info(s"Merged Config: $mergedConfig.root().render()")
+
   implicit val system =
-    untyped.ActorSystem(clusterConfig.getString("hmda.cluster.name"),
-                        clusterConfig)
+    untyped.ActorSystem(mergedConfig.getString("hmda.cluster.name"),
+      mergedConfig)
 
   implicit val typedSystem = system.toTyped
 


### PR DESCRIPTION
This PR changes how environment specific configs are loaded in order to allow overrides to be passed in at runtime after the project has been assembled in a fat jar using the `-D` flag.

Before the entire configuration was loaded twice. First with the `ConfigFactory.load()` (which does pick up runtime overrides), this load was used to decide the runtime environment. Then the configuration was loaded again using `ConfigFactory.parseResources("<cluster>").resolve()` (which does not pick up runtime overrides) to pick up a version of the config that included cluster specific elements. This second config was then used to create the actor system and so runtime overrides were disappearing.

This PR does three things to change how the config is loaded. First it unlinks the cluster configs from the main `application.conf`. This means that when `ConfigFactory.parseResources("<cluster>").resolve()` is called, and the cluster specific configuration is loaded, that the rest of the configuration is not included, only the cluster specific bits. Second, it then merges the two configurations using `clusterConfig.withFallback(config)`. This unlink and then merge approach makes sure that our runtime overrides get properly passed into the configuration along with the cluster specific configuration elements. Finally, this PR removes duplication from the cluster specific and base `application.conf`.

The configuration hierarchy from this change is:

Cluster Specific Config -> Runtime Override -> `application.conf`