### PR TITLE
Allow pod-namespace to be set for cluster.bootstrap when using kubernetes-api

### DIFF
--- a/hmda/src/main/resources/application-kubernetes.conf
+++ b/hmda/src/main/resources/application-kubernetes.conf
@@ -19,6 +19,8 @@ akka {
 
     kubernetes-api {
       pod-label-selector = "actorSystemName=hmda2"
+      pod-namespace = "default"
+      pod-namespace = ${?KUBERNETES_HMDA_POD_NAMESPACE}
     }
   }
 

--- a/kubernetes/hmda-platform/templates/deployment.yaml
+++ b/kubernetes/hmda-platform/templates/deployment.yaml
@@ -25,6 +25,10 @@ spec:
         env:
         - name: HMDA_RUNTIME_MODE
           value: {{ .Values.hmda.runtimeMode }}
+        - name: KUBERNETES_HMDA_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: HOST_NAME
           valueFrom:
             fieldRef:


### PR DESCRIPTION
While trying to run hmda v2 in our datacenter, I discovered that Akka ClusterBootstrap requires this property to be set for discovery to correctly take place, if one is not using `default` namespace for the deployment.

The `service-namespace` in the same file is not used when using `kubernetes-api`.

The [docs](https://developer.lightbend.com/docs/akka-management/current/bootstrap/kubernetes-api.html) themselves mention of the `pod-namespace` key, but also a `namespace` ENV var. That var did not work for me.