### PR TITLE
advance to status 14 when there are no quality or macro errors found

### DIFF
--- a/hmda/src/main/scala/hmda/persistence/submission/HmdaValidationError.scala
+++ b/hmda/src/main/scala/hmda/persistence/submission/HmdaValidationError.scala
@@ -207,7 +207,8 @@ object HmdaValidationError
       case CompleteMacro(submissionId) =>
         log.info(s"Macro Validation finished for $submissionId")
         val updatedStatus =
-          if (!state.macroVerified) MacroErrors
+          if (state.quality.isEmpty && state.`macro`.isEmpty && !state.macroVerified && !state.qualityVerified) Verified //This is for when a submission doesn't contain any quality or macro errors
+          else if (!state.macroVerified) MacroErrors
           else if (state.qualityVerified) Verified
           else Macro
         updateSubmissionStatus(sharding, submissionId, updatedStatus, log)


### PR DESCRIPTION
Closes #3272 

This PR makes it so that if a submission file has no quality and macro errors, then the status code advances to 14 so that the submission can be signed. Below is a sample file to test with

[Bank0_clean_1_row no MQ.txt](https://github.com/cfpb/hmda-platform/files/3879414/Bank0_clean_1_row.no.MQ.txt)
