### PR TITLE
WIP: Fix Trimming

### DIFF
--- a/irs-publisher/src/main/scala/hmda/publication/lar/publication/IrsPublisher.scala
+++ b/irs-publisher/src/main/scala/hmda/publication/lar/publication/IrsPublisher.scala
@@ -23,6 +23,7 @@ import hmda.model.filing.submission.SubmissionId
 import hmda.parser.filing.lar.LarCsvParser
 import hmda.publication.lar.model.{Msa, MsaMap, MsaSummary}
 import hmda.query.HmdaQuery._
+import hmda.util.streams.FlowUtils.framing
 import io.circe.generic.auto._
 
 import scala.concurrent.Future
@@ -120,6 +121,10 @@ object IrsPublisher {
               readRawData(submissionId)
                 .drop(1)
                 .map(l => l.data)
+                .map(ByteString(_))
+                .via(framing("\n"))
+                .map(_.utf8String)
+                .map(_.trim)
                 .map(s => LarCsvParser(s).getOrElse(LoanApplicationRegister()))
                 .mapAsyncUnordered(1)(lar =>
                   getCensus(lar.geography.tract)


### PR DESCRIPTION
Trim the lar data prior to validating it. There are cases when lar data ends in `|` followed by windows end of line character. This makes the number of records in a lar row as 111 as opposed to 110 and the validation fails. This trimming matches the trimming done elsewhere in HmdaValidationError. 