### PR TITLE
WIP: tag with commit id instead of latest

### DIFF
--- a/hmda/Jenkinsfile
+++ b/hmda/Jenkinsfile
@@ -10,6 +10,7 @@ volumes: [
      def repo = checkout scm
      def gitCommit = repo.GIT_COMMIT
      def gitBranch = repo.GIT_BRANCH
+     def commitId = sh(returnStdout: true, script: 'git rev-parse HEAD')
 
      stage('Build Scala Code and Generate Dockerfile') {
        container('sbt') {
@@ -25,12 +26,8 @@ volumes: [
             usernameVariable: 'DTR_USER', passwordVariable: 'DTR_PASSWORD']]) {
             withCredentials([string(credentialsId: 'internal-docker-registry', variable: 'DOCKER_REGISTRY_URL')]){
               sh "docker build --rm -t=${env.DOCKER_HUB_USER}/hmda-platform hmda/target/docker/stage"
-              if (env.TAG_NAME != null || gitBranch == "master") {
-                if (gitBranch == "master") {
-                  env.DOCKER_TAG = "latest"
-                } else {
-                  env.DOCKER_TAG = env.TAG_NAME
-                }
+              if (gitBranch == "master") {
+                env.DOCKER_TAG = commitId
                 sh """
                   docker tag ${env.DOCKER_HUB_USER}/hmda-platform ${env.DOCKER_HUB_USER}/hmda-platform:${env.DOCKER_TAG}
                   docker login -u ${env.DOCKER_HUB_USER} -p ${env.DOCKER_HUB_PASSWORD} 


### PR DESCRIPTION
This PR uses short git commit to tag the docker image prior to pushing it to docker hub. This should trigger helm to deploy the new changes as per the best practices https://docs.helm.sh/chart_best_practices/#images . 

Also, we're pushing each [PR to docker hub](https://hub.docker.com/r/hmda/hmda-platform/tags/) which seems un-necessary. We only deploy the master branch so we should only be pushing the master branch to docker hub. 

Once we can test this change on hmda-platform we can replicate it onto other repos/microservices. 