### PR TITLE
simplify ambassador routes for check-digit and include validate routes

### DIFF
--- a/kubernetes/check-digit/templates/service.yaml
+++ b/kubernetes/check-digit/templates/service.yaml
@@ -33,23 +33,8 @@ metadata:
       apiVersion: ambassador/v0
       kind: Mapping
       name: check_digit_mapping
-      prefix: /v2/public/uli/checkDigit/
-      rewrite: /uli/checkDigit
-      service: {{ template "check-digit.fullname" .}}:{{ .Values.service.port }}
-      ---
-      apiVersion: ambassador/v0
-      kind: Mapping
-      name: check_digit_root
-      method: GET
-      prefix: /v2/public/uli/status/
-      rewrite: /
-      service: {{ template "check-digit.fullname" .}}:{{ .Values.service.port }}
-      ---
-      apiVersion: ambassador/v0
-      kind: Mapping
-      name: check_digit_csv
-      prefix: /v2/public/uli/checkDigit/csv/
-      rewrite: /uli/checkDigit/csv
+      prefix: /v2/public/uli/
+      rewrite: /uli/
       service: {{ template "check-digit.fullname" .}}:{{ .Values.service.port }}
 
 spec:


### PR DESCRIPTION
1. simplify ambassador routes 
1. expose validate routes
1. bring ambassador routes closer inline with api documentation

This came from discussion with @awolfe76  about the -ui will consumer the check-digit api.