### PR TITLE
Allow signing submissions with no Q but M

### DIFF
--- a/hmda/src/main/scala/hmda/persistence/submission/HmdaValidationError.scala
+++ b/hmda/src/main/scala/hmda/persistence/submission/HmdaValidationError.scala
@@ -290,7 +290,7 @@ object HmdaValidationError
         if (state.statusCode == Verified.code) {
           val timestamp = Instant.now().toEpochMilli
           val signed    = SubmissionSigned(submissionId, timestamp, Signed)
-          if ((state.qualityVerified && state.macroVerified) || state.noEditsFound() || (state.qualityVerified && state.`macro`.isEmpty)) {
+          if ((state.qualityVerified && state.macroVerified) || state.noEditsFound() || (state.qualityVerified && state.`macro`.isEmpty) || (state.quality.isEmpty && state.macroVerified)) {
             Effect.persist(signed).thenRun { _ =>
               log.info(s"Submission $submissionId signed at ${Instant.ofEpochMilli(timestamp)}")
               updateSubmissionStatusAndReceipt(


### PR DESCRIPTION
closes #3325 

This PR allows for signing a submission that does not have quality errors but has macro errors. In this scenario the post to verify quality isn't required thats why at the time of signing we disregard this check.