### PR TITLE
set lifespan to 5 hours

### DIFF
--- a/kubernetes/keycloak/realm.json
+++ b/kubernetes/keycloak/realm.json
@@ -4,7 +4,7 @@
   "notBefore": 0,
   "revokeRefreshToken": false,
   "refreshTokenMaxReuse": 0,
-  "accessTokenLifespan": 300,
+  "accessTokenLifespan": 18000,
   "accessTokenLifespanForImplicitFlow": 900,
   "ssoSessionIdleTimeout": 1800,
   "ssoSessionMaxLifespan": 36000,


### PR DESCRIPTION
Updates the access token life span to 5 hours instead of 5 minutes.