### PR TITLE
Check-digit merge strategy

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -110,6 +110,13 @@ lazy val `check-digit` = (project in file("check-digit"))
     Seq(
       assemblyJarName in assembly := {
         s"${name.value}.jar"
+      },
+      assemblyMergeStrategy in assembly := {
+        case "application.conf"                      => MergeStrategy.concat
+        case "META-INF/io.netty.versions.properties" => MergeStrategy.concat
+        case x =>
+          val oldStrategy = (assemblyMergeStrategy in assembly).value
+          oldStrategy(x)
       }
     ),
     scalafmtSettings,


### PR DESCRIPTION
Fixes multiple instances of `io.netty.versions.properties`

Closes #1808 