### PR TITLE
Send submission receipt number to email kafka topic

### DIFF
--- a/common/src/main/scala/hmda/serialization/submission/SubmissionProcessingCommandsProtobufConverter.scala
+++ b/common/src/main/scala/hmda/serialization/submission/SubmissionProcessingCommandsProtobufConverter.scala
@@ -282,7 +282,8 @@ object SubmissionProcessingCommandsProtobufConverter {
   def signSubmissionToProtobuf(cmd: SignSubmission, refResolver: ActorRefResolver): SignSubmissionMessage =
     SignSubmissionMessage(
       submissionIdToProtobuf(cmd.submissionId),
-      refResolver.toSerializationFormat(cmd.replyTo)
+      refResolver.toSerializationFormat(cmd.replyTo),
+      cmd.email
     )
 
   def signSubmissionFromProtobuf(msg: SignSubmissionMessage, refResolver: ActorRefResolver): SignSubmission =

--- a/email-service/src/main/scala/hmda/publication/lar/streams/Stream.scala
+++ b/email-service/src/main/scala/hmda/publication/lar/streams/Stream.scala
@@ -18,8 +18,10 @@ import org.apache.kafka.common.serialization.StringDeserializer
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import org.slf4j.LoggerFactory
 
 object Stream {
+  val log = LoggerFactory.getLogger("hmda")
   def pullEmails(system: ActorSystem, bootstrapServers: String): SourceWithContext[
     CommittableMessage[String, String],
     CommittableOffset,
@@ -63,6 +65,8 @@ object Stream {
     val rawSubmissionId = record.key()
     val toAddress       = record.value()
     val sId             = submissionId(rawSubmissionId)
+
+    log.info(s"Working on ${rawSubmissionId} and ${toAddress}")
 
     val process = for {
       optPresent <- submissionStatusRepo.findBySubmissionId(sId)

--- a/hmda/src/main/scala/hmda/persistence/submission/HmdaValidationError.scala
+++ b/hmda/src/main/scala/hmda/persistence/submission/HmdaValidationError.scala
@@ -302,7 +302,9 @@ object HmdaValidationError
                 Signed,
                 log
               )
-              publishSignEvent(submissionId, email).map(signed => log.info(s"Published signed event for $submissionId"))
+              publishSignEvent(submissionId, email, signed.timestamp).map(signed => log.info(s"Published signed event for $submissionId. " +
+                s"${signTopic} (key: ${submissionId.lei}, value: ${submissionId.toString}. " +
+                s"${emailTopic} (key: ${submissionId.toString}, value: ${email})"))
               setHmdaFilerFlag(submissionId.lei, submissionId.period, sharding)
               replyTo ! signed
             }
@@ -687,10 +689,11 @@ object HmdaValidationError
 
   private def publishSignEvent(
     submissionId: SubmissionId,
-    email: String
+    email: String,
+    signedTimestamp: Long
   )(implicit system: ActorSystem, materializer: ActorMaterializer): Future[Done] = {
     produceRecord(signTopic, submissionId.lei, submissionId.toString)
-    produceRecord(emailTopic, submissionId.toString, email)
+    produceRecord(emailTopic, s"${submissionId.toString}-${signedTimestamp}", email)
   }
 
   private def setHmdaFilerFlag[as: AS, mat: MAT, ec: EC](institutionID: String, period: String, sharding: ClusterSharding): Unit = {


### PR DESCRIPTION
Closes #3252 

This PR:
1 - Fixes a protobuf bug in email-service
2 - Sends the sign receipt number (`<lei>-<year>-<sequencenumber>-<timestamp>`) to the email kafka topic as opposed to just the submission id (`<lei>-<year>-<sequencenumber>-<timestamp>`)