### PR TITLE
remove spaces from edits csv header

### DIFF
--- a/hmda/src/main/scala/hmda/api/http/filing/submissions/EditsHttpApi.scala
+++ b/hmda/src/main/scala/hmda/api/http/filing/submissions/EditsHttpApi.scala
@@ -184,7 +184,7 @@ trait EditsHttpApi extends HmdaTimeDirectives {
   }
 
   private val csvHeaderSource =
-    Source.fromIterator(() => Iterator("editType, editId, ULI\n"))
+    Source.fromIterator(() => Iterator("editType,editId,ULI\n"))
 
   private def validationErrorEventStream(
       submissionId: SubmissionId): Source[String, NotUsed] = {


### PR DESCRIPTION
Closes #1566 

Although I think the best practice is to ignore them if they exist, this leaves [the check digit](https://github.com/cfpb/hmda-platform/blob/b3d6d4766d4c8dd906460ccf0cfed3d3399942f8/check-digit/src/main/scala/hmda/uli/api/http/ULIHttpApi.scala#L138) as is because I think it's more common to not have spaces in the headers.

**🙏 Please double check this! 🙏**

