### PR TITLE
FFVT parser messaging

### DIFF
--- a/hmda/src/main/scala/hmda/api/http/ParserErrorUtils.scala
+++ b/hmda/src/main/scala/hmda/api/http/ParserErrorUtils.scala
@@ -7,10 +7,13 @@ import hmda.messages.submission.SubmissionProcessingEvents._
 
 object ParserErrorUtils {
 
-    def parserValidationErrorSummaryConvertor(line: Int, lar: String, errors: List[ParserValidationError]): HmdaRowParsedErrorSummary = {
+    def parserValidationErrorSummaryConvertor(line: Int, lar: Option[String], errors: List[ParserValidationError]): HmdaRowParsedErrorSummary = {
         HmdaRowParsedErrorSummary(
             line,
-            estimateULI(lar),
+            lar match {
+              case Some(lar) => estimateULI(lar)
+              case None => "Transmittal Sheet"
+            }, 
             errors.map(error => 
             FieldParserErrorSummary(
                 error.fieldName,

--- a/hmda/src/main/scala/hmda/api/http/ParserErrorUtils.scala
+++ b/hmda/src/main/scala/hmda/api/http/ParserErrorUtils.scala
@@ -1,0 +1,45 @@
+package hmda.api.http.utils
+
+import hmda.model.filing.ParserValidValuesLookup._
+import hmda.api.http.model.filing.submissions.{ HmdaRowParsedErrorSummary, FieldParserErrorSummary }
+import hmda.parser.ParserErrorModel.ParserValidationError
+import hmda.messages.submission.SubmissionProcessingEvents._
+
+object ParserErrorUtils {
+
+    def parserValidationErrorSummaryConvertor(line: Int, lar: String, errors: List[ParserValidationError]): HmdaRowParsedErrorSummary = {
+        HmdaRowParsedErrorSummary(
+            line,
+            estimateULI(lar),
+            errors.map(error => 
+            FieldParserErrorSummary(
+                error.fieldName,
+                error.inputValue,
+                lookupParserValidValues(error.fieldName)
+            )
+            ))
+    }
+  def parserErrorSummaryConvertor(
+      hmdaRowParsedError: HmdaRowParsedError): HmdaRowParsedErrorSummary = {
+    HmdaRowParsedErrorSummary(
+      hmdaRowParsedError.rowNumber,
+      hmdaRowParsedError.estimatedULI,
+      hmdaRowParsedError.errorMessages.map(
+        errorMessage =>
+          FieldParserErrorSummary(
+            errorMessage.fieldName,
+            errorMessage.inputValue,
+            lookupParserValidValues(errorMessage.fieldName)
+        ))
+    )
+  }
+
+  def estimateULI(line: String): String = {
+    val larItems = line.split('|')
+    if (larItems.length >= 3) {
+      larItems(2)
+    } else {
+      "The ULI could not be identified."
+    }
+  }
+}

--- a/hmda/src/main/scala/hmda/api/http/filing/submissions/ParseErrorHttpApi.scala
+++ b/hmda/src/main/scala/hmda/api/http/filing/submissions/ParseErrorHttpApi.scala
@@ -19,7 +19,6 @@ import hmda.model.filing.submission.{ Submission, SubmissionId }
 import hmda.model.processing.state.HmdaParserErrorState
 import hmda.persistence.submission.{ HmdaParserError, SubmissionPersistence }
 import hmda.util.http.FilingResponseUtils._
-import hmda.model.filing.ParserValidValuesLookup._
 import hmda.api.http.model.filing.submissions._
 import hmda.api.http.PathMatchers._
 import hmda.utils.YearUtils.Period

--- a/hmda/src/main/scala/hmda/api/http/filing/submissions/ParseErrorHttpApi.scala
+++ b/hmda/src/main/scala/hmda/api/http/filing/submissions/ParseErrorHttpApi.scala
@@ -21,9 +21,9 @@ import hmda.persistence.submission.{ HmdaParserError, SubmissionPersistence }
 import hmda.util.http.FilingResponseUtils._
 import hmda.model.filing.ParserValidValuesLookup._
 import hmda.api.http.model.filing.submissions._
-import hmda.messages.submission.SubmissionProcessingEvents.HmdaRowParsedError
 import hmda.api.http.PathMatchers._
 import hmda.utils.YearUtils.Period
+import hmda.api.http.utils.ParserErrorUtils._
 
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.{ Failure, Success }
@@ -103,19 +103,4 @@ trait ParseErrorHttpApi extends HmdaTimeDirectives with QuarterlyFilingAuthoriza
         }
       }
     }
-
-  private def parserErrorSummaryConvertor(hmdaRowParsedError: HmdaRowParsedError): HmdaRowParsedErrorSummary =
-    HmdaRowParsedErrorSummary(
-      hmdaRowParsedError.rowNumber,
-      hmdaRowParsedError.estimatedULI,
-      hmdaRowParsedError.errorMessages.map(
-        errorMessage =>
-          FieldParserErrorSummary(
-            errorMessage.fieldName,
-            errorMessage.inputValue,
-            lookupParserValidValues(errorMessage.fieldName)
-          )
-      )
-    )
-
 }

--- a/hmda/src/main/scala/hmda/api/http/model/filing/submissions/ParsingErrorSummary.scala
+++ b/hmda/src/main/scala/hmda/api/http/model/filing/submissions/ParsingErrorSummary.scala
@@ -11,7 +11,13 @@ case class FieldParserErrorSummary(fieldName: String,
 case class HmdaRowParsedErrorSummary(
     rowNumber: Int,
     estimatedULI: String,
-    errorMessages: List[FieldParserErrorSummary])
+    errorMessages: List[FieldParserErrorSummary]){
+      def toCsv: String = {
+        errorMessages.map(error => 
+          s"$rowNumber|$estimatedULI|${error.fieldName}|${error.inputValue}|${error.validValues}\n"
+        ).reduce(_ + _)
+      }
+    }
 
 case class ParsingErrorSummary(
     transmittalSheetErrors: Seq[HmdaRowParsedErrorSummary] = Nil,

--- a/hmda/src/main/scala/hmda/api/http/model/public/LarValidateResponse.scala
+++ b/hmda/src/main/scala/hmda/api/http/model/public/LarValidateResponse.scala
@@ -1,3 +1,0 @@
-package hmda.api.http.model.public
-
-case class LarValidateResponse(errorMessages: List[String])

--- a/hmda/src/main/scala/hmda/api/http/model/public/TsValidateResponse.scala
+++ b/hmda/src/main/scala/hmda/api/http/model/public/TsValidateResponse.scala
@@ -1,3 +1,0 @@
-package hmda.api.http.model.public
-
-case class TsValidateResponse(errorMessages: List[String])

--- a/hmda/src/main/scala/hmda/api/http/model/public/ValidatedResponse.scala
+++ b/hmda/src/main/scala/hmda/api/http/model/public/ValidatedResponse.scala
@@ -1,7 +1,0 @@
-package hmda.api.http.model.public
-
-case class ValidatedResponse(validated: Seq[Validated])
-
-case class Validated(lineNumber: Int, errors: String) {
-  def toCSV: String = s"$lineNumber|$errors"
-}

--- a/hmda/src/main/scala/hmda/api/http/public/FilingValidationHttpApi.scala
+++ b/hmda/src/main/scala/hmda/api/http/public/FilingValidationHttpApi.scala
@@ -6,18 +6,18 @@ import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.server.Directives._
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
 import io.circe.generic.auto._
-import hmda.api.http.model.public.{ LarValidateResponse, SingleValidationErrorResult, ValidationErrorSummary, ValidationSingleErrorSummary }
+import hmda.api.http.model.public.{ SingleValidationErrorResult, ValidationErrorSummary, ValidationSingleErrorSummary }
 import hmda.model.validation._
 import hmda.parser.ParserErrorModel.ParserValidationError
 import hmda.model.filing.EditDescriptionLookup
 import hmda.utils.YearUtils.Period
+import hmda.api.http.utils.ParserErrorUtils._
 
 trait FilingValidationHttpApi {
 
-  def completeWithParsingErrors(errors: List[ParserValidationError]): Route = {
-    val errorList = errors.map(e => e.fieldName)
+  def completeWithParsingErrors(lar: String, errors: List[ParserValidationError]): Route = {
     complete(
-      ToResponseMarshallable(StatusCodes.BadRequest -> LarValidateResponse(errorList))
+      ToResponseMarshallable(StatusCodes.BadRequest -> parserValidationErrorSummaryConvertor(0, lar, errors))
     )
   }
 

--- a/hmda/src/main/scala/hmda/api/http/public/FilingValidationHttpApi.scala
+++ b/hmda/src/main/scala/hmda/api/http/public/FilingValidationHttpApi.scala
@@ -15,7 +15,7 @@ import hmda.api.http.utils.ParserErrorUtils._
 
 trait FilingValidationHttpApi {
 
-  def completeWithParsingErrors(lar: String, errors: List[ParserValidationError]): Route = {
+  def completeWithParsingErrors(lar: Option[String], errors: List[ParserValidationError]): Route = {
     complete(
       ToResponseMarshallable(StatusCodes.BadRequest -> parserValidationErrorSummaryConvertor(0, lar, errors))
     )

--- a/hmda/src/main/scala/hmda/api/http/public/HmdaFileValidationHttpApi.scala
+++ b/hmda/src/main/scala/hmda/api/http/public/HmdaFileValidationHttpApi.scala
@@ -131,7 +131,7 @@ trait HmdaFileValidationHttpApi extends HmdaTimeDirectives {
       .map {
         case (i, Right(_)) => None
         case (i, Left(errors)) =>
-          Some(ParserErrorUtils.parserValidationErrorSummaryConvertor(i, "ts", errors))
+          Some(ParserErrorUtils.parserValidationErrorSummaryConvertor(i, None, errors))
       }
 
   private def processLarSource: Flow[ByteString, Option[HmdaRowParsedErrorSummary], NotUsed] =
@@ -148,7 +148,7 @@ trait HmdaFileValidationHttpApi extends HmdaTimeDirectives {
       .map {
         case (i, lar, Right(_)) => None
         case (i, lar, Left(errors)) =>
-          Some(ParserErrorUtils.parserValidationErrorSummaryConvertor(i, lar, errors))
+          Some(ParserErrorUtils.parserValidationErrorSummaryConvertor(i, Some(lar), errors))
       }
 
 }

--- a/hmda/src/main/scala/hmda/api/http/public/HmdaFileValidationHttpApi.scala
+++ b/hmda/src/main/scala/hmda/api/http/public/HmdaFileValidationHttpApi.scala
@@ -42,11 +42,7 @@ trait HmdaFileValidationHttpApi extends HmdaTimeDirectives {
           onComplete(processF) {
             case Success(parsed) =>
               val errorList = parsed.filter(_ != None)
-              if (errorList.length == 0){
-                complete("yay")
-              } else {
-                complete(errorList)
-              }
+              complete(errorList)
 
             case Failure(error) =>
               complete(ToResponseMarshallable(StatusCodes.BadRequest -> error.getLocalizedMessage))

--- a/hmda/src/main/scala/hmda/api/http/public/LarValidationHttpApi.scala
+++ b/hmda/src/main/scala/hmda/api/http/public/LarValidationHttpApi.scala
@@ -41,7 +41,7 @@ trait LarValidationHttpApi extends HmdaTimeDirectives with FilingValidationHttpA
               case Right(lar) =>
                 complete(ToResponseMarshallable(lar))
               case Left(errors) =>
-                completeWithParsingErrors(req.lar, errors)
+                completeWithParsingErrors(Some(req.lar), errors)
             }
           }
         }
@@ -61,7 +61,7 @@ trait LarValidationHttpApi extends HmdaTimeDirectives with FilingValidationHttpA
               LarCsvParser(req.lar) match {
                 case Right(lar) => validate(lar, checkType, year, None)
                 case Left(errors) =>
-                  completeWithParsingErrors(req.lar, errors)
+                  completeWithParsingErrors(Some(req.lar), errors)
               }
             }
           }
@@ -79,7 +79,7 @@ trait LarValidationHttpApi extends HmdaTimeDirectives with FilingValidationHttpA
               LarCsvParser(req.lar) match {
                 case Right(lar) => validate(lar, checkType, year, Some(quarter))
                 case Left(errors) =>
-                  completeWithParsingErrors(req.lar, errors)
+                  completeWithParsingErrors(Some(req.lar), errors)
               }
             }
           }

--- a/hmda/src/main/scala/hmda/api/http/public/LarValidationHttpApi.scala
+++ b/hmda/src/main/scala/hmda/api/http/public/LarValidationHttpApi.scala
@@ -41,7 +41,7 @@ trait LarValidationHttpApi extends HmdaTimeDirectives with FilingValidationHttpA
               case Right(lar) =>
                 complete(ToResponseMarshallable(lar))
               case Left(errors) =>
-                completeWithParsingErrors(errors)
+                completeWithParsingErrors(req.lar, errors)
             }
           }
         }
@@ -61,7 +61,7 @@ trait LarValidationHttpApi extends HmdaTimeDirectives with FilingValidationHttpA
               LarCsvParser(req.lar) match {
                 case Right(lar) => validate(lar, checkType, year, None)
                 case Left(errors) =>
-                  completeWithParsingErrors(errors)
+                  completeWithParsingErrors(req.lar, errors)
               }
             }
           }
@@ -79,7 +79,7 @@ trait LarValidationHttpApi extends HmdaTimeDirectives with FilingValidationHttpA
               LarCsvParser(req.lar) match {
                 case Right(lar) => validate(lar, checkType, year, Some(quarter))
                 case Left(errors) =>
-                  completeWithParsingErrors(errors)
+                  completeWithParsingErrors(req.lar, errors)
               }
             }
           }

--- a/hmda/src/main/scala/hmda/api/http/public/TsValidationHttpApi.scala
+++ b/hmda/src/main/scala/hmda/api/http/public/TsValidationHttpApi.scala
@@ -40,7 +40,7 @@ trait TsValidationHttpApi extends HmdaTimeDirectives with FilingValidationHttpAp
             TsCsvParser(req.ts) match {
               case Right(ts) => complete(ToResponseMarshallable(ts))
               case Left(errors) =>
-                completeWithParsingErrors(req.ts, errors)
+                completeWithParsingErrors(None, errors)
             }
           }
         }
@@ -61,7 +61,7 @@ trait TsValidationHttpApi extends HmdaTimeDirectives with FilingValidationHttpAp
                 case Right(ts) =>
                   validate(ts, checkType, year, None)
                 case Left(errors) =>
-                  completeWithParsingErrors(req.ts, errors)
+                  completeWithParsingErrors(None, errors)
               }
             }
           }
@@ -80,7 +80,7 @@ trait TsValidationHttpApi extends HmdaTimeDirectives with FilingValidationHttpAp
                 case Right(ts) =>
                   validate(ts, checkType, year, Some(quarter))
                 case Left(errors) =>
-                  completeWithParsingErrors(req.ts, errors)
+                  completeWithParsingErrors(None, errors)
               }
             }
           }

--- a/hmda/src/main/scala/hmda/api/http/public/TsValidationHttpApi.scala
+++ b/hmda/src/main/scala/hmda/api/http/public/TsValidationHttpApi.scala
@@ -40,7 +40,7 @@ trait TsValidationHttpApi extends HmdaTimeDirectives with FilingValidationHttpAp
             TsCsvParser(req.ts) match {
               case Right(ts) => complete(ToResponseMarshallable(ts))
               case Left(errors) =>
-                completeWithParsingErrors(errors)
+                completeWithParsingErrors(req.ts, errors)
             }
           }
         }
@@ -61,7 +61,7 @@ trait TsValidationHttpApi extends HmdaTimeDirectives with FilingValidationHttpAp
                 case Right(ts) =>
                   validate(ts, checkType, year, None)
                 case Left(errors) =>
-                  completeWithParsingErrors(errors)
+                  completeWithParsingErrors(req.ts, errors)
               }
             }
           }
@@ -80,7 +80,7 @@ trait TsValidationHttpApi extends HmdaTimeDirectives with FilingValidationHttpAp
                 case Right(ts) =>
                   validate(ts, checkType, year, Some(quarter))
                 case Left(errors) =>
-                  completeWithParsingErrors(errors)
+                  completeWithParsingErrors(req.ts, errors)
               }
             }
           }

--- a/hmda/src/main/scala/hmda/persistence/submission/HmdaParserError.scala
+++ b/hmda/src/main/scala/hmda/persistence/submission/HmdaParserError.scala
@@ -22,6 +22,7 @@ import hmda.model.processing.state.HmdaParserErrorState
 import hmda.parser.filing.ParserFlow._
 import hmda.persistence.HmdaTypedPersistentActor
 import hmda.persistence.submission.HmdaProcessingUtils.{ readRawData, updateSubmissionStatus }
+import hmda.api.http.utils.ParserErrorUtils._
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
@@ -133,15 +134,6 @@ object HmdaParserError extends HmdaTypedPersistentActor[SubmissionProcessingComm
 
   def startShardRegion(sharding: ClusterSharding): ActorRef[ShardingEnvelope[SubmissionProcessingCommand]] =
     super.startShardRegion(sharding)
-
-  def estimateULI(line: String): String = {
-    val larItems = line.split('|')
-    if (larItems.length >= 3) {
-      larItems(2)
-    } else {
-      "The ULI could not be identified."
-    }
-  }
 
   def selectHmdaParserError(sharding: ClusterSharding, submissionId: SubmissionId): EntityRef[SubmissionProcessingCommand] =
     sharding.entityRefFor(HmdaParserError.typeKey, s"${HmdaParserError.name}-${submissionId.toString}")

--- a/hmda/src/test/scala/hmda/api/http/codec/filing/submission/ParsingErrorSummaryGenerator.scala
+++ b/hmda/src/test/scala/hmda/api/http/codec/filing/submission/ParsingErrorSummaryGenerator.scala
@@ -3,7 +3,6 @@ package hmda.api.http.codec.filing.submission
 import hmda.api.http.model.filing.submissions.{ParsingErrorSummary, HmdaRowParsedErrorSummary, FieldParserErrorSummary}
 import org.scalacheck.Gen
 import hmda.model.submission.SubmissionGenerator._
-import hmda.serialization.submission.HmdaParserErrorStateGenerator._
 
 object ParsingErrorSummaryGenerator {
 

--- a/hmda/src/test/scala/hmda/api/http/public/HmdaFileValidationHttpApiSpec.scala
+++ b/hmda/src/test/scala/hmda/api/http/public/HmdaFileValidationHttpApiSpec.scala
@@ -4,7 +4,6 @@ import akka.event.{LoggingAdapter, NoLogging}
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import akka.util.Timeout
-import hmda.api.http.model.public.ValidatedResponse
 import hmda.model.filing.lar.LarGenerators.larNGen
 import hmda.model.filing.ts.TransmittalSheet
 import hmda.model.filing.ts.TsGenerators.tsGen

--- a/hmda/src/test/scala/hmda/api/http/public/HmdaFileValidationHttpApiSpec.scala
+++ b/hmda/src/test/scala/hmda/api/http/public/HmdaFileValidationHttpApiSpec.scala
@@ -13,6 +13,7 @@ import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
 import io.circe.generic.auto._
 import akka.http.scaladsl.unmarshalling.Unmarshaller._
 import hmda.util.http.FileUploadUtils
+import hmda.api.http.model.filing.submissions.HmdaRowParsedErrorSummary
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
@@ -37,7 +38,7 @@ class HmdaFileValidationHttpApiSpec
   val tsCsv = s"${ts.toCSV}\n"
   val larsCsv = lars.map(lar => s"${lar.toCSV}")
   val badLar =
-    "2|AYAKEFD53DRJIQYNCI0U||a|4|5|2|2|1|16041|2|20181217|1234 Hocus Potato Way|Tatertown|UT|84096|49035|49035111906|1|||||8GMCACAP36H23X5P4CY43EKEW9U99R4VGENRVJ26M7YPH9U7O9PCXLZAWN08ZEVNW5GMGT|14|11|13|1|12|IN376P|1|2|2|3|5|4|4|XI523E3TOC6AA3J7IWQYPHNA7XQF6VZHLC5YMDLSOANWCJLP69S2PRIWV1L4W|AZAQ11|Y2O3RJE1NNVPLQIKPOVK2QTCPX367O8I2XGGW2854INVZGIMPYBANX82JFNOD7NP1PU|6|||||YL0MF86ZDTHSY4IR9XTN0943NWGII7N74ZWBVEYDFIAZ|IQS0OJCR|1NINW4K9VEJPOLIX3H3Z430MTXXIQAKVFTVXSOU7ITFO905GR2L58J4IBDGO0I0KVPUDRO9O21IPZATYBE3MQI|1|3|2|3|1|2|36|59|NA|0|NA|3|2|392|581|8|ZUXWM29BLH3MY74D09ZTO16HVBXJBY5DQ800PHRA2TCX8J6EV0KYFDAA17E2DIHBDOP|7||10|||||NA|NA|NA|NA|NA|9.7|NA|NA|188|NA|21|1|1|1|1|15962|3|5|28|17|2|2|LMIS8LM|3||||1||1||||2||1|1|2"
+    "2|AYAKEFD53DRJIQYNCI0U|LEI123|a|4|5|2|2|1|16041|2|20181217|1234 Hocus Potato Way|Tatertown|UT|84096|49035|49035111906|1|||||8GMCACAP36H23X5P4CY43EKEW9U99R4VGENRVJ26M7YPH9U7O9PCXLZAWN08ZEVNW5GMGT|14|11|13|1|12|IN376P|1|2|2|3|5|4|4|XI523E3TOC6AA3J7IWQYPHNA7XQF6VZHLC5YMDLSOANWCJLP69S2PRIWV1L4W|AZAQ11|Y2O3RJE1NNVPLQIKPOVK2QTCPX367O8I2XGGW2854INVZGIMPYBANX82JFNOD7NP1PU|6|||||YL0MF86ZDTHSY4IR9XTN0943NWGII7N74ZWBVEYDFIAZ|IQS0OJCR|1NINW4K9VEJPOLIX3H3Z430MTXXIQAKVFTVXSOU7ITFO905GR2L58J4IBDGO0I0KVPUDRO9O21IPZATYBE3MQI|1|3|2|3|1|2|36|59|NA|0|NA|3|2|392|581|8|ZUXWM29BLH3MY74D09ZTO16HVBXJBY5DQ800PHRA2TCX8J6EV0KYFDAA17E2DIHBDOP|7||10|||||NA|NA|NA|NA|NA|9.7|NA|NA|188|NA|21|1|1|1|1|15962|3|5|28|17|2|2|LMIS8LM|3||||1||1||||2||1|1|2"
   val badCsv = tsCsv + s"$badLar\n" + larsCsv.mkString("\n")
   val badFile = multipartFile(badCsv, "bad-lars.txt")
 
@@ -53,8 +54,8 @@ class HmdaFileValidationHttpApiSpec
     "parse a HMDA file" in {
       Post("/hmda/parse", badFile) ~> hmdaFileRoutes ~> check {
         status mustBe StatusCodes.OK
-        val result = responseAs[ValidatedResponse]
-        result.validated.size mustBe 1
+        val result = responseAs[List[HmdaRowParsedErrorSummary]]
+        result.size mustBe 1
       }
     }
 
@@ -62,8 +63,8 @@ class HmdaFileValidationHttpApiSpec
       Post("/hmda/parse/csv", badFile) ~> hmdaFileRoutes ~> check {
         status mustBe StatusCodes.OK
         val csv = responseAs[String]
-        csv must include("lineNumber|errors")
-        csv must include("2|Application Date")
+        csv must include("Row Number|Estimated ULI|Field Name|Input Value|Valid Values")
+        csv must include("2|LEI123|Application Date|a|Integer or NA")
       }
     }
   }

--- a/hmda/src/test/scala/hmda/api/http/public/TsValidationHttpApiSpec.scala
+++ b/hmda/src/test/scala/hmda/api/http/public/TsValidationHttpApiSpec.scala
@@ -6,8 +6,7 @@ import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.util.Timeout
 import hmda.api.http.model.public.{
   SingleValidationErrorResult,
-  TsValidateRequest,
-  TsValidateResponse
+  TsValidateRequest
 }
 import org.scalatest.{MustMatchers, WordSpec}
 
@@ -16,6 +15,7 @@ import scala.concurrent.duration._
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
 import hmda.model.filing.ts.{Address, Contact, TransmittalSheet}
 import hmda.model.institution.Agency
+import hmda.api.http.model.filing.submissions.HmdaRowParsedErrorSummary
 import io.circe.generic.auto._
 
 class TsValidationHttpApiSpec
@@ -69,9 +69,7 @@ class TsValidationHttpApiSpec
     "fail to parse an invalid pipe delimited TS and return list of errors" in {
       Post("/ts/parse", TsValidateRequest(invalidParseCsv)) ~> tsRoutes ~> check {
         status mustBe StatusCodes.BadRequest
-        responseAs[TsValidateResponse].errorMessages mustBe List(
-          "Transmittal Sheet Record Identifier",
-          "Federal Agency")
+        responseAs[HmdaRowParsedErrorSummary].errorMessages.length mustBe 2
       }
     }
 
@@ -80,8 +78,7 @@ class TsValidationHttpApiSpec
         TsValidateRequest(tsCsv + "|too|many|fields")
       Post("/ts/parse", tsValidateRequestWithTooManyFields) ~> tsRoutes ~> check {
         status mustBe StatusCodes.BadRequest
-        responseAs[TsValidateResponse].errorMessages mustBe List(
-          "Incorrect Number of TS Fields")
+        responseAs[HmdaRowParsedErrorSummary].errorMessages.length mustBe 1
       }
     }
 

--- a/hmda/src/test/scala/hmda/persistence/submission/HmdaValidationErrorSpec.scala
+++ b/hmda/src/test/scala/hmda/persistence/submission/HmdaValidationErrorSpec.scala
@@ -7,7 +7,7 @@ import akka.cluster.sharding.typed.scaladsl.ClusterSharding
 import akka.cluster.typed.{ Cluster, Join }
 import hmda.messages.submission.SubmissionProcessingCommands._
 import hmda.messages.submission.SubmissionProcessingEvents._
-import hmda.model.filing.submission.{ Macro, SubmissionId, Verified, MacroErrors }
+import hmda.model.filing.submission.{ SubmissionId, Verified, MacroErrors }
 import hmda.model.processing.state.{ EditSummary, HmdaValidationErrorState }
 import hmda.model.validation._
 import hmda.persistence.AkkaCassandraPersistenceSpec


### PR DESCRIPTION
Closes #3257

This changes the response of three of our public apis:
- `hmda/parse`
```json
   {"validated":[{"lineNumber":2,"errors":"age is not numeric,age is not numeric"}]}
```
- `lar/parse`
```json
{
    "errorMessages": [
        "id is not numeric"
    ]
}
```
- `ts/parse`
```json
{
    "errorMessages": [
        "An incorrect number of data fields were reported: 110 data fields were found, when 15 data fields were expected."
    ]
}
```

This changes all of these api returns to the common response returned by the hmda filing application:

```
      { 
         "rowNumber":2,
         "estimatedULI":"549300NFAQXBUC5NPK66509128038",
         "errorMessages":[ 
            { 
               "fieldName":"Age of Applicant or Borrower",
               "inputValue":"",
               "validValues":"Integer"
            },
            { 
               "fieldName":"Age of Co-Applicant or Co-Borrower",
               "inputValue":"",
               "validValues":"Integer"
            }
         ]
      }
```