### PR TITLE
Additional logging for the ratespread API json endpoint

### DIFF
--- a/ratespread-calculator/src/main/scala/hmda/calculator/api/http/RateSpreadAPIRoutes.scala
+++ b/ratespread-calculator/src/main/scala/hmda/calculator/api/http/RateSpreadAPIRoutes.scala
@@ -54,6 +54,8 @@ trait RateSpreadAPIRoutes extends HmdaTimeDirectives {
                     "API Rate Spread Request: " + rateSpreadBody.toString + "\n" + " RateSpread Result: " + response.rateSpread)
                   complete(ToResponseMarshallable(response))
                 case Failure(error) =>
+                  log.info(
+                    "API Rate Spread Request Failed: " + rateSpreadBody.toString + "\n" + " Error Message: " + error.toString)
                   failedResponse(StatusCodes.BadRequest, uri, error)
               }
             }


### PR DESCRIPTION
closes #3088 