### PR TITLE
support for quarterly filings

### DIFF
--- a/email-service/src/main/scala/hmda/publication/lar/streams/Stream.scala
+++ b/email-service/src/main/scala/hmda/publication/lar/streams/Stream.scala
@@ -56,8 +56,8 @@ object Stream {
   def submissionId(submissionWithReceipt: String): Submission = {
     submissionWithReceipt.split("-").size match {
       case 4 =>
-        val lei :: period :: seqNo :: receipt :: Nil = submissionWithReceipt.split("-").take(4).toList
-        Submission(id = SubmissionId(lei, YearUtils.parsePeriod(period).right.get, seqNo.toInt), receipt = receipt)
+        val lei :: year :: seqNo :: receipt :: Nil = submissionWithReceipt.split("-").take(4).toList
+        Submission(id = SubmissionId(lei, YearUtils.parsePeriod(year).right.get, seqNo.toInt), receipt = receipt)
       case 5 =>
         val lei :: year :: quarter :: seqNo :: receipt :: Nil = submissionWithReceipt.split("-").take(5).toList
         Submission(id = SubmissionId(lei, Period(year.toInt, Some(quarter)), seqNo.toInt), receipt = receipt)

--- a/email-service/src/main/scala/hmda/publication/lar/streams/Stream.scala
+++ b/email-service/src/main/scala/hmda/publication/lar/streams/Stream.scala
@@ -54,8 +54,14 @@ object Stream {
     }
 
   def submissionId(submissionWithReceipt: String): Submission = {
-    val lei :: period :: seqNo :: receipt :: Nil = submissionWithReceipt.split("-").take(4).toList
-    Submission(id = SubmissionId(lei, YearUtils.parsePeriod(period).right.get, seqNo.toInt), receipt = receipt)
+    submissionWithReceipt.split("-").size match {
+      case 4 =>
+        val lei :: period :: seqNo :: receipt :: Nil = submissionWithReceipt.split("-").take(4).toList
+        Submission(id = SubmissionId(lei, YearUtils.parsePeriod(period).right.get, seqNo.toInt), receipt = receipt)
+      case 5 =>
+        val lei :: year :: quarter :: seqNo :: receipt :: Nil = submissionWithReceipt.split("-").take(5).toList
+        Submission(id = SubmissionId(lei, Period(year.toInt, Some(quarter)), seqNo.toInt), receipt = receipt)
+    }
   }
 
   def sendEmailAndUpdateStatus(


### PR DESCRIPTION
Closes #3310 

This PR adds support for sending emails for quarterly submissions:

<img width="1141" alt="Screen Shot 2019-12-05 at 9 54 46 AM" src="https://user-images.githubusercontent.com/44377678/70246206-59808a80-1745-11ea-92aa-c740880e86a0.png">
