### PR TITLE
Fix institutions-api Helm Chart Docker Image

### DIFF
--- a/kubernetes/institutions-api/values.yaml
+++ b/kubernetes/institutions-api/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: hmda/hmda-institutions-api
+  repository: hmda/institutions-api
   tag: 0.1.3
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Changes the docker image used in the `institutions-api` helm chart to use the `hmda/institutions-api` image rather than the `hmda/hmda-institutions-api` image. This makes the helm chart conform to where jenkins is pushing the latest images.