### PR TITLE
Fixed empty emails

### DIFF
--- a/hmda/src/main/scala/hmda/parser/institution/InstitutionCsvParser.scala
+++ b/hmda/src/main/scala/hmda/parser/institution/InstitutionCsvParser.scala
@@ -25,6 +25,9 @@ object InstitutionCsvParser {
     val topHolderName = values(16)
     val hmdaFiler = values(17)
 
+    val emails =
+      if (emailDomains.isEmpty) List() else emailDomains.split(',').toList
+
     Institution(
       acticityYear,
       lei,
@@ -33,7 +36,7 @@ object InstitutionCsvParser {
       if (instId2017 == "") None else Some(instId2017),
       if (taxId == "") None else Some(taxId),
       rssd.toInt,
-      emailDomains.split(',').toList,
+      emails,
       Respondent(
         if (respondentName == "") None else Some(respondentName),
         if (respondentState == "") None else Some(respondentState),

--- a/hmda/src/test/scala/hmda/parser/institution/InstitutionCsvParserSpec.scala
+++ b/hmda/src/test/scala/hmda/parser/institution/InstitutionCsvParserSpec.scala
@@ -12,7 +12,15 @@ class InstitutionCsvParserSpec
   property("Institution CSV Parser must parse values into CSV") {
     forAll(institutionGen) { institution =>
       val csv = institution.toCSV
-      InstitutionCsvParser(csv) mustBe institution
+      InstitutionCsvParser(csv) must equal(institution)
+    }
+  }
+
+  property("Empty emails should parse correctly") {
+    forAll(institutionGen) { institution =>
+      val i = institution.copy(emailDomains = List())
+      val csv = i.toCSV
+      InstitutionCsvParser(csv) must equal(i)
     }
   }
 


### PR DESCRIPTION
The problem with an empty email List is that calling `"".split(',').toList` will return `List("")`.  This will not equal the original empty collection.

Closes #1842 