### PR TITLE
Add Jenkinsfile for Keycloak

### DIFF
--- a/jenkins/seed.groovy
+++ b/jenkins/seed.groovy
@@ -1,8 +1,12 @@
 projects = [
-    [name: "hmda-platform", repo: "hmda-platform", jenkinsfilePath: "hmda/Jenkinsfile", ],
-    [name: "check-digit", repo: "hmda-platform", jenkinsfilePath: "check-digit/Jenkinsfile", ],
-    [name: "institutions-api", repo: "hmda-platform", jenkinsfilePath: "institutions-api/Jenkinsfile", ],
-    [name: "hmda-help", repo: "hmda-help", jenkinsfilePath: "Jenkinsfile", ]
+    [name: "hmda-platform", repo: "hmda-platform", jenkinsfilePath: "hmda/Jenkinsfile"],
+    [name: "check-digit", repo: "hmda-platform", jenkinsfilePath: "check-digit/Jenkinsfile"],
+    [name: "institutions-api", repo: "hmda-platform", jenkinsfilePath: "institutions-api/Jenkinsfile"],
+    [name: "keycloak", repo: "hmda-platform", jenkinsfilePath: "kubernetes/keycloak/Jenkinsfile"],
+    [name: "hmda-help", repo: "hmda-help", jenkinsfilePath: "Jenkinsfile"],
+    [name: "hmda-pub-ui", repo: "hmda-pub-ui", jenkinsfilePath: "Jenkinsfile"],
+    [name: "hmda-platform-tools", repo: "hmda-platform-tools", jenkinsfilePath: "Jenkinsfile"],
+    [name: "hmda-homepage", repo: "hmda-homepage", jenkinsfilePath: "Jenkinsfile"],
 ]
 
 projects.each { project ->

--- a/kubernetes/keycloak/Jenkinsfile
+++ b/kubernetes/keycloak/Jenkinsfile
@@ -12,7 +12,7 @@ podTemplate(label: 'buildHelm', containers: [
             expression { return gitBranch == 'master' }
         }
         container('helm') {
-            withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'keylcloak-admin',
+            withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'keycloak-admin',
             usernameVariable: 'KEYCLOAK_USER', passwordVariable: 'KEYCLOAK_PASSWORD']]) {
                 withCredentials([string(credentialsId: 'keycloak-db', variable: 'POSTGRES_HOST')]) {
                     sh "helm upgrade --install --force --namespace=default \

--- a/kubernetes/keycloak/Jenkinsfile
+++ b/kubernetes/keycloak/Jenkinsfile
@@ -1,0 +1,28 @@
+podTemplate(label: 'buildHelm', containers: [
+  containerTemplate(name: 'helm', image: 'lachlanevenson/k8s-helm', ttyEnabled: true, command: 'cat')
+]) {
+   node('buildHelm') {
+     def repo = checkout scm
+     def gitCommit = repo.GIT_COMMIT
+     def gitBranch = repo.GIT_BRANCH
+     def shortGitCommit = "${gitCommit[0..10]}"
+
+    stage('Deploy') {
+        when {
+            expression { return gitBranch == 'master' }
+        }
+        container('helm') {
+            withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'keylcloak-admin',
+            usernameVariable: 'KEYCLOAK_USER', passwordVariable: 'KEYCLOAK_PASSWORD']]) {
+                withCredentials([string(credentialsId: 'keycloak-db', variable: 'POSTGRES_HOST')]) {
+                    sh "helm upgrade --install --force --namespace=default \
+                    --values=kubernetes/keycloak/values.yaml \
+                    --set keycloak.persistence.dbHost=${env.POSTGRES_HOST} \
+                    --set keycloak.username=${env.KEYCLOAK_USER} \
+                    --set keycloak.password=${env.KEYCLOAK_PASSWORD} \
+                    keycloak kubernetes/keycloak"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #2044 

We are unable to set the keycloak admin password as a secret because the keycloak helm chart creates a secret itself to store this information.

As such, this jenkins pipeline uses credentials in Jenkins to set the postgres db host and the keycloak admin credentials.