### PR TITLE
Remove Ambassador Post Method Requirement

### DIFF
--- a/kubernetes/check-digit/templates/service.yaml
+++ b/kubernetes/check-digit/templates/service.yaml
@@ -33,7 +33,6 @@ metadata:
       apiVersion: ambassador/v0
       kind: Mapping
       name: check_digit_mapping
-      method: POST
       prefix: /v2/public/uli/checkDigit/
       rewrite: /uli/checkDigit
       service: {{ template "check-digit.fullname" .}}:{{ .Values.service.port }}
@@ -49,7 +48,6 @@ metadata:
       apiVersion: ambassador/v0
       kind: Mapping
       name: check_digit_csv
-      method: POST
       prefix: /v2/public/uli/checkDigit/csv/
       rewrite: /uli/checkDigit/csv
       service: {{ template "check-digit.fullname" .}}:{{ .Values.service.port }}


### PR DESCRIPTION
In testing, the ambassador configuration for the `check-digit` service fails if it includes the `POST` method requirement. I am not sure why the `method: POST` declaration causes the configuration to fail. It will take more research to discover the exact cause of the failure and possibly add the method requirement back.

For the time being this change allows the `check-digit` single ULI and csv upload endpoints to work and does not change these endpoints requirement for a `POST` call. However, instead of `ambassador` catching an improper method call, the `check-digit` service itself catches it and responds with `HTTP method not allowed, supported methods: POST`.

I have created an issue to research the issue further.