### PR TITLE
Fix ethnicity logic for Hispanic or Latino

### DIFF
--- a/modified-lar/src/main/scala/hmda/publication/lar/parser/EthnicityCategorization.scala
+++ b/modified-lar/src/main/scala/hmda/publication/lar/parser/EthnicityCategorization.scala
@@ -9,22 +9,22 @@ object EthnicityCategorization {
     val ethnicity = lar.applicant.ethnicity
     val coEthnicity = lar.coApplicant.ethnicity
     val ethnicityFields = Array(ethnicity.ethnicity1,
-                                ethnicity.ethnicity2,
-                                ethnicity.ethnicity3,
-                                ethnicity.ethnicity4,
-                                ethnicity.ethnicity5)
+      ethnicity.ethnicity2,
+      ethnicity.ethnicity3,
+      ethnicity.ethnicity4,
+      ethnicity.ethnicity5)
 
     val coethnicityFields = Array(coEthnicity.ethnicity1,
-                                  coEthnicity.ethnicity2,
-                                  coEthnicity.ethnicity3,
-                                  coEthnicity.ethnicity4,
-                                  coEthnicity.ethnicity5)
+      coEthnicity.ethnicity2,
+      coEthnicity.ethnicity3,
+      coEthnicity.ethnicity4,
+      coEthnicity.ethnicity5)
 
     val hispanicEnums = Array(HispanicOrLatino,
-                              Mexican,
-                              PuertoRican,
-                              Cuban,
-                              OtherHispanicOrLatino)
+      Mexican,
+      PuertoRican,
+      Cuban,
+      OtherHispanicOrLatino)
 
     val coapplicantNoHispanicEnums = (!hispanicEnums.contains(
       coEthnicity.ethnicity1) && !hispanicEnums.contains(coEthnicity.ethnicity2) && !hispanicEnums
@@ -47,7 +47,7 @@ object EthnicityCategorization {
       .reduce(_ && _)
 
     val coapplicantNotHispanic = ethnicityFields
-      .map(_ == NotHispanicOrLatino)
+      .map(_ != NotHispanicOrLatino)
       .reduce(_ && _)
 
     if (ethnicity.otherHispanicOrLatino != "" && ethnicity.ethnicity1 == EmptyEthnicityValue)
@@ -70,7 +70,6 @@ object EthnicityCategorization {
       "Joint"
     else if (coethnicityFields.contains(NotHispanicOrLatino) && coApplicantOnlyHispanic)
       "Joint"
-
     else
       "Ethnicity Not Available"
   }


### PR DESCRIPTION
Fixes #2723 

It addresses this particular logic https://github.com/cfpb/hmda-platform/wiki/Ethnicity-Categorization---V2-2018#hispanic-or-latino

> Co-Applicant Ethnicity: 1, 2, 3 4 or 5 **does not equal** Not Hispanic or Latino (Code 2)