### PR TITLE
Pagination refactor

### DIFF
--- a/hmda/src/main/resources/hmda.conf
+++ b/hmda/src/main/resources/hmda.conf
@@ -40,6 +40,8 @@ hmda {
     shardNumber = 100
   }
 
+  pageSize = 20
+
   loader {
     parallelism = 4
     institution {

--- a/hmda/src/main/resources/hmda.conf
+++ b/hmda/src/main/resources/hmda.conf
@@ -41,6 +41,7 @@ hmda {
   }
 
   pageSize = 20
+  pageSize = ${?HMDA_PAGE_SIZE}
 
   loader {
     parallelism = 4

--- a/hmda/src/main/scala/hmda/api/http/model/filing/submissions/PaginatedResponse.scala
+++ b/hmda/src/main/scala/hmda/api/http/model/filing/submissions/PaginatedResponse.scala
@@ -24,8 +24,8 @@ trait PaginatedResponse extends WithPagination {
     } else 0
   }
 
-  def fromIndex: Int = calculateStartIndex(total, 0, currentPage)
-  def toIndex: Int = calculateEndIndex(total, 0, currentPage)
+  def fromIndex: Int = calculateStartIndex(total, currentPage)
+  def toIndex: Int = calculateEndIndex(total, currentPage)
 
   private def validPage: Boolean = currentPage >= 1 && currentPage <= lastPage
 

--- a/hmda/src/main/scala/hmda/api/http/model/filing/submissions/PaginatedResponse.scala
+++ b/hmda/src/main/scala/hmda/api/http/model/filing/submissions/PaginatedResponse.scala
@@ -24,6 +24,9 @@ trait PaginatedResponse extends WithPagination {
     } else 0
   }
 
+  def fromIndex: Int = calculateStartIndex(total, 0, currentPage)
+  def toIndex: Int = calculateEndIndex(total, 0, currentPage)
+
   private def validPage: Boolean = currentPage >= 1 && currentPage <= lastPage
 
   private def configurablePath: String = s"$path{rel}"

--- a/hmda/src/main/scala/hmda/model/filing/submissions/PaginatedResource.scala
+++ b/hmda/src/main/scala/hmda/model/filing/submissions/PaginatedResource.scala
@@ -1,16 +1,23 @@
 package hmda.model.filing.submissions
 
+import com.typesafe.config.ConfigFactory
+
 case class PaginatedResource(totalRecords: Int, offset: Int = 0)(page: Int)
     extends WithPagination {
-  def fromIndex: Int = {
-    val i = if (page == 1) 0 else pageSize * (page - 1) - offset
-    Math.min(totalRecords, i)
-  }
-  def toIndex: Int = {
-    Math.min(totalRecords, (page * pageSize) - offset)
-  }
+  def fromIndex: Int = calculateStartIndex(totalRecords, offset, page)
+  def toIndex: Int = calculateEndIndex(totalRecords, offset, page)
 }
 
 trait WithPagination {
-  def pageSize: Int = 20
+  private val config = ConfigFactory.load()
+  def pageSize: Int = config.getInt("hmda.pageSize")
+
+  def calculateStartIndex(total: Int, offset: Int, page: Int): Int = {
+    val i = if (page == 1) 0 else pageSize * (page - 1) - offset
+    Math.min(total, i)
+  }
+
+  def calculateEndIndex(total: Int, offset: Int, page: Int): Int = {
+    Math.min(total, (page * pageSize) - offset)
+  }
 }

--- a/hmda/src/main/scala/hmda/model/filing/submissions/PaginatedResource.scala
+++ b/hmda/src/main/scala/hmda/model/filing/submissions/PaginatedResource.scala
@@ -4,20 +4,20 @@ import com.typesafe.config.ConfigFactory
 
 case class PaginatedResource(totalRecords: Int, offset: Int = 0)(page: Int)
     extends WithPagination {
-  def fromIndex: Int = calculateStartIndex(totalRecords, offset, page)
-  def toIndex: Int = calculateEndIndex(totalRecords, offset, page)
+  def fromIndex: Int = calculateStartIndex(totalRecords, page, offset)
+  def toIndex: Int = calculateEndIndex(totalRecords, page, offset)
 }
 
 trait WithPagination {
   private val config = ConfigFactory.load()
   def pageSize: Int = config.getInt("hmda.pageSize")
 
-  def calculateStartIndex(total: Int, offset: Int, page: Int): Int = {
+  def calculateStartIndex(total: Int, page: Int, offset: Int = 0): Int = {
     val i = if (page == 1) 0 else pageSize * (page - 1) - offset
     Math.min(total, i)
   }
 
-  def calculateEndIndex(total: Int, offset: Int, page: Int): Int = {
+  def calculateEndIndex(total: Int, page: Int, offset: Int = 0): Int = {
     Math.min(total, (page * pageSize) - offset)
   }
 }


### PR DESCRIPTION
* Moves common pagination methods into the `WithPagination` trait
* Fix - uses existing logic in `PaginatedResponse` to calculate `take()` logic
* Simplifies EditDetails gathering by using existing `EditDetailsSummary` object

Closes #2284 