### PR TITLE
Fix institution quarter endpoint

### DIFF
--- a/common/src/main/scala/hmda/api/http/directives/CreateFilingAuthorization.scala
+++ b/common/src/main/scala/hmda/api/http/directives/CreateFilingAuthorization.scala
@@ -17,9 +17,7 @@ trait CreateFilingAuthorization {
   def isFilingAllowed(year: Int, quarter: Option[String])(successful: Route): Route = extractMatchedPath { path =>
     // we use this only for month and day information (not time)
     val now = LocalDate.now()
-    val runtimeMode = config.getString("hmda.runtime.mode")
-
-    if (runtimeMode == "dev" || check(year, now.getDayOfYear, quarter)) successful
+    if (check(year, now.getDayOfYear, quarter)) successful
     else complete((BadRequest, ErrorResponse(BadRequest.intValue, "The provided year or quarter isn't open at the moment", path)))
   }
 }

--- a/common/src/main/scala/hmda/api/http/directives/CreateFilingAuthorization.scala
+++ b/common/src/main/scala/hmda/api/http/directives/CreateFilingAuthorization.scala
@@ -17,7 +17,9 @@ trait CreateFilingAuthorization {
   def isFilingAllowed(year: Int, quarter: Option[String])(successful: Route): Route = extractMatchedPath { path =>
     // we use this only for month and day information (not time)
     val now = LocalDate.now()
-    if (check(year, now.getDayOfYear, quarter)) successful
+    val runtimeMode = config.getString("hmda.runtime.mode")
+
+    if (runtimeMode == "dev" || check(year, now.getDayOfYear, quarter)) successful
     else complete((BadRequest, ErrorResponse(BadRequest.intValue, "The provided year or quarter isn't open at the moment", path)))
   }
 }

--- a/hmda/src/main/scala/hmda/api/http/filing/InstitutionHttpApi.scala
+++ b/hmda/src/main/scala/hmda/api/http/filing/InstitutionHttpApi.scala
@@ -63,16 +63,16 @@ trait InstitutionHttpApi extends HmdaTimeDirectives with QuarterlyFilingAuthoriz
     } yield(institution, filings)
 
     onComplete(iDetails) {
-      case Success((Some(institution), Some(filings))) =>
-        complete(ToResponseMarshallable(InstitutionDetail(Option(institution), List(filings.filing))))
+      case Success((i @ Some(_), optFilings)) =>
+        complete(InstitutionDetail(i, optFilings.map(_.filing).toList))
+      case Success((i @ Some(_), None)) =>
+        complete(InstitutionDetail(i, List(Filing())))
       case Success((None,_)) =>
         val errorResponse =
           ErrorResponse(404, s"Institution: $lei does not exist", uri.path)
         complete(
           ToResponseMarshallable(StatusCodes.NotFound -> errorResponse)
         )
-      case Success((Some(institution), None)) =>
-        complete(ToResponseMarshallable(InstitutionDetail(Option(institution), List(Filing()))))
 
       case Failure(error) =>
         failedResponse(StatusCodes.InternalServerError, uri, error)

--- a/hmda/src/main/scala/hmda/api/http/filing/InstitutionHttpApi.scala
+++ b/hmda/src/main/scala/hmda/api/http/filing/InstitutionHttpApi.scala
@@ -4,23 +4,26 @@ import akka.actor.ActorSystem
 import akka.cluster.sharding.typed.scaladsl.ClusterSharding
 import akka.event.LoggingAdapter
 import akka.http.scaladsl.marshalling.ToResponseMarshallable
-import akka.http.scaladsl.model.{ StatusCodes, Uri }
+import akka.http.scaladsl.model.{StatusCodes, Uri}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import akka.stream.ActorMaterializer
 import akka.util.Timeout
 import ch.megard.akka.http.cors.scaladsl.CorsDirectives._
-import hmda.api.http.directives.{ HmdaTimeDirectives, QuarterlyFilingAuthorization }
+import hmda.api.http.directives.{HmdaTimeDirectives, QuarterlyFilingAuthorization}
 import hmda.util.http.FilingResponseUtils._
-import hmda.messages.institution.InstitutionCommands.GetInstitutionDetails
-import hmda.model.institution.InstitutionDetail
+import hmda.messages.institution.InstitutionCommands.{GetInstitution, GetInstitutionDetails}
+import hmda.model.institution.{Institution, InstitutionDetail}
 import hmda.api.http.PathMatchers._
 
-import scala.concurrent.{ ExecutionContext, Future }
-import scala.util.{ Failure, Success }
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
 import hmda.api.http.model.ErrorResponse
 import hmda.auth.OAuth2Authorization
+import hmda.messages.filing.FilingCommands.GetFilingDetails
+import hmda.model.filing.FilingDetails
+import hmda.persistence.filing.FilingPersistence.selectFiling
 import hmda.persistence.institution.InstitutionPersistence.selectInstitution
 
 trait InstitutionHttpApi extends HmdaTimeDirectives with QuarterlyFilingAuthorization {
@@ -51,11 +54,18 @@ trait InstitutionHttpApi extends HmdaTimeDirectives with QuarterlyFilingAuthoriz
 
   def obtainFilingDetails(lei: String, year: Int, quarter: Option[String], uri: Uri): Route = {
     val institutionPersistence                      = selectInstitution(sharding, lei, year)
-    val iDetails: Future[Option[InstitutionDetail]] = institutionPersistence ? (ref => GetInstitutionDetails(ref))
+    val fInstitution: Future[Option[Institution]] = institutionPersistence ? (ref => GetInstitution(ref))
+    val fil = selectFiling(sharding, lei, year, quarter)
+    val fDetails: Future[Option[FilingDetails]] = fil ? (ref => GetFilingDetails(ref))
+    val iDetails = for {
+      institution <- fInstitution
+      filings <- fDetails
+    } yield(institution, filings)
+
     onComplete(iDetails) {
-      case Success(Some(institutionDetails)) =>
-        complete(ToResponseMarshallable(institutionDetails))
-      case Success(None) =>
+      case Success((Some(institution), Some(filings))) =>
+        complete(ToResponseMarshallable(InstitutionDetail(Option(institution), List(filings.filing))))
+      case Success((None,_)) =>
         val errorResponse =
           ErrorResponse(404, s"Institution: $lei does not exist", uri.path)
         complete(

--- a/hmda/src/main/scala/hmda/api/http/filing/InstitutionHttpApi.scala
+++ b/hmda/src/main/scala/hmda/api/http/filing/InstitutionHttpApi.scala
@@ -22,7 +22,7 @@ import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
 import hmda.api.http.model.ErrorResponse
 import hmda.auth.OAuth2Authorization
 import hmda.messages.filing.FilingCommands.GetFilingDetails
-import hmda.model.filing.FilingDetails
+import hmda.model.filing.{Filing, FilingDetails}
 import hmda.persistence.filing.FilingPersistence.selectFiling
 import hmda.persistence.institution.InstitutionPersistence.selectInstitution
 
@@ -71,6 +71,9 @@ trait InstitutionHttpApi extends HmdaTimeDirectives with QuarterlyFilingAuthoriz
         complete(
           ToResponseMarshallable(StatusCodes.NotFound -> errorResponse)
         )
+      case Success((Some(institution), None)) =>
+        complete(ToResponseMarshallable(InstitutionDetail(Option(institution), List(Filing()))))
+
       case Failure(error) =>
         failedResponse(StatusCodes.InternalServerError, uri, error)
     }


### PR DESCRIPTION
Closes #3301 

This PR makes `/institutions/<lei>/year/<y>/quarter/<q>` API return the quarterly filing like below:

```
...
    "filings": [
        {
            "period": "2020-Q1",
            "lei": "B90YWS6AFX2LGWOXJ1LD",
            "status": {
                "code": 2,
                "message": "in-progress"
            },
            "filingRequired": true,
            "start": 1575219884742,
            "end": 0
        }
    ]

```