### PR TITLE
Keycloak config for database

### DIFF
--- a/docs/v2/README.md
+++ b/docs/v2/README.md
@@ -154,6 +154,16 @@ You can access `Jenkins` by issuing `minikube service --n jenkins-system jenkins
 
 Follow the on screen instructions to finalize `Jenkins` setup. When logged in, update plugins if necessary.
 
+* Install Keycloak
+
+Make sure the two secrets are created: `realm` from the file under `/kubernetes/keycloak`, and `keycloak-credentials`
+with the key `password` set to the Postgres password.  Find the URL of the Postgres database, and then install Keycloak with 
+this command:
+
+```bash
+helm upgrade -i -f kubernetes/keycloak/values.yaml keycloak stable/keycloak --set keycloak.persistence.dbHost="<db URL>"
+```
+
 * Docker Hub Credentials
 
 Add credentials in Jenkins for `Docker Hub` so that images can be pushed as part of `Jenkins` pipeline builds.

--- a/kubernetes/keycloak/values.yaml
+++ b/kubernetes/keycloak/values.yaml
@@ -170,7 +170,7 @@ keycloak:
   ## Add additional volumes and mounts, e. g. for custom themes
   extraVolumes: |
     - name: realm-secret
-      secret: 
+      secret:
         secretName: realm-secret
   extraVolumeMounts: |
     - name: realm-secret
@@ -224,18 +224,18 @@ keycloak:
     deployPostgres: false
 
     # The database vendor. Can be either "postgres", "mysql", "mariadb", or "h2"
-    dbVendor: h2
+    dbVendor: postgres
 
     ## The following values only apply if "deployPostgres" is set to "false"
 
     # Specifies an existing secret to be used for the database password
-    existingSecret: ""
+    existingSecret: "keycloak-credentials"
 
     # The key in the existing secret that stores the password
     existingSecretKey: password
 
-    dbName: keycloak
-    dbHost: mykeycloak
+    dbName: keycloak_v2
+    dbHost: ""
     dbPort: 5432
     dbUser: keycloak
 


### PR DESCRIPTION
Closes #2046 

A database has been created in our RDS instance for the V2 deployment of keycloak.  To correctly install, first create the two secrets (realm and keycloak-credentials).  
Install with 
```
helm upgrade -i -f kubernetes/keycloak/values.yaml keycloak stable/keycloak --set keycloak.persistence.dbHost="<db URL>"
```