### PR TITLE
Add email content for email

### DIFF
--- a/email-service/src/main/resources/application.conf
+++ b/email-service/src/main/resources/application.conf
@@ -32,9 +32,9 @@ aws {
 hmda {
   lar {
     email {
-      subject = "You Filed your HMDA data!"
+      subject = "HMDA filing accepted!"
       subject = ${?EMAIL_SUBJECT}
-      content = "Your submission has been processed"
+      content = "<b>HMDA filing accepted!</b><br>Congratulations, you have successfully completed your HMDA filing for <period>!<br>Your data and signature were received and recorded on <datetime>. Your receipt number for this submission is <uniq_id> "
       content = ${?EMAIL_CONTENT}
       from-address = "noreply@cfpb.gov"
       from-address = ${?SENDER_EMAIL_ADDRESS}

--- a/email-service/src/main/scala/hmda/publication/lar/EmailGuardian.scala
+++ b/email-service/src/main/scala/hmda/publication/lar/EmailGuardian.scala
@@ -36,7 +36,7 @@ object EmailGuardian {
 
       val (control, streamCompletion) =
         pullEmails(system, config.kafka.bootstrapServers)
-          .via(sendEmailsIfNecessary(emailService, emailStatusRepo, config.email.content, config.email.parallelism))
+          .via(sendEmailsIfNecessary(emailService, emailStatusRepo, config.email.content, config.email.subject, config.email.parallelism))
           .asSource
           .map { case (_, offset) => offset }
           .toMat(commitMessages(commitSettings))(Keep.both)

--- a/email-service/src/main/scala/hmda/publication/lar/database/PGSlickEmailSubmissionStatusRepository.scala
+++ b/email-service/src/main/scala/hmda/publication/lar/database/PGSlickEmailSubmissionStatusRepository.scala
@@ -20,7 +20,7 @@ class PGSlickEmailSubmissionStatusRepository(databaseConfig: DatabaseConfig[Jdbc
   override def recordEmailSent(e: EmailSubmissionMetadata): Task[EmailSubmissionStatus] = {
     val status = EmailSubmissionStatus(
       lei = e.submissionId.lei,
-      year = e.submissionId.period.toInt,
+      year = e.submissionId.period.year,
       submissionId = e.submissionId.toString,
       emailAddress = e.emailAddress,
       successful = true,
@@ -33,7 +33,7 @@ class PGSlickEmailSubmissionStatusRepository(databaseConfig: DatabaseConfig[Jdbc
   override def recordEmailFailed(e: EmailSubmissionMetadata, reason: String): Task[EmailSubmissionStatus] = {
     val status = EmailSubmissionStatus(
       lei = e.submissionId.lei,
-      year = e.submissionId.period.toInt,
+      year = e.submissionId.period.year,
       submissionId = e.submissionId.toString,
       emailAddress = e.emailAddress,
       successful = false,

--- a/email-service/src/main/scala/hmda/publication/lar/email/SESEmailService.scala
+++ b/email-service/src/main/scala/hmda/publication/lar/email/SESEmailService.scala
@@ -17,7 +17,7 @@ class SESEmailService(emailClient: AmazonSimpleEmailService, fromAddress: String
           .withMessage(
             new Message()
               .withSubject(new Content().withCharset(UTF8).withData(subject))
-              .withBody(new Body().withText(new Content().withCharset(UTF8).withData(plainTextContent)))
+              .withBody(new Body().withHtml(new Content().withData(plainTextContent)))
           )
           .withDestination(new Destination().withToAddresses(recipientAddress))
           .withSource(fromAddress)

--- a/kubernetes/config-maps/email-configmap.yaml
+++ b/kubernetes/config-maps/email-configmap.yaml
@@ -3,6 +3,6 @@ kind: ConfigMap
 metadata:
   name: email-configmap
 data:
-  emailSubject: HMDA Filing Confirmation
-  emailContent: Congradulations on the completion of your HMDA submission.
+  emailSubject: HMDA filing accepted!
+  emailContent: <b>HMDA filing accepted!</b><br>Congratulations, you have successfully completed your HMDA filing for <period>!<br>Your data and signature were received and recorded on <datetime>. Your receipt number for this submission is <uniq_id>
   emailSender: noreply@cfpb.gov


### PR DESCRIPTION
Closes #3241 

Adds html email capability. The text used is the same text from the signing page.

<img width="1147" alt="Screen Shot 2019-11-24 at 6 34 11 PM" src="https://user-images.githubusercontent.com/44377678/69503600-45d55880-0ee9-11ea-8aa4-d5f52e71f3c0.png">
