### PR TITLE
Fix verified logic for Q but no M

### DIFF
--- a/common/src/main/scala/hmda/model/processing/state/HmdaValidationErrorState.scala
+++ b/common/src/main/scala/hmda/model/processing/state/HmdaValidationErrorState.scala
@@ -59,7 +59,7 @@ case class HmdaValidationErrorState(statusCode: Int = 1,
 
   def verifyQuality(evt: QualityVerified): HmdaValidationErrorState = {
     val status = if (evt.verified) {
-      if (macroVerified) Verified.code
+      if (!macroVerified && `macro`.isEmpty) Verified.code
       else if (`macro`.isEmpty) hmda.model.filing.submission.Macro.code
       else MacroErrors.code
     } else {

--- a/hmda/src/main/scala/hmda/persistence/submission/HmdaValidationError.scala
+++ b/hmda/src/main/scala/hmda/persistence/submission/HmdaValidationError.scala
@@ -290,8 +290,7 @@ object HmdaValidationError
         if (state.statusCode == Verified.code) {
           val timestamp = Instant.now().toEpochMilli
           val signed    = SubmissionSigned(submissionId, timestamp, Signed)
-          if ((state.qualityVerified && state.macroVerified) || state
-                .noEditsFound()) {
+          if ((state.qualityVerified && state.macroVerified) || state.noEditsFound() || (state.qualityVerified && state.`macro`.isEmpty)) {
             Effect.persist(signed).thenRun { _ =>
               log.info(s"Submission $submissionId signed at ${Instant.ofEpochMilli(timestamp)}")
               updateSubmissionStatusAndReceipt(


### PR DESCRIPTION
Closes #3280 

This PR allows signing a file that has quality edits but has no macro edits. When a submission has no quality edits, the front end does not do a POST on `/verify`. 