### PR TITLE
prune images

### DIFF
--- a/check-digit/Jenkinsfile
+++ b/check-digit/Jenkinsfile
@@ -27,8 +27,7 @@ volumes: [
               sh "docker login -u ${env.DOCKER_HUB_USER} -p ${env.DOCKER_HUB_PASSWORD} "
               sh "docker push ${env.DOCKER_HUB_USER}/hmda-check-digit:${gitBranch}"
               sh "docker images"
-              sh "docker images | grep 'check-digit' | awk '{print \$3}' | uniq"
-              sh "docker rmi -f \$(docker images --filter='dangling=true' --filter='name=check-digit' | awk '{print \$3}' | uniq)"
+              sh "docker image prune -f"
               sh "docker images"
               sh "docker ps -a"
             }

--- a/hmda/Jenkinsfile
+++ b/hmda/Jenkinsfile
@@ -27,8 +27,7 @@ volumes: [
               sh "docker login -u ${env.DOCKER_HUB_USER} -p ${env.DOCKER_HUB_PASSWORD} "
               sh "docker push ${env.DOCKER_HUB_USER}/hmda-platform:${gitBranch}"
               sh "docker images"
-              sh "docker images | grep 'hmda-platform' | awk '{print \$3}' | uniq"
-              sh "docker rmi -f \$(docker images --filter='dangling=true' --filter='name=hmda-platform' | awk '{print \$3}' | uniq)"
+              sh "docker image prune -f"
               sh "docker images"
               sh "docker ps -a"
             }

--- a/institutions-api/Jenkinsfile
+++ b/institutions-api/Jenkinsfile
@@ -27,8 +27,7 @@ volumes: [
               sh "docker login -u ${env.DOCKER_HUB_USER} -p ${env.DOCKER_HUB_PASSWORD} "
               sh "docker push ${env.DOCKER_HUB_USER}/institutions-api:${gitBranch}"
               sh "docker images"
-              sh "docker images | grep 'institutions-api' | awk '{print \$3}' | uniq"
-              sh "docker rmi -f \$(docker images --filter='dangling=true' --filter='name=institutions-api' | awk '{print \$3}' | uniq)"
+              sh "docker image prune -f"
               sh "docker images"
               sh "docker ps -a"
             }

--- a/kubernetes/keycloak/theme-provider/Jenkinsfile
+++ b/kubernetes/keycloak/theme-provider/Jenkinsfile
@@ -19,8 +19,7 @@ volumes: [
               sh "docker login -u ${env.DOCKER_HUB_USER} -p ${env.DOCKER_HUB_PASSWORD} "
               sh "docker push ${env.DOCKER_HUB_USER}/theme-provider:${gitBranch}"
               sh "docker images"
-              sh "docker images | grep 'theme-provider' | awk '{print \$3}' | uniq"
-              sh "docker rmi -f \$(docker images --filter='dangling=true' --filter='name=theme-provider' | awk '{print \$3}' | uniq)"
+              sh "docker image prune -f"
               sh "docker images"
               sh "docker ps -a"
             }


### PR DESCRIPTION
We're running version `1.30` in Jenkins. Beginning with `1.25+`, docker provides the `image prune` and `system prune` commands. 

https://docs.docker.com/engine/reference/commandline/image_prune/

`image prune` should remove all dangling images. It will still not remove tagged but unused (not referenced by a container) images. To assess this I've added `docker images` and `docker ps -a` commands so that we can assess how many unused  images are being accumulated after each build.