### PR TITLE
Empty modified lar fix

### DIFF
--- a/common/src/main/scala/hmda/parser/filing/lar/LarCsvParser.scala
+++ b/common/src/main/scala/hmda/parser/filing/lar/LarCsvParser.scala
@@ -5,9 +5,9 @@ import hmda.parser.ParserErrorModel.ParserValidationError
 import hmda.parser.filing.lar.LarFormatValidator.validateLar
 
 object LarCsvParser {
-  def apply(s: String)
+  def apply(s: String, fromCassandra: Boolean = false)
     : Either[List[ParserValidationError], LoanApplicationRegister] = {
     val values = s.trim.split('|').map(_.trim).toList
-    validateLar(values, s).leftMap(xs => xs.toList).toEither
+    validateLar(values, s, fromCassandra).leftMap(xs => xs.toList).toEither
   }
 }

--- a/common/src/main/scala/hmda/parser/filing/lar/LarFormatValidator.scala
+++ b/common/src/main/scala/hmda/parser/filing/lar/LarFormatValidator.scala
@@ -15,10 +15,12 @@ sealed trait LarFormatValidator extends LarParser {
 
   val numberOfFields = config.getInt("hmda.filing.lar.length")
 
-  def validateLar(values: Seq[String], rawLine: String = "")
+  def validateLar(values: Seq[String],
+                  rawLine: String = "",
+                  fromCassandra: Boolean = false)
     : LarParserValidationResult[LoanApplicationRegister] = {
 
-    if (values.lengthCompare(numberOfFields) != 0 || rawLine.trim.endsWith("|")) {
+    if (values.lengthCompare(numberOfFields) != 0 || (rawLine.trim.endsWith("|") && (!fromCassandra))) {
       IncorrectNumberOfFields(values.length, numberOfFields).invalidNel
     } else {
       val id = values.headOption.getOrElse("")

--- a/modified-lar/src/main/scala/hmda/publication/lar/parser/ModifiedLarCsvParser.scala
+++ b/modified-lar/src/main/scala/hmda/publication/lar/parser/ModifiedLarCsvParser.scala
@@ -9,7 +9,7 @@ import hmda.parser.filing.lar.LarCsvParser
 object ModifiedLarCsvParser {
 
   def apply(s: String): ModifiedLoanApplicationRegister = {
-    convert(LarCsvParser(s).getOrElse(LoanApplicationRegister()))
+    convert(LarCsvParser(s, true).getOrElse(LoanApplicationRegister()))
   }
 
   private def convert(


### PR DESCRIPTION
This PR fixes some modified lar issues. It will only flag lines ending in `|` when we're not parsing the data coming out of cassandra. 