### PR TITLE
Remove double slash from error page

### DIFF
--- a/kubernetes/keycloak/theme-provider/themes/hmda/login/error.ftl
+++ b/kubernetes/keycloak/theme-provider/themes/hmda/login/error.ftl
@@ -7,7 +7,7 @@
     <#elseif section = "form">
         <div id="kc-error-message">
             <p class="instruction">${message.summary?no_esc}</p>
-            <p><a class="usa-button" id="backToApplication" href="${properties.filingAppUrl}/institutions">${msg("doLogIn")}</a></p>
+            <p><a class="usa-button" id="backToApplication" href="${properties.filingAppUrl}institutions">${msg("doLogIn")}</a></p>
         </div>
     </#if>
 </@layout.registrationLayout>


### PR DESCRIPTION
filingAppUrl now includes the trailing slash