### PR TITLE
Q617 decimal place fixes

### DIFF
--- a/hmda/src/main/scala/hmda/validation/rules/lar/quality/Q617.scala
+++ b/hmda/src/main/scala/hmda/validation/rules/lar/quality/Q617.scala
@@ -29,9 +29,6 @@ object Q617 extends EditCheck[LoanApplicationRegister] {
       val ratioToPrecision =
         BigDecimal(calculatedRatio).setScale(precision, RoundingMode.HALF_UP)
 
-      println(s"CLTV: $combinedLoanValueRatio")
-      println(s"Calc: $ratioToPrecision")
-
       combinedLoanValueRatio is greaterThanOrEqual(ratioToPrecision)
     }
   }

--- a/hmda/src/test/scala/hmda/validation/rules/lar/quality/Q617Spec.scala
+++ b/hmda/src/test/scala/hmda/validation/rules/lar/quality/Q617Spec.scala
@@ -24,10 +24,28 @@ class Q617Spec extends LarEditCheckSpec {
         .mustFail
       appLar
         .copy(property = appLar.property.copy(propertyValue = "20.0"))
-        .mustFail
+        .mustPass
       appLar
         .copy(property = appLar.property.copy(propertyValue = "21.0"))
         .mustPass
+    }
+  }
+
+  property("Calculation should match number of digits reported in CLTV ratio") {
+    forAll(larGen) { lar =>
+      val appLar =
+        lar.copy(
+          loan = lar.loan.copy(combinedLoanToValueRatio = "50", amount = 50.4))
+      appLar
+        .copy(property = appLar.property.copy(propertyValue = "100.0"))
+        .mustPass
+
+      val roundLar =
+        lar.copy(
+          loan = lar.loan.copy(combinedLoanToValueRatio = "50", amount = 50.5))
+      roundLar
+        .copy(property = roundLar.property.copy(propertyValue = "100.0"))
+        .mustFail
     }
   }
 }


### PR DESCRIPTION
Address #1894 

The calculated loan-to-property-value ratio should match the number of decimal places reported in the "Combined Loan-to-Value Ratio" field of the LAR.