### PR TITLE
Optimize msaMd endpoint

### DIFF
--- a/common/src/main/scala/hmda/query/repository/ModifiedLarRepository.scala
+++ b/common/src/main/scala/hmda/query/repository/ModifiedLarRepository.scala
@@ -1,6 +1,9 @@
 package hmda.query.repository
 
-import hmda.model.modifiedlar.{EnrichedModifiedLoanApplicationRegister, ModifiedLoanApplicationRegister}
+import hmda.model.modifiedlar.{
+  EnrichedModifiedLoanApplicationRegister,
+  ModifiedLoanApplicationRegister
+}
 import slick.basic.DatabaseConfig
 import slick.jdbc.JdbcProfile
 
@@ -21,7 +24,7 @@ class ModifiedLarRepository(tableName: String,
   def msaMds(lei: String, filingYear: Int): Future[Vector[(String, String)]] =
     db.run {
       sql"""SELECT DISTINCT msa_md, msa_md_name
-                         FROM modifiedlar2018 WHERE UPPER(lei) = ${lei.toUpperCase} AND filing_year = ${filingYear}"""
+                         FROM modifiedlar2018 WHERE lei = ${lei.toUpperCase} AND filing_year = ${filingYear}"""
         .as[(String, String)]
     }
 

--- a/modified-lar/src/main/resources/modified-lar.sql
+++ b/modified-lar/src/main/resources/modified-lar.sql
@@ -113,3 +113,5 @@ ALTER TABLE public.modifiedlar2018
 ALTER TABLE  public.modifiedlar2018
   ADD COLUMN race_categorization character varying,
   ADD COLUMN sex_categorization character varying;
+
+CREATE INDEX ON modifiedlar2018 (lei);


### PR DESCRIPTION
Closes #2697 

This PR removes `UPPER`. Since we're adding `UPPER` while inserting records, there is no need to do them on select as well. The index on the `modifiedlar2018` table has been created on `lei`.

Prior to creating the index the `msaMds` endpoint took 6 seconds, after the index it takes less than a second.