### PR TITLE
remove 'test' from the create an account form heading

### DIFF
--- a/kubernetes/keycloak/theme-provider/themes/hmda/login/register.ftl
+++ b/kubernetes/keycloak/theme-provider/themes/hmda/login/register.ftl
@@ -9,7 +9,7 @@
       <fieldset>
         <input type="text" readonly value="this is not a login form" style="display: none;">
         <input type="password" readonly value="this is not a login form" style="display: none;">
-        <legend class="usa-drop_text">Create a test account</legend>
+        <legend class="usa-drop_text">Create an account</legend>
         <span>or <a href="${url.loginUrl}">go back to login</a></span>
         <#if !realm.registrationEmailAsUsername>
           <label for="username" class="${properties.kcLabelClass!}">${msg("username")}</label>


### PR DESCRIPTION
Closes #2605 

Draft because we can wait until after the season to apply this **but if we NEED to do a Keycloak deployment at some point** we can add this in.