### PR TITLE
Fix Filing State

### DIFF
--- a/hmda/src/main/scala/hmda/persistence/filing/FilingPersistence.scala
+++ b/hmda/src/main/scala/hmda/persistence/filing/FilingPersistence.scala
@@ -14,14 +14,10 @@ import hmda.messages.filing.FilingEvents.{
   SubmissionAdded,
   SubmissionUpdated
 }
+
 import hmda.messages.institution.InstitutionCommands.AddFiling
 import hmda.model.filing.FilingDetails
-import hmda.model.filing.submission.{
-  Signed,
-  Submission,
-  SubmissionStatus,
-  SubmissionSummary
-}
+import hmda.model.filing.submission.SubmissionSummary
 import hmda.persistence.HmdaTypedPersistentActor
 import hmda.persistence.institution.InstitutionPersistence
 

--- a/hmda/src/main/scala/hmda/persistence/filing/FilingPersistence.scala
+++ b/hmda/src/main/scala/hmda/persistence/filing/FilingPersistence.scala
@@ -16,7 +16,12 @@ import hmda.messages.filing.FilingEvents.{
 }
 import hmda.messages.institution.InstitutionCommands.AddFiling
 import hmda.model.filing.FilingDetails
-import hmda.model.filing.submission.SubmissionSummary
+import hmda.model.filing.submission.{
+  Signed,
+  Submission,
+  SubmissionStatus,
+  SubmissionSummary
+}
 import hmda.persistence.HmdaTypedPersistentActor
 import hmda.persistence.institution.InstitutionPersistence
 

--- a/hmda/src/main/scala/hmda/persistence/filing/FilingState.scala
+++ b/hmda/src/main/scala/hmda/persistence/filing/FilingState.scala
@@ -28,7 +28,13 @@ case class FilingState(filing: Filing = Filing(),
           FilingState(this.filing, submission :: submissions)
         }
       case SubmissionUpdated(updated) =>
-        if (submissions.map(_.id).contains(updated.id) && !isSigned(updated)) {
+        if (submissions.map(_.id).contains(updated.id)
+            && !isSigned(updated)
+            && (!isSigned(
+              submissions
+                .filter(_.id == updated.id)
+                .headOption
+                .getOrElse(Submission())))) {
           val updatedList = updated :: submissions.filterNot(s =>
             s.id == updated.id)
           FilingState(this.filing, updatedList)
@@ -49,6 +55,7 @@ case class FilingState(filing: Filing = Filing(),
   }
 
   private def isSigned(updated: Submission): Boolean = {
+
     return updated.end != 0 || updated.status == SubmissionStatus
       .valueOf(Signed.code) || !updated.receipt.isEmpty
   }

--- a/hmda/src/main/scala/hmda/persistence/filing/FilingState.scala
+++ b/hmda/src/main/scala/hmda/persistence/filing/FilingState.scala
@@ -55,7 +55,6 @@ case class FilingState(filing: Filing = Filing(),
   }
 
   private def isSigned(updated: Submission): Boolean = {
-
     return updated.end != 0 || updated.status == SubmissionStatus
       .valueOf(Signed.code) || !updated.receipt.isEmpty
   }


### PR DESCRIPTION
Submissions were being updated even after sign. This fix ensures that if the `updated` submission already exists in the `submissions` list and has already been signed, then there is no need to update it again. 

Closes #2394 