### PR TITLE
Close GRPC connections after they are used

### DIFF
--- a/hmda/src/main/scala/hmda/persistence/submission/HmdaValidationError.scala
+++ b/hmda/src/main/scala/hmda/persistence/submission/HmdaValidationError.scala
@@ -23,19 +23,33 @@ import akka.cluster.sharding.typed.ShardingEnvelope
 import akka.cluster.sharding.typed.scaladsl.ClusterSharding
 import akka.stream.ActorMaterializer
 import akka.stream.typed.scaladsl.ActorFlow
-import hmda.messages.institution.InstitutionCommands.{GetInstitution, ModifyInstitution}
+import hmda.messages.institution.InstitutionCommands.{
+  GetInstitution,
+  ModifyInstitution
+}
 import hmda.model.filing.ts.{TransmittalLar, TransmittalSheet}
 import hmda.model.institution.Institution
 import hmda.persistence.institution.InstitutionPersistence
 import hmda.validation.context.ValidationContext
 import hmda.parser.filing.ParserFlow._
 import hmda.validation.filing.ValidationFlow._
-import HmdaProcessingUtils.{readRawData, updateSubmissionReceipt, updateSubmissionStatus}
+import HmdaProcessingUtils.{
+  readRawData,
+  updateSubmissionReceipt,
+  updateSubmissionStatus
+}
 import EditDetailsConverter._
 import akka.{Done, NotUsed}
 import akka.cluster.sharding.typed.scaladsl.EntityRef
-import hmda.messages.institution.InstitutionEvents.{InstitutionEvent, InstitutionKafkaEvent, InstitutionModified}
-import hmda.messages.submission.EditDetailsCommands.{EditDetailsPersistenceCommand, PersistEditDetails}
+import hmda.messages.institution.InstitutionEvents.{
+  InstitutionEvent,
+  InstitutionKafkaEvent,
+  InstitutionModified
+}
+import hmda.messages.submission.EditDetailsCommands.{
+  EditDetailsPersistenceCommand,
+  PersistEditDetails
+}
 import hmda.messages.submission.EditDetailsEvents.EditDetailsPersistenceEvent
 import hmda.publication.KafkaUtils._
 import hmda.messages.pubsub.HmdaTopics._
@@ -570,12 +584,11 @@ object HmdaValidationError
       sharding: ClusterSharding): Unit = {
 
     val institutionPersistence =
-      sharding.entityRefFor(
-        InstitutionPersistence.typeKey,
-        s"${InstitutionPersistence.name}-$institutionID")
+      sharding.entityRefFor(InstitutionPersistence.typeKey,
+                            s"${InstitutionPersistence.name}-$institutionID")
 
     val fInstitution: Future[Option[Institution]] = institutionPersistence ? (
-      ref => GetInstitution(ref))
+        ref => GetInstitution(ref))
 
     for {
       maybeInst <- fInstitution

--- a/hmda/src/main/scala/hmda/validation/rules/lar/quality/Q603.scala
+++ b/hmda/src/main/scala/hmda/validation/rules/lar/quality/Q603.scala
@@ -43,9 +43,13 @@ object Q603 extends AsyncEditCheck[LoanApplicationRegister] {
     val client = CensusServiceClient(
       GrpcClientSettings.connectToServiceAt(host, port).withTls(false)
     )
-    client
-      .validatePopulation(ValidPopulationRequest(county))
-      .map(response => response.isValid)
+    for {
+      response <- client
+        .validatePopulation(ValidPopulationRequest(county))
+        .map(response => response.isValid)
+      _ <- client.close()
+      closed <- client.closed()
+    } yield (response, closed)._1
   }
 
 }

--- a/hmda/src/main/scala/hmda/validation/rules/lar/quality/Q604.scala
+++ b/hmda/src/main/scala/hmda/validation/rules/lar/quality/Q604.scala
@@ -43,9 +43,13 @@ object Q604 extends AsyncEditCheck[LoanApplicationRegister] {
     val client = CensusServiceClient(
       GrpcClientSettings.connectToServiceAt(host, port).withTls(false)
     )
-    client
-      .validateCounty(ValidCountyRequest(county))
-      .map(response => response.isValid)
+    for {
+      response <- client
+        .validateCounty(ValidCountyRequest(county))
+        .map(response => response.isValid)
+      _ <- client.close()
+      closed <- client.closed()
+    } yield (response, closed)._1
   }
 
 }

--- a/hmda/src/main/scala/hmda/validation/rules/lar/validity/V609.scala
+++ b/hmda/src/main/scala/hmda/validation/rules/lar/validity/V609.scala
@@ -42,9 +42,13 @@ object V609 extends AsyncEditCheck[LoanApplicationRegister] {
     val client = CheckDigitServiceClient(
       GrpcClientSettings.connectToServiceAt(host, port).withTls(false)
     )
-    client
-      .validateUli(ValidUliRequest(uli))
-      .map(response => response.isValid)
+    for {
+      response <- client
+        .validateUli(ValidUliRequest(uli))
+        .map(response => response.isValid)
+      _ <- client.close()
+      closed <- client.closed()
+    } yield (response, closed)._1
   }
 
 }


### PR DESCRIPTION
This PR addresses #2386
 I believe this bug is related to the inclusion of the `Census` edit checks, which require a request to the `census` microservice through `gRPC`. The problem seems to be that the connections created in the process are not closed, and the sheer number of them create scaling issues, including a memory leak that will end up with the application blowing up the heap. The changes in this PR might help in mitigating this, but I have not had time to test this fully and thus are labeling this as WIP. I don't like the implementation here but decided to go for something that had minimal code impact, if I had more time I would think about how to inject the connection at runtime for the services that need it (at this point, 2 microservices, check digit and census). These 2 connections can be reused by all the calls being made to these backend resources. While not a full solution, the code here should hopefully point in the right direction