### PR TITLE
Fix V619_2 For 2019

### DIFF
--- a/data-browser/Jenkinsfile
+++ b/data-browser/Jenkinsfile
@@ -28,7 +28,7 @@ volumes: [
 
     stage('Build Scala Code and Generate Dockerfile') {
       container('sbt') {
-        sh "sbt -batch data-browser/docker:stage"
+        sh "env JAVA_OPTS=\"-Xms256m -Xmx4096m -Xss8m\" sbt -batch data-browser/docker:stage"
       }
     }
 

--- a/hmda/src/main/scala/hmda/validation/engine/2018/LarEngine2018.scala
+++ b/hmda/src/main/scala/hmda/validation/engine/2018/LarEngine2018.scala
@@ -40,7 +40,7 @@ private[engine] object LarEngine2018
     V617,
     V618,
     V619_1,
-    V619_2,
+    eighteen.V619_2,
     V619_3,
     V620,
     V621,

--- a/hmda/src/main/scala/hmda/validation/engine/2019/LarEngine2019.scala
+++ b/hmda/src/main/scala/hmda/validation/engine/2019/LarEngine2019.scala
@@ -40,7 +40,7 @@ private[engine] object LarEngine2019
     V617,
     V618,
     V619_1,
-    V619_2,
+    nineteen.V619_2,
     V619_3,
     V620,
     V621,

--- a/hmda/src/main/scala/hmda/validation/rules/lar/validity/2018/V619_2.scala
+++ b/hmda/src/main/scala/hmda/validation/rules/lar/validity/2018/V619_2.scala
@@ -1,0 +1,22 @@
+package hmda.validation.rules.lar.validity.eighteen
+
+import com.typesafe.config.ConfigFactory
+import hmda.model.filing.lar.LoanApplicationRegister
+import hmda.validation.dsl.PredicateCommon._
+import hmda.validation.dsl.PredicateSyntax._
+import hmda.validation.dsl.ValidationResult
+import hmda.validation.rules.EditCheck
+
+object V619_2 extends EditCheck[LoanApplicationRegister] {
+  override def name: String = "V619-2"
+
+  override def parent: String = "V619"
+
+  override def apply(lar: LoanApplicationRegister): ValidationResult = {
+    val config = ConfigFactory.load()
+    val year = "2018"
+
+    lar.action.actionTakenDate.toString.slice(0, 4) is equalTo(year)
+  }
+
+}

--- a/hmda/src/main/scala/hmda/validation/rules/lar/validity/2019/V619_2.scala
+++ b/hmda/src/main/scala/hmda/validation/rules/lar/validity/2019/V619_2.scala
@@ -1,4 +1,4 @@
-package hmda.validation.rules.lar.validity
+package hmda.validation.rules.lar.validity.nineteen
 
 import com.typesafe.config.ConfigFactory
 import hmda.model.filing.lar.LoanApplicationRegister
@@ -14,7 +14,7 @@ object V619_2 extends EditCheck[LoanApplicationRegister] {
 
   override def apply(lar: LoanApplicationRegister): ValidationResult = {
     val config = ConfigFactory.load()
-    val year = config.getInt("edits.V619.year").toString
+    val year = "2019"
 
     lar.action.actionTakenDate.toString.slice(0, 4) is equalTo(year)
   }

--- a/hmda/src/test/scala/hmda/api/http/public/LarValidationHttpApiSpec.scala
+++ b/hmda/src/test/scala/hmda/api/http/public/LarValidationHttpApiSpec.scala
@@ -51,6 +51,9 @@ class LarValidationHttpApiSpec
   val validLar =
     "2|95GVQQ61RS6CWQF0SZD9|95GVQQ61RS6CWQF0SZD9F4VRXNN1OCVXHP1JURF9ZJS92|20180914|1|1|2|1|1|101000|1|20180916|1234 Hocus Potato Way|Tatertown|RI|29801|36085|36085011402|3||||||11||14|12|13||2|2|6||||||||8||||||||3|4|2|2|1|1|85|104|500|4|1|3|1|746|8888|7||9||10|||||NA|8636|8597|2362|9120|18.18|29|NA|65|329|34|2|1|2|1|590943|3|5|24|NA|1|2|12345678|6||||||17||||||2|2|2"
 
+  val validLar2019 =
+    "2|95GVQQ61RS6CWQF0SZD9|95GVQQ61RS6CWQF0SZD9F4VRXNN1OCVXHP1JURF9ZJS92|20190914|1|1|2|1|1|101000|1|20190916|1234 Hocus Potato Way|Tatertown|RI|29801|36085|36085011402|3||||||11||14|12|13||2|2|6||||||||8||||||||3|4|2|2|1|1|85|104|500|4|1|3|1|746|8888|7||9||10|||||NA|8636|8597|2362|9120|18.18|29|NA|65|329|34|2|1|2|1|590943|3|5|24|NA|1|2|12345678|6||||||17||||||2|2|2"
+
   val invalidLar =
     "2|95GVQQ61RS6CWQF0SZD90|95GVQQ61RS6CWQF0SZD9F4VRXNN1OCVXHP1JURF9ZJS92|20180914|1|1|2|1|1|101000|1|20180916|1234 Hocus Potato Way|Tatertown|XX|29801|36085|36085011402|3||||||11||14|12|13||2|2|6||||||||8||||||||3|4|2|2|1|1|85|104|500|4|1|3|1|746|8888|7||9||10|||||NA|8636|8597|2362|9120|18.18|29|NA|65|329|34|2|1|2|1|590943|3|5|24|NA|1|2|12345678|6||||||17||||||2|2|2"
 
@@ -92,9 +95,9 @@ class LarValidationHttpApiSpec
     }
 
     "validate a lar" in {
-      Post("/lar/validate/2019", LarValidateRequest(validLar)) ~> larRoutes ~> check {
+      Post("/lar/validate/2019", LarValidateRequest(validLar2019)) ~> larRoutes ~> check {
         status mustBe StatusCodes.OK
-        responseAs[LoanApplicationRegister] mustBe LarCsvParser(validLar)
+        responseAs[LoanApplicationRegister] mustBe LarCsvParser(validLar2019)
           .getOrElse(LoanApplicationRegister())
       }
     }
@@ -103,7 +106,7 @@ class LarValidationHttpApiSpec
       Post("/lar/validate/2019", LarValidateRequest(invalidLar)) ~> larRoutes ~> check {
         status mustBe StatusCodes.OK
         responseAs[SingleValidationErrorResult] mustBe SingleValidationErrorResult(
-          validity = ValidationErrorSummary(Seq("V600", "V623")))
+          validity = ValidationErrorSummary(Seq("V600", "V619-2", "V623")))
       }
     }
   }

--- a/hmda/src/test/scala/hmda/validation/rules/lar/validity/2018/V619_2Spec.scala
+++ b/hmda/src/test/scala/hmda/validation/rules/lar/validity/2018/V619_2Spec.scala
@@ -1,6 +1,5 @@
-package hmda.validation.rules.lar.validity
+package hmda.validation.rules.lar.validity.eighteen
 
-import com.typesafe.config.ConfigFactory
 import hmda.model.filing.lar.LarGenerators._
 import hmda.model.filing.lar.LoanApplicationRegister
 import hmda.validation.rules.EditCheck
@@ -11,8 +10,7 @@ class V619_2Spec extends LarEditCheckSpec {
 
   property("Action taken date must be in the current year") {
     forAll(larGen) { lar =>
-      val config = ConfigFactory.load()
-      val year = config.getInt("edits.V619.year")
+      val year = 2018
       val badActionYear = (year - 1) * 1000 + 110
       val goodActionYear = year * 10000 + 101
 

--- a/hmda/src/test/scala/hmda/validation/rules/lar/validity/2019/V619_2Spec.scala
+++ b/hmda/src/test/scala/hmda/validation/rules/lar/validity/2019/V619_2Spec.scala
@@ -1,0 +1,27 @@
+package hmda.validation.rules.lar.validity.nineteen
+
+import hmda.model.filing.lar.LarGenerators._
+import hmda.model.filing.lar.LoanApplicationRegister
+import hmda.validation.rules.EditCheck
+import hmda.validation.rules.lar.LarEditCheckSpec
+
+class V619_2Spec extends LarEditCheckSpec {
+  override def check: EditCheck[LoanApplicationRegister] = V619_2
+
+  property("Action taken date must be in the current year") {
+    forAll(larGen) { lar =>
+      val year = 2019
+      val badActionYear = (year - 1) * 1000 + 110
+      val goodActionYear = year * 10000 + 101
+
+      val badActionDate1 =
+        lar.action.copy(actionTakenDate = 0)
+      val badActionDate2 = lar.action.copy(actionTakenDate = badActionYear)
+      lar.copy(action = badActionDate1).mustFail
+      lar.copy(action = badActionDate2).mustFail
+
+      val goodAction = lar.action.copy(actionTakenDate = goodActionYear)
+      lar.copy(action = goodAction).mustPass
+    }
+  }
+}

--- a/kubernetes/institutions-api/templates/service.yaml
+++ b/kubernetes/institutions-api/templates/service.yaml
@@ -49,4 +49,4 @@ spec:
     port: {{ .Values.ambassador.port }}
     targetPort: {{ .Values.ambassador.port }}
   selector:
-service: {{ .Values.ambassador.name }}
+    service: {{ .Values.ambassador.name }}

--- a/modified-lar/src/main/resources/application.conf
+++ b/modified-lar/src/main/resources/application.conf
@@ -66,6 +66,7 @@ hmda {
     modified {
       parallelism = 1
       year = 2018
+      year = ${?MODIFIED_LAR_YEAR}
       generateS3Files = false
       generateS3Files = ${?IS_GENERATE_MLAR_S3_FIES}
       creteDispositionRecord = false

--- a/modified-lar/src/main/scala/hmda/publication/lar/publication/ModifiedLarPublisher.scala
+++ b/modified-lar/src/main/scala/hmda/publication/lar/publication/ModifiedLarPublisher.scala
@@ -45,7 +45,7 @@ object ModifiedLarPublisher {
 
   val config = ConfigFactory.load()
 
-  val filingYear = config.getInt("hmda.filing.year") // resides in common
+  val filingYear = config.getInt("hmda.lar.modified.year")
   val accessKeyId = config.getString("aws.access-key-id")
   val secretAccess = config.getString("aws.secret-access-key ")
   val region = config.getString("aws.region")


### PR DESCRIPTION
Divides V619_2 into 2 versions, one for 2018 and one for 2019.

Also fixes a Jenkins, helm, and modified-lar issue.

Closes #2811 
Closes #2825 
Closes #2826 
Closes #2827 