### PR TITLE
Set logging to debug for persisted events

### DIFF
--- a/hmda/src/main/scala/hmda/persistence/submission/EditDetailsPersistence.scala
+++ b/hmda/src/main/scala/hmda/persistence/submission/EditDetailsPersistence.scala
@@ -47,7 +47,7 @@ object EditDetailsPersistence
       case PersistEditDetails(editDetail, maybeReplyTo) =>
         val evt = EditDetailsAdded(editDetail)
         Effect.persist(evt).thenRun { _ =>
-          log.info(s"Persisted: $evt")
+          log.debug(s"Persisted: $evt")
           maybeReplyTo match {
             case Some(replyTo) =>
               replyTo ! evt

--- a/hmda/src/main/scala/hmda/persistence/submission/HmdaValidationError.scala
+++ b/hmda/src/main/scala/hmda/persistence/submission/HmdaValidationError.scala
@@ -227,7 +227,7 @@ object HmdaValidationError
           Effect
             .persist(HmdaRowValidatedError(rowNumber, validationErrors))
             .thenRun { _ =>
-              log.info(
+              log.debug(
                 s"Persisted: ${HmdaRowValidatedError(rowNumber, validationErrors)}")
 
               val hmdaRowValidatedError =


### PR DESCRIPTION
Reduces logging for persistent events so that logs are easier to read