### PR TITLE
Fix app version

### DIFF
--- a/hmda/Jenkinsfile
+++ b/hmda/Jenkinsfile
@@ -10,6 +10,7 @@ volumes: [
      def repo = checkout scm
      def gitCommit = repo.GIT_COMMIT
      def gitBranch = repo.GIT_BRANCH
+     def gitDescribe = sh(returnStdout: true, script: 'git describe --always --tags')
 
      stage('Build Scala Code and Generate Dockerfile') {
        container('sbt') {
@@ -31,16 +32,32 @@ volumes: [
                 } else {
                   env.DOCKER_TAG = env.TAG_NAME
                 }
+                //push latest or tag to Docker Hub
                 sh """
                   docker tag ${env.DOCKER_HUB_USER}/hmda-platform ${env.DOCKER_HUB_USER}/hmda-platform:${env.DOCKER_TAG}
                   docker login -u ${env.DOCKER_HUB_USER} -p ${env.DOCKER_HUB_PASSWORD} 
                   docker push ${env.DOCKER_HUB_USER}/hmda-platform:${env.DOCKER_TAG}
+                """
+                //push git describe to docker hub
+                sh """
+                  docker tag ${env.DOCKER_HUB_USER}/hmda-platform ${env.DOCKER_HUB_USER}/hmda-platform:${gitDescribe}
+                  docker login -u ${env.DOCKER_HUB_USER} -p ${env.DOCKER_HUB_PASSWORD}
+                  docker push ${env.DOCKER_HUB_USER}/hmda-platform:${gitDescribe}
+                """
+                //push latest or tag to DTR
+                sh """
                   docker tag ${env.DOCKER_HUB_USER}/hmda-platform:${env.DOCKER_TAG} ${DOCKER_REGISTRY_URL}/${env.DOCKER_HUB_USER}/hmda-platform:${env.DOCKER_TAG}
-                  docker login ${DOCKER_REGISTRY_URL} -u ${env.DTR_USER} -p ${env.DTR_PASSWORD} 
+                  docker login ${DOCKER_REGISTRY_URL} -u ${env.DTR_USER} -p ${env.DTR_PASSWORD}
                   docker push ${DOCKER_REGISTRY_URL}/${env.DOCKER_HUB_USER}/hmda-platform:${env.DOCKER_TAG}
+                """
+                //cleanup
+                sh """
                   docker images
                   docker image prune -f
                   docker images
+                """
+                //show running containers
+                sh """
                   docker ps -a
                 """
               }
@@ -53,6 +70,15 @@ volumes: [
     stage('Deploy') {
         if (env.BRANCH_NAME == 'master') {
             container('helm') {
+                //run packaging with app version and version
+                dir("kubernetes/hmda-platform") {
+                    sh """
+                        helm package --app-version=${gitDescribe} --version=${env.TAG_NAME} .
+                        tar --strip-components=1 -zxf hmda-platform-*
+                        rm -rf hmda-platform-*.tgz
+                    """
+                }
+
                 sh """
                   helm upgrade --install --force \
                   --namespace=default \

--- a/hmda/Jenkinsfile
+++ b/hmda/Jenkinsfile
@@ -13,6 +13,20 @@ volumes: [
      def gitDescribe = sh(returnStdout: true, script: 'git describe --always --tags')
      def gitTag = sh(returnStdout: true, script: "git tag --sort version:refname | tail -1").trim()
      def commitId = sh(returnStdout: true, script: 'git rev-parse HEAD')
+     def result = sh(returnStatus: true, script: "git log -1 | grep '\\[deploy pr\\]'")
+     def isDeployPR = result == 0 ? true : false
+     if (gitBranch == "master") {
+       env.DOCKER_TAG = "latest"
+     }
+     else if (isDeployPR) {
+        env.DOCKER_TAG = "${env.JOB_NAME?.split('/')[1]}${env.BUILD_NUMBER}""
+        gitTag = env.DOCKER_TAG+gitTag
+     }
+     else {
+       env.DOCKER_TAG = env.TAG_NAME
+     }
+
+     println "DOCKER_TAG: ${env.DOCKER_TAG}, gitDescribe: ${gitDescribe}, gitTag: ${gitTag}, commitId: ${commitId}, isDeployPR: ${isDeployPR}"
 
      stage('Build Scala Code and Generate Dockerfile') {
        container('sbt') {
@@ -28,12 +42,8 @@ volumes: [
             usernameVariable: 'DTR_USER', passwordVariable: 'DTR_PASSWORD']]) {
             withCredentials([string(credentialsId: 'internal-docker-registry', variable: 'DOCKER_REGISTRY_URL')]){
               sh "docker build --rm -t=${env.DOCKER_HUB_USER}/hmda-platform hmda/target/docker/stage"
-              if (env.TAG_NAME != null || gitBranch == "master") {
-                if (gitBranch == "master") {
-                  env.DOCKER_TAG = "latest"
-                } else {
-                  env.DOCKER_TAG = env.TAG_NAME
-                }
+              if (env.TAG_NAME != null || gitBranch == "master" || isDeployPR) {
+
                 sh """
                   docker tag ${env.DOCKER_HUB_USER}/hmda-platform ${env.DOCKER_HUB_USER}/hmda-platform:${env.DOCKER_TAG}
                   docker login -u ${env.DOCKER_HUB_USER} -p ${env.DOCKER_HUB_PASSWORD} 
@@ -54,7 +64,7 @@ volumes: [
     }
 
     stage('Deploy') {
-        if (env.BRANCH_NAME == 'master') {
+        if (env.BRANCH_NAME == 'master' || isDeployPR) {
             container('helm') {
                 //run packaging with app version and version
                 dir("kubernetes/hmda-platform") {
@@ -70,7 +80,7 @@ volumes: [
                   helm upgrade --install --force \
                   --namespace=default \
                   --values=kubernetes/hmda-platform/values.yaml \
-                  --set image.tag=latest \
+                  --set image.tag="${DOCKER_TAG}" \
                   --set service.name=hmda-platform-api \
                   --set image.pullPolicy=Always \
                   hmda-platform kubernetes/hmda-platform

--- a/hmda/Jenkinsfile
+++ b/hmda/Jenkinsfile
@@ -34,32 +34,16 @@ volumes: [
                 } else {
                   env.DOCKER_TAG = env.TAG_NAME
                 }
-                //push latest or tag to Docker Hub
                 sh """
                   docker tag ${env.DOCKER_HUB_USER}/hmda-platform ${env.DOCKER_HUB_USER}/hmda-platform:${env.DOCKER_TAG}
                   docker login -u ${env.DOCKER_HUB_USER} -p ${env.DOCKER_HUB_PASSWORD} 
                   docker push ${env.DOCKER_HUB_USER}/hmda-platform:${env.DOCKER_TAG}
-                """
-                //push git describe to docker hub
-                sh """
-                  docker tag ${env.DOCKER_HUB_USER}/hmda-platform ${env.DOCKER_HUB_USER}/hmda-platform:${gitDescribe}
-                  docker login -u ${env.DOCKER_HUB_USER} -p ${env.DOCKER_HUB_PASSWORD}
-                  docker push ${env.DOCKER_HUB_USER}/hmda-platform:${gitDescribe}
-                """
-                //push latest or tag to DTR
-                sh """
                   docker tag ${env.DOCKER_HUB_USER}/hmda-platform:${env.DOCKER_TAG} ${DOCKER_REGISTRY_URL}/${env.DOCKER_HUB_USER}/hmda-platform:${env.DOCKER_TAG}
                   docker login ${DOCKER_REGISTRY_URL} -u ${env.DTR_USER} -p ${env.DTR_PASSWORD}
                   docker push ${DOCKER_REGISTRY_URL}/${env.DOCKER_HUB_USER}/hmda-platform:${env.DOCKER_TAG}
-                """
-                //cleanup
-                sh """
                   docker images
                   docker image prune -f
                   docker images
-                """
-                //show running containers
-                sh """
                   docker ps -a
                 """
               }
@@ -86,7 +70,7 @@ volumes: [
                   helm upgrade --install --force \
                   --namespace=default \
                   --values=kubernetes/hmda-platform/values.yaml \
-                  --set image.tag="${gitDescribe}" \
+                  --set image.tag=latest \
                   --set service.name=hmda-platform-api \
                   --set image.pullPolicy=Always \
                   hmda-platform kubernetes/hmda-platform

--- a/hmda/Jenkinsfile
+++ b/hmda/Jenkinsfile
@@ -73,7 +73,9 @@ volumes: [
                 //run packaging with app version and version
                 dir("kubernetes/hmda-platform") {
                     sh """
-                        helm package --app-version=${gitDescribe} --version=${env.TAG_NAME} .
+                        helm init --client-only
+                        helm package --app-version="${gitDescribe}" \--version=${env.TAG_NAME} \
+                        .
                         tar --strip-components=1 -zxf hmda-platform-*
                         rm -rf hmda-platform-*.tgz
                     """

--- a/hmda/Jenkinsfile
+++ b/hmda/Jenkinsfile
@@ -71,7 +71,7 @@ volumes: [
                 dir("kubernetes/hmda-platform") {
                     sh """
                         helm init --client-only
-                        helm package --app-version="${commitId[0..7]}" --version=${gitTag} .
+                        helm package --app-version="${shortCommit}" --version=${gitTag} .
                         tar --strip-components=1 -zxf hmda-platform-*
                         rm -rf hmda-platform-*.tgz
                     """

--- a/hmda/Jenkinsfile
+++ b/hmda/Jenkinsfile
@@ -11,6 +11,8 @@ volumes: [
      def gitCommit = repo.GIT_COMMIT
      def gitBranch = repo.GIT_BRANCH
      def gitDescribe = sh(returnStdout: true, script: 'git describe --always --tags')
+     def gitTag = sh(returnStdout: true, script: "git tag --sort version:refname | tail -1").trim()
+     def commitId = sh(returnStdout: true, script: 'git rev-parse HEAD')
 
      stage('Build Scala Code and Generate Dockerfile') {
        container('sbt') {
@@ -74,8 +76,7 @@ volumes: [
                 dir("kubernetes/hmda-platform") {
                     sh """
                         helm init --client-only
-                        helm package --app-version="${gitDescribe}" \--version=${env.TAG_NAME} \
-                        .
+                        helm package --app-version="${commitId[0..7]}" --version=${gitTag} .
                         tar --strip-components=1 -zxf hmda-platform-*
                         rm -rf hmda-platform-*.tgz
                     """
@@ -85,7 +86,7 @@ volumes: [
                   helm upgrade --install --force \
                   --namespace=default \
                   --values=kubernetes/hmda-platform/values.yaml \
-                  --set image.tag=latest \
+                  --set image.tag="${gitDescribe}" \
                   --set service.name=hmda-platform-api \
                   --set image.pullPolicy=Always \
                   hmda-platform kubernetes/hmda-platform

--- a/hmda/Jenkinsfile
+++ b/hmda/Jenkinsfile
@@ -19,7 +19,7 @@ volumes: [
        env.DOCKER_TAG = "latest"
      }
      else if (isDeployPR) {
-        env.DOCKER_TAG = "${env.JOB_NAME?.split('/')[1]}${env.BUILD_NUMBER}""
+        env.DOCKER_TAG = "${env.JOB_NAME?.split('/')[1]}${env.BUILD_NUMBER}"
         gitTag = env.DOCKER_TAG+gitTag
      }
      else {

--- a/hmda/Jenkinsfile
+++ b/hmda/Jenkinsfile
@@ -13,14 +13,15 @@ volumes: [
      def gitDescribe = sh(returnStdout: true, script: 'git describe --always --tags')
      def gitTag = sh(returnStdout: true, script: "git tag --sort version:refname | tail -1").trim()
      def commitId = sh(returnStdout: true, script: 'git rev-parse HEAD')
+     def shortCommit = commitId[0..7]
      def result = sh(returnStatus: true, script: "git log -1 | grep '\\[deploy pr\\]'")
      def isDeployPR = result == 0 ? true : false
      if (gitBranch == "master") {
        env.DOCKER_TAG = "latest"
      }
      else if (isDeployPR) {
-        env.DOCKER_TAG = "${env.JOB_NAME?.split('/')[1]}${env.BUILD_NUMBER}"
-        gitTag = env.DOCKER_TAG+gitTag
+        env.DOCKER_TAG = "${env.JOB_NAME?.split('/')[1]}-${env.BUILD_NUMBER}"
+        shortCommit = env.DOCKER_TAG+shortCommit
      }
      else {
        env.DOCKER_TAG = env.TAG_NAME

--- a/hmda/src/main/scala/hmda/persistence/submission/HmdaValidationError.scala
+++ b/hmda/src/main/scala/hmda/persistence/submission/HmdaValidationError.scala
@@ -450,7 +450,7 @@ object HmdaValidationError
       header <- headerResultTest
       rest <- restResult
       res <- validateAndPersistErrors(TransmittalLar(header, rest),
-                                      "syntactical",
+        editType,
                                       validationContext)
     } yield res
   }


### PR DESCRIPTION
This PR Closes #2469 

1. Adds `APP VERSION` and `VERSION` in helm based on the current git tag and current commit. Removing the need to bump up app version and version manually in `Chart.yaml`
2. Adds support for automatically deploy a pr -- if and only if the commit message contains `[deploy pr]`
3. With these changes `helm list` will correctly show the deployed version.
4. Building master on jenkins will deploy to server using helm upgrade