### PR TITLE
ambassador timeout for keycloak

### DIFF
--- a/kubernetes/keycloak/keycloak-ambassador.yaml
+++ b/kubernetes/keycloak/keycloak-ambassador.yaml
@@ -12,6 +12,7 @@ metadata:
       prefix: /auth/
       rewrite: /auth/
       service: keycloak-http
+      timeout_ms: 20000
 spec:
   type: NodePort
   ports:


### PR DESCRIPTION
This provides sufficient time for keycloak to validate the token with other services