### PR TITLE
Fix encoding for submission status in ws endpoint

### DIFF
--- a/hmda/src/main/scala/hmda/api/ws/filing/submissions/SubmissionWsApi.scala
+++ b/hmda/src/main/scala/hmda/api/ws/filing/submissions/SubmissionWsApi.scala
@@ -11,6 +11,7 @@ import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.server.Directives._
 import akka.stream.scaladsl.{Flow, Source}
 import ch.megard.akka.http.cors.scaladsl.CorsDirectives._
+import hmda.api.http.codec.filing.submission.SubmissionStatusCodec._
 import com.typesafe.config.ConfigFactory
 import hmda.api.ws.model.{
   KeepAliveWsResponse,


### PR DESCRIPTION
Without this import, the ws endpoint prints out submission status with the wrong structure