### PR TITLE
Put timed guards in configmaps

### DIFF
--- a/kubernetes/beta/config-maps/timed-guards-configmap.yaml
+++ b/kubernetes/beta/config-maps/timed-guards-configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: timed-guards
+data:
+  yearsAllowed: "2018,2019"
+  currentYear: "2018"
+  quarterlyYearsAllowed: "2020"
+  q1Start: "April 01"
+  q1End: "May 30"
+  q2Start: "July 01"
+  q2End: "September 30"
+  q3Start: "October 01"
+  q3End: "December 31"

--- a/kubernetes/beta/hmda-platform/templates/deployment.yaml
+++ b/kubernetes/beta/hmda-platform/templates/deployment.yaml
@@ -42,24 +42,51 @@ spec:
             cpu: "2"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
-        - name: CURRENT_YEAR
-          value: "{{ .Values.current.year }}"
-        - name: RULES_YEARLY_FILING_YEARS_ALLOWED
-          value: "{{ .Values.rules.yearlyFilingYearsAllowed }}"
-        - name: RULES_QF_FILING_YEARS_ALLOWED
-          value: "{{ .Values.rules.quarterlyFilingYearsAllowed }}"
-        - name: RULES_QF_Q1_START
-          value: "{{ .Values.rules.q1Start }}"
-        - name: RULES_QF_Q1_END
-          value: "{{ .Values.rules.q1End }}"
-        - name: RULES_QF_Q2_START
-          value: "{{ .Values.rules.q2Start }}"
-        - name: RULES_QF_Q2_END
-          value: "{{ .Values.rules.q2End }}"
-        - name: RULES_QF_Q3_START
-          value: "{{ .Values.rules.q3Start }}"
-        - name: RULES_QF_Q3_END
-          value: "{{ .Values.rules.q3End }}"
+          - name: CURRENT_YEAR
+            valueFrom:
+              configMapKeyRef:
+                name: timed-guards
+                key: currentYear
+          - name: RULES_YEARLY_FILING_YEARS_ALLOWED
+            valueFrom:
+              configMapKeyRef:
+                name: timed-guards
+                key: yearsAllowed
+          - name: RULES_QF_FILING_YEARS_ALLOWED
+            valueFrom:
+              configMapKeyRef:
+                name: timed-guards
+                key: quarterlyYearsAllowed
+          - name: RULES_QF_Q1_START
+            valueFrom:
+              configMapKeyRef:
+                name: timed-guards
+                key: q1Start
+          - name: RULES_QF_Q1_END
+            valueFrom:
+              configMapKeyRef:
+                name: timed-guards
+                key: q1End
+          - name: RULES_QF_Q2_START
+            valueFrom:
+              configMapKeyRef:
+                name: timed-guards
+                key: q2Start
+          - name: RULES_QF_Q2_END
+            valueFrom:
+              configMapKeyRef:
+                name: timed-guards
+                key: q2End
+          - name: RULES_QF_Q3_START
+            valueFrom:
+              configMapKeyRef:
+                name: timed-guards
+                key: q3Start
+          - name: RULES_QF_Q3_END
+            valueFrom:
+              configMapKeyRef:
+                name: timed-guards
+                key: q3End
         - name: KAFKA_INSTITUTIONS_TOPIC
           value: {{.Values.kafka.institutionsTopic}}
         - name: KAFKA_SIGN_TOPIC

--- a/kubernetes/beta/hmda-platform/values.yaml
+++ b/kubernetes/beta/hmda-platform/values.yaml
@@ -32,18 +32,6 @@ kafka:
   analyticsTopic: beta-hmda-analytics
   signTopic: beta-hmda-sign
 
-rules:
-  yearlyFilingYearsAllowed: 2018,2019
-  quarterlyFilingYearsAllowed: 2020
-  q1Start: April 01
-  q1End: May 30
-  q2Start: July 01
-  q2End: September 30
-  q3Start: October 01
-  q3End: December 31
-
-current:
-  year: 2019
 
 service:
   type: ClusterIP

--- a/kubernetes/config-maps/timed-guards-configmap.yaml
+++ b/kubernetes/config-maps/timed-guards-configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: timed-guards
+data:
+  yearsAllowed: "2018"
+  currentYear: "2018"
+  quarterlyYearsAllowed: "2020"
+  q1Start: "April 01"
+  q1End: "May 30"
+  q2Start: "July 01"
+  q2End: "September 30"
+  q3Start: "October 01"
+  q3End: "December 31"

--- a/kubernetes/hmda-platform/templates/deployment.yaml
+++ b/kubernetes/hmda-platform/templates/deployment.yaml
@@ -40,23 +40,50 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         - name: CURRENT_YEAR
-          value: "{{ .Values.current.year }}"
+          valueFrom:
+            configMapKeyRef:
+              name: timed-guards
+              key: currentYear
         - name: RULES_YEARLY_FILING_YEARS_ALLOWED
-          value: "{{ .Values.rules.yearlyFilingYearsAllowed }}"
+          valueFrom:
+            configMapKeyRef:
+              name: timed-guards
+              key: yearsAllowed
         - name: RULES_QF_FILING_YEARS_ALLOWED
-          value: "{{ .Values.rules.quarterlyFilingYearsAllowed }}"
+          valueFrom:
+            configMapKeyRef:
+              name: timed-guards
+              key: quarterlyYearsAllowed
         - name: RULES_QF_Q1_START
-          value: "{{ .Values.rules.q1Start }}"
+          valueFrom:
+            configMapKeyRef:
+              name: timed-guards
+              key: q1Start
         - name: RULES_QF_Q1_END
-          value: "{{ .Values.rules.q1End }}"
+          valueFrom:
+            configMapKeyRef:
+              name: timed-guards
+              key: q1End
         - name: RULES_QF_Q2_START
-          value: "{{ .Values.rules.q2Start }}"
+          valueFrom:
+            configMapKeyRef:
+              name: timed-guards
+              key: q2Start
         - name: RULES_QF_Q2_END
-          value: "{{ .Values.rules.q2End }}"
+          valueFrom:
+            configMapKeyRef:
+              name: timed-guards
+              key: q2End
         - name: RULES_QF_Q3_START
-          value: "{{ .Values.rules.q3Start }}"
+          valueFrom:
+            configMapKeyRef:
+              name: timed-guards
+              key: q3Start
         - name: RULES_QF_Q3_END
-          value: "{{ .Values.rules.q3End }}"
+          valueFrom:
+            configMapKeyRef:
+              name: timed-guards
+              key: q3End
         - name: KAFKA_INSTITUTIONS_TOPIC
           value: {{.Values.kafka.institutionsTopic}}
         - name: KAFKA_SIGN_TOPIC

--- a/kubernetes/hmda-platform/values-dev.yaml
+++ b/kubernetes/hmda-platform/values-dev.yaml
@@ -33,20 +33,6 @@ kafka:
   signTopic: hmda-sign
   disclosureTopic: hmda-spark-disclosure
 
-rules:
-  yearlyFilingYearsAllowed: 2018
-  quarterlyFilingYearsAllowed: 2020
-  q1Start: April 01
-  q1End: May 30
-  q2Start: July 01
-  q2End: September 30
-  q3Start: October 01
-  q3End: December 31
-
-current:
-  year: 2018
-
-
 service:
   type: ClusterIP
   account:

--- a/kubernetes/hmda-platform/values.yaml
+++ b/kubernetes/hmda-platform/values.yaml
@@ -33,18 +33,6 @@ kafka:
   signTopic: hmda-sign
   disclosureTopic: hmda-spark-disclosure
 
-rules:
-  yearlyFilingYearsAllowed: 2018
-  quarterlyFilingYearsAllowed: 2020
-  q1Start: April 01
-  q1End: May 30
-  q2Start: July 01
-  q2End: September 30
-  q3Start: October 01
-  q3End: December 31
-
-current:
-  year: 2018
 
 service:
   type: ClusterIP


### PR DESCRIPTION
Closes #3305 

This PR:

1. Puts timed guards as configmaps
2. References timed guards configmaps from deployment yaml
3. Removes timed guards from values yaml

Configmaps are applied and can be applied as follows:

`kubectl apply -f kubernetes/config-maps/timed-guards-configmap.yaml` 

after the configmaps are changed, the platform would need to be rescaled for the changes to take affect. 