### PR TITLE
Add diagnostics

### DIFF
--- a/hmda/commercial-build.txt
+++ b/hmda/commercial-build.txt
@@ -27,6 +27,7 @@ libraryDependencies += Cinnamon.library.cinnamonAkkaHttp
 libraryDependencies += Cinnamon.library.cinnamonAkkaStream
 libraryDependencies += Cinnamon.library.cinnamonPrometheus
 libraryDependencies += Cinnamon.library.cinnamonPrometheusHttpServer
+libraryDependencies += "com.lightbend.akka" %% "akka-diagnostics" % "1.1.7"
 
 javaOptions in Universal ++= Seq(
   "-J-XX:+UnlockExperimentalVMOptions",

--- a/hmda/src/main/resources/application-kubernetes.conf
+++ b/hmda/src/main/resources/application-kubernetes.conf
@@ -4,6 +4,16 @@ include "cors.conf"
 
 akka {
 
+
+  diagnostics {
+    starvation-detector {
+      check-interval = 1s
+      initial-delay = 30s
+      max-delay-warning-threshold = 100 ms
+      warning-interval = 10 seconds
+    }
+  }
+
   loglevel = INFO
 
   http.server.default-host-header = "cfpb.gov"
@@ -45,9 +55,9 @@ akka {
       }
 
       #contact-point {
-        # currently this port HAS TO be the same as the `akka.management.http.port`
-        # it would not have to be once we implement the SRV record watching, since then we could potentially
-        # get the ports from the DNS records.
+      # currently this port HAS TO be the same as the `akka.management.http.port`
+      # it would not have to be once we implement the SRV record watching, since then we could potentially
+      # get the ports from the DNS records.
       #  fallback-port = 8558
       #}
     }

--- a/hmda/src/main/resources/application.conf
+++ b/hmda/src/main/resources/application.conf
@@ -5,6 +5,15 @@ include "edits.conf"
 
 akka {
 
+  diagnostics {
+    starvation-detector {
+      check-interval = 1s
+      initial-delay = 30s
+      max-delay-warning-threshold = 100 ms
+      warning-interval = 10 seconds
+    }
+  }
+
   blocking-quality-dispatcher {
     type = Dispatcher
     executor = "thread-pool-executor"
@@ -97,7 +106,7 @@ cinnamon.akka {
     }
   }
 }
-  // expose the HTTP metrics server that Prometheus will scrape to gather metrics
+// expose the HTTP metrics server that Prometheus will scrape to gather metrics
 cinnamon.prometheus {
   http-server {
     port = 9009
@@ -107,5 +116,4 @@ cinnamon.prometheus {
   // runs on port 9009
   exporters += http-server
 }
-
 


### PR DESCRIPTION
Enable Akka Diagnostics to detect thread starvation warnings. 

Closes #2620 