### PR TITLE
modify LEI endpoint for data-browser

### DIFF
--- a/data-browser/src/main/scala/hmda/dataBrowser/api/DataBrowserDirectives.scala
+++ b/data-browser/src/main/scala/hmda/dataBrowser/api/DataBrowserDirectives.scala
@@ -392,6 +392,16 @@ trait DataBrowserDirectives {
       }
     }
 
+  def extractYearsMsaMdsStatesAndCounties(innerRoute: List[QueryField] => Route): Route =
+    (extractYears & extractMsaMds & extractStates & extractCounties) { (years, msaMds, states, counties) =>
+      if (msaMds.nonEmpty && states.nonEmpty && counties.nonEmpty)
+        complete(BadRequest, OnlyStatesOrMsaMdsOrCountiesOrLEIs())
+      else if (years.nonEmpty)
+        innerRoute(List(years, msaMds, states, counties).flatten)
+      else
+        complete(BadRequest, ProvideYearAndStatesOrMsaMdsOrCounties())
+    }
+
   def extractYearsAndMsaAndStateAndCountyAndLEIBrowserFields(innerRoute: List[QueryField] => Route): Route =
     (extractYears & extractMsaMds & extractStates & extractCounties & extractLEIs) { (years, msaMds, states, counties, leis) =>
       if ((msaMds.nonEmpty && states.nonEmpty && counties.nonEmpty && leis.nonEmpty) || (msaMds.isEmpty && states.isEmpty && counties.isEmpty && leis.isEmpty))

--- a/data-browser/src/main/scala/hmda/dataBrowser/api/DataBrowserHttpApi.scala
+++ b/data-browser/src/main/scala/hmda/dataBrowser/api/DataBrowserHttpApi.scala
@@ -180,15 +180,20 @@ trait DataBrowserHttpApi extends Settings {
               }
             }
           } ~
-          // GET /view/filers/<year>
-          (path("filers" / IntNumber) & get) { year =>
-            onComplete(query.fetchFilers(year).runToFuture) {
-              case Failure(ex) =>
-                log.error(ex, "Failed to obtain filer information")
-                complete(StatusCodes.InternalServerError)
+          // GET /view/filers?years=2018&states=<csv-states> -- GET LEIs for specific states
+          // GET /view/filers?years=2018&msamds=<csv-msamds> -- GET LEIs for specific msamds
+          // GET /view/filers?years=2018&counties=<csv-counties> -- GET LEIs for specific counties
+          // GET /view/filers?years=2018 -- GET all LEIs
+          (path("filers") & get) {
+            extractYearsMsaMdsStatesAndCounties { filerFields =>
+              onComplete(query.fetchFilers(filerFields).runToFuture) {
+                case Failure(ex) =>
+                  log.error(ex, "Failed to obtain filer information")
+                  complete(StatusCodes.InternalServerError)
 
-              case Success(filerResponse) =>
-                complete(StatusCodes.OK, filerResponse)
+                case Success(filerResponse) =>
+                  complete(StatusCodes.OK, filerResponse)
+              }
             }
           }
       } ~

--- a/data-browser/src/main/scala/hmda/dataBrowser/models/ErrorResponse.scala
+++ b/data-browser/src/main/scala/hmda/dataBrowser/models/ErrorResponse.scala
@@ -40,9 +40,20 @@ final case class OnlyStatesOrMsaMdsOrCountiesOrLEIs(
                                                message: String = "Provide only states or msamds or counties or leis but not all"
                                              ) extends ErrorResponse
 
+final case class OnlyStatesOrMsaMdsOrCounties(
+                                                     errorType: String = "provide-only-msamds-or-states-or-counties-or-leis",
+                                                     message: String = "Provide only states or msamds or counties but not all"
+                                                   ) extends ErrorResponse
+
+
 final case class ProvideYearAndStatesOrMsaMds(
                                                errorType: String = "provide-atleast-msamds-or-states",
                                                message: String = "Provide year and either states or msamds (but not both) "
+                                             ) extends ErrorResponse
+
+final case class ProvideYearAndStatesOrMsaMdsOrCounties(
+                                               errorType: String = "provide-atleast-msamds-or-states",
+                                               message: String = "Provide year and either states or msamds or counties (but not all) "
                                              ) extends ErrorResponse
 
 final case class NoMandatoryFieldsInCount(

--- a/data-browser/src/main/scala/hmda/dataBrowser/models/FilerInformation.scala
+++ b/data-browser/src/main/scala/hmda/dataBrowser/models/FilerInformation.scala
@@ -3,11 +3,11 @@ package hmda.dataBrowser.models
 import io.circe.Codec
 import slick.jdbc.GetResult
 
-case class FilerInformation(lei: String, respondentName: String, year: Int)
+case class FilerInformation(lei: String, respondentName: String, count: Int ,year: Int)
 
 object FilerInformation {
-  implicit val getResult: GetResult[FilerInformation] = GetResult(r => FilerInformation(r.<<, r.<<, r.<<))
+  implicit val getResult: GetResult[FilerInformation] = GetResult(r => FilerInformation(r.<<, r.<<, r.<<, r.<<))
 
   implicit val codec: Codec[FilerInformation] =
-    Codec.forProduct3("lei", "name", "period")(FilerInformation.apply)(f => (f.lei, f.respondentName, f.year))
+    Codec.forProduct4("lei", "name", "count","period")(FilerInformation.apply)(f => (f.lei, f.respondentName, f.count, f.year))
 }

--- a/data-browser/src/main/scala/hmda/dataBrowser/repositories/ModifiedLarAggregateCache.scala
+++ b/data-browser/src/main/scala/hmda/dataBrowser/repositories/ModifiedLarAggregateCache.scala
@@ -6,11 +6,11 @@ import monix.eval.Task
 trait Cache {
   def find(queryFields: List[QueryField]): Task[Option[Statistic]]
 
-  def find(year: Int): Task[Option[FilerInstitutionResponse]]
+  def findFilers(queryFields: List[QueryField]): Task[Option[FilerInstitutionResponse]]
 
   def update(queryFields: List[QueryField], statistic: Statistic): Task[Statistic]
 
-  def update(year: Int, filerInstitutionResponse: FilerInstitutionResponse): Task[FilerInstitutionResponse]
+  def updateFilers(queryFields: List[QueryField], filerInstitutionResponse: FilerInstitutionResponse): Task[FilerInstitutionResponse]
 
   def invalidate(queryField: List[QueryField]): Task[Unit]
 }

--- a/data-browser/src/main/scala/hmda/dataBrowser/repositories/ModifiedLarRepository.scala
+++ b/data-browser/src/main/scala/hmda/dataBrowser/repositories/ModifiedLarRepository.scala
@@ -8,5 +8,5 @@ import monix.eval.Task
 trait ModifiedLarRepository {
   def find(browserFields: List[QueryField]): Source[ModifiedLarEntity, NotUsed]
   def findAndAggregate(browserFields: List[QueryField]): Task[Statistic]
-  def filers(year: Int): Task[Seq[FilerInformation]]
+  def findFilers(leiFields: List[QueryField]): Task[Seq[FilerInformation]]
 }

--- a/data-browser/src/main/scala/hmda/dataBrowser/repositories/PostgresModifiedLarRepository.scala
+++ b/data-browser/src/main/scala/hmda/dataBrowser/repositories/PostgresModifiedLarRepository.scala
@@ -178,9 +178,9 @@ class PostgresModifiedLarRepository(tableName: String, config: DatabaseConfig[Jd
     }
     val query =
       sql"""
-        SELECT a.lei, b.respondent_name, '#${year.getOrElse("2018")}'
+        SELECT a.lei, b.respondent_name, a.lar_count, '#${year.getOrElse("2018")}'
         from (
-          SELECT lei
+          SELECT lei, count(*) as lar_count
           FROM #${tableName}
           #$filterCriteria
           GROUP BY lei

--- a/data-browser/src/main/scala/hmda/dataBrowser/repositories/PostgresModifiedLarRepository.scala
+++ b/data-browser/src/main/scala/hmda/dataBrowser/repositories/PostgresModifiedLarRepository.scala
@@ -131,6 +131,7 @@ class PostgresModifiedLarRepository(tableName: String, config: DatabaseConfig[Jd
     else {
       val secondaries =
         remainingExpressions
+          //do not include year in the WHERE clause because all entries in the table (modifiedlar2018_snapshot) have filing_year = 2018
           .filterNot(_ == "filing_year IN ('2018')")
           .map(expr => s"AND $expr")
           .mkString(sep = " ")
@@ -163,17 +164,25 @@ class PostgresModifiedLarRepository(tableName: String, config: DatabaseConfig[Jd
     Source.fromPublisher(publisher)
   }
 
-  override def filers(year: Int): Task[Seq[FilerInformation]] = {
+  override def findFilers(filerFields: List[QueryField]): Task[Seq[FilerInformation]] = {
+    val year = filerFields.find(_.name == "year").map(_.values.head.toInt)
     val institutionsTableName = year match { //will be needed when databrowser has to support multiple years
-      case 2018 => "institutions2018"
+      case Some(2018) => "institutions2018"
       case _ => "institutions2018"
+    }
+    //do not include year in the WHERE clause because all entries in the table (modifiedlar2018_snapshot) have filing_year = 2018
+    val queries = filerFields.filterNot(_.name == "year").map(field => in(field.dbName, field.values))
+    val filterCriteria = queries match {
+      case Nil          => ""
+      case head :: tail => whereAndOpt(head, tail: _*)
     }
     val query =
       sql"""
-        SELECT a.lei, b.respondent_name, '#${year}'
+        SELECT a.lei, b.respondent_name, '#${year.getOrElse("2018")}'
         from (
           SELECT lei
           FROM #${tableName}
+          #$filterCriteria
           GROUP BY lei
         ) a
           JOIN #${institutionsTableName} b ON a.lei = b.lei

--- a/data-browser/src/main/scala/hmda/dataBrowser/repositories/RedisModifiedLarAggregateCache.scala
+++ b/data-browser/src/main/scala/hmda/dataBrowser/repositories/RedisModifiedLarAggregateCache.scala
@@ -51,16 +51,19 @@ class RedisCache(redisClient: Task[RedisAsyncCommands[String, String]], timeToLi
     findAndParse[Statistic](redisKey)
   }
 
-  override def find(year: Int): Task[Option[FilerInstitutionResponse]] =
-    findAndParse[FilerInstitutionResponse](year.toString)
+  override def findFilers(filerFields: List[QueryField]): Task[Option[FilerInstitutionResponse]] =
+    findAndParse[FilerInstitutionResponse]("year".toString)
 
   override def update(queryFields: List[QueryField], statistic: Statistic): Task[Statistic] = {
     val redisKey = key(queryFields)
     updateAndSetTTL(redisKey, statistic)
   }
 
-  override def update(year: Int, filerInstitutionResponse: FilerInstitutionResponse): Task[FilerInstitutionResponse] =
-    updateAndSetTTL(year.toString, filerInstitutionResponse)
+  override def updateFilers(queryFields: List[QueryField], filerInstitutionResponse: FilerInstitutionResponse): Task[FilerInstitutionResponse] = {
+    val redisKey = key(queryFields)
+    updateAndSetTTL(redisKey.toString, filerInstitutionResponse)
+  }
+
 
   override def invalidate(queryFields: List[QueryField]): Task[Unit] = {
     val redisKey = key(queryFields)

--- a/data-browser/src/main/scala/hmda/dataBrowser/services/DataBrowserQueryService.scala
+++ b/data-browser/src/main/scala/hmda/dataBrowser/services/DataBrowserQueryService.scala
@@ -81,10 +81,12 @@ class DataBrowserQueryService(repo: ModifiedLarRepository, cache: Cache) extends
     }
   }
 
-  override def fetchFilers(year: Int): Task[FilerInstitutionResponse] =
+  override def fetchFilers(fields: List[QueryField]): Task[FilerInstitutionResponse] = {
     cacheResult(
-      cacheLookup = cache.find(year),
-      onMiss = repo.filers(year).map(FilerInstitutionResponse(_)),
-      cacheUpdate = cache.update(year, _: FilerInstitutionResponse)
+      cacheLookup = cache.findFilers(fields),
+      onMiss = repo.findFilers(fields).map(FilerInstitutionResponse(_)),
+      cacheUpdate = cache.updateFilers(fields, _: FilerInstitutionResponse)
     )
+  }
+
 }

--- a/data-browser/src/main/scala/hmda/dataBrowser/services/QueryService.scala
+++ b/data-browser/src/main/scala/hmda/dataBrowser/services/QueryService.scala
@@ -9,5 +9,5 @@ import monix.eval.Task
 trait QueryService {
   def fetchAggregate(fields: List[QueryField]): Task[Seq[Aggregation]]
   def fetchData(fields: List[QueryField]): Source[ModifiedLarEntity, NotUsed]
-  def fetchFilers(year: Int): Task[FilerInstitutionResponse]
+  def fetchFilers(fields: List[QueryField]): Task[FilerInstitutionResponse]
 }


### PR DESCRIPTION
Closes #3268 

This PR changes the endpoint in data-browser to fetch LEI. 

Previously the endpoint was: `view/filers/2018` but this PR changes it to:

`view/filers?states=MD,DC,CA&years=2018` -- Get LEIs for specific states
or
`view/filers?counties=343333,03939&years=2018` -- Get LEIs for specific counties
or
`view/filers?msamds=34343,34343&years=2018` -- Get LEIs for specific msamds
or
`view/filers?years=2018` -- Get all LEIs