### PR TITLE
Insert records in serial and prevent duplicates

### DIFF
--- a/common/src/main/scala/hmda/projection/ResumableProjection.scala
+++ b/common/src/main/scala/hmda/projection/ResumableProjection.scala
@@ -60,7 +60,7 @@ trait ResumableProjection {
               SaveOffset(env.offset, ref))
             result
           }
-          .runWith(Sink.ignore)
+          .runWith(Sink.onComplete(_ => log.error("The Institutions API has stopped streaming")))
         Effect.none
 
       case SaveOffset(offset, replyTo) =>

--- a/institutions-api/src/main/scala/hmda/institution/projection/InstitutionDBProjection.scala
+++ b/institutions-api/src/main/scala/hmda/institution/projection/InstitutionDBProjection.scala
@@ -39,8 +39,7 @@ object InstitutionDBProjection
       case InstitutionCreated(i) =>
         institutionRepository.insertOrUpdate(InstitutionConverter.convert(i))
         val emails = InstitutionConverter.emailsFromInstitution(i)
-        emails.foreach(email =>
-          institutionEmailsRepository.insertOrUpdate(email))
+        emails.foreach(email => updateEmails(email))
 
       case InstitutionModified(i) =>
         institutionRepository.insertOrUpdate(InstitutionConverter.convert(i))

--- a/institutions-api/src/main/scala/hmda/institution/projection/InstitutionDBProjection.scala
+++ b/institutions-api/src/main/scala/hmda/institution/projection/InstitutionDBProjection.scala
@@ -4,16 +4,13 @@ import akka.persistence.query.EventEnvelope
 import akka.util.Timeout
 import com.typesafe.config.ConfigFactory
 import hmda.institution.api.http.InstitutionConverter
-import hmda.institution.query.InstitutionComponent
-import hmda.messages.institution.InstitutionEvents.{
-  InstitutionCreated,
-  InstitutionDeleted,
-  InstitutionModified
-}
+import hmda.institution.query.{InstitutionComponent, InstitutionEmailEntity}
+import hmda.messages.institution.InstitutionEvents.{InstitutionCreated, InstitutionDeleted, InstitutionModified}
+import hmda.model.institution.Institution
 import hmda.projection.ResumableProjection
 import hmda.query.DbConfiguration._
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 
 object InstitutionDBProjection
@@ -37,20 +34,35 @@ object InstitutionDBProjection
     val event = envelope.event
     event match {
       case InstitutionCreated(i) =>
-        institutionRepository.insertOrUpdate(InstitutionConverter.convert(i))
-        val emails = InstitutionConverter.emailsFromInstitution(i)
-        emails.foreach(email => updateEmails(email))
+        updateTables(i)
 
       case InstitutionModified(i) =>
-        institutionRepository.insertOrUpdate(InstitutionConverter.convert(i))
-        val emails = InstitutionConverter.emailsFromInstitution(i)
-        emails.foreach(email => updateEmails(email))
+        updateTables(i)
 
       case InstitutionDeleted(lei) =>
         institutionRepository.deleteById(lei)
         deleteEmails(lei)
     }
     envelope
+  }
+
+  private def updateTables(inst: Institution): Future[List[Int]] = {
+    val insertResult = institutionRepository.insertOrUpdate(InstitutionConverter.convert(inst))
+    val emails = InstitutionConverter.emailsFromInstitution(inst).toList
+    for {
+      institutionRow <- insertResult
+      emailsRows <- updateEmailsInSerial(emails)
+    } yield emailsRows :+ institutionRow
+  }
+
+  private def updateEmailsInSerial(emails: List[InstitutionEmailEntity]): Future[List[Int]] = {
+    emails.foldLeft(Future(List.empty[Int])) {
+      (previousInserts, nextEmail) =>
+        for {
+          completedInserts <- previousInserts
+          insertResult <- updateEmails(nextEmail)
+        } yield completedInserts :+ insertResult
+    }
   }
 
 }


### PR DESCRIPTION
Changes the projection behavior to insert records in serial to avoid dropped write operations that have been observed while loading institutions.  

Also uses the existing `update` method for emails to avoid inserting duplicate email records, which should allow us to reload institution data repeatedly without wiping the database.

Adds a log error if the Institutions API stops streaming.