### PR TITLE
Stream check-digit response

### DIFF
--- a/check-digit/src/main/scala/hmda/uli/api/http/ULIHttpApi.scala
+++ b/check-digit/src/main/scala/hmda/uli/api/http/ULIHttpApi.scala
@@ -121,10 +121,6 @@ trait ULIHttpApi extends HmdaTimeDirectives {
                     val withUliWrapper: Flow[ByteString, ByteString, NotUsed] =
                       Flow[ByteString]
                         .intersperse(uStart, uMiddle, uEnd)
-                        .map(s => {
-                          println(s.utf8String)
-                          s
-                        })
                     implicit val jsonStreamingSupport
                       : JsonEntityStreamingSupport =
                       EntityStreamingSupport

--- a/docs/v2/api/uli.md
+++ b/docs/v2/api/uli.md
@@ -36,18 +36,20 @@ Example file contents:
 Example response in `JSON` format:
 
 ```json
-[
-    {
-        "loanId": "10Bx939c5543TqA1144M999143X",
-        "checkDigit": 38,
-        "uli": "10Bx939c5543TqA1144M999143X38"
-    },
-    {
-        "loanId": "10Cx939c5543TqA1144M999143X",
-        "checkDigit": 10,
-        "uli": "10Cx939c5543TqA1144M999143X10"
-    }
-]
+{
+    "loanIds": [
+        {
+            "loanId": "10Bx939c5543TqA1144M999143X",
+            "checkDigit": 38,
+            "uli": "10Bx939c5543TqA1144M999143X38"
+        },
+        {
+            "loanId": "10Cx939c5543TqA1144M999143X",
+            "checkDigit": 10,
+            "uli": "10Cx939c5543TqA1144M999143X10"
+        }
+    ]
+}
 ```
 
 * `/uli/checkDigit/csv`
@@ -104,20 +106,22 @@ Example file contents:
 Example response in `JSON` format:
 
 ```json
-[
-    {
-        "uli": "10Cx939c5543TqA1144M999143X10",
-        "isValid": true
-    },
-    {
-        "uli": "10Bx939c5543TqA1144M999143X38",
-        "isValid": true
-    },
-    {
-        "uli": "10Bx939c5543TqA1144M999133X38",
-        "isValid": false
-    }
-]
+{
+    "ulis": [
+        {
+            "uli": "10Cx939c5543TqA1144M999143X10",
+            "isValid": true
+        },
+        {
+            "uli": "10Bx939c5543TqA1144M999143X38",
+            "isValid": true
+        },
+        {
+            "uli": "10Bx939c5543TqA1144M999133X38",
+            "isValid": false
+        }
+    ]
+}
 ```
 
 * `/uli/validate/csv`

--- a/docs/v2/api/uli.md
+++ b/docs/v2/api/uli.md
@@ -36,20 +36,18 @@ Example file contents:
 Example response in `JSON` format:
 
 ```json
-{
-    "loanIds": [
-        {
-            "loanId": "10Bx939c5543TqA1144M999143X",
-            "checkDigit": 38,
-            "uli": "10Bx939c5543TqA1144M999143X38"
-        },
-        {
-            "loanId": "10Cx939c5543TqA1144M999143X",
-            "checkDigit": 10,
-            "uli": "10Cx939c5543TqA1144M999143X10"
-        }
-    ]
-}
+[
+    {
+        "loanId": "10Bx939c5543TqA1144M999143X",
+        "checkDigit": 38,
+        "uli": "10Bx939c5543TqA1144M999143X38"
+    },
+    {
+        "loanId": "10Cx939c5543TqA1144M999143X",
+        "checkDigit": 10,
+        "uli": "10Cx939c5543TqA1144M999143X10"
+    }
+]
 ```
 
 * `/uli/checkDigit/csv`
@@ -106,22 +104,20 @@ Example file contents:
 Example response in `JSON` format:
 
 ```json
-{
-    "ulis": [
-        {
-            "uli": "10Cx939c5543TqA1144M999143X10",
-            "isValid": true
-        },
-        {
-            "uli": "10Bx939c5543TqA1144M999143X38",
-            "isValid": true
-        },
-        {
-            "uli": "10Bx939c5543TqA1144M999133X38",
-            "isValid": false
-        }
-    ]
-}
+[
+    {
+        "uli": "10Cx939c5543TqA1144M999143X10",
+        "isValid": true
+    },
+    {
+        "uli": "10Bx939c5543TqA1144M999143X38",
+        "isValid": true
+    },
+    {
+        "uli": "10Bx939c5543TqA1144M999133X38",
+        "isValid": false
+    }
+]
 ```
 
 * `/uli/validate/csv`


### PR DESCRIPTION
Switches the response of the file upload, non-csv endpoints to stream a response back instead of creating a large JSON object.  This will help avoid the timeouts and allow larger files to be checked and validated.

Closes #1667 