### PR TITLE
[Dec 31] Frontend: Open and announce 2019 filing season

### DIFF
--- a/frontend/config.json
+++ b/frontend/config.json
@@ -1,20 +1,20 @@
 {
   "prod": {
-    "announcement": "On September 25th, 2019, the Bureau released the 2020 FIG and the Supplemental Guide for Quarterly Filers.",
-    "defaultPeriod": "2018",
-    "filingPeriods": ["2018"],
+    "announcement": "The filing period is open. March 1st, 2020 is the deadline to submit your HMDA data.",
+    "defaultPeriod": "2019",
+    "filingPeriods": ["2019", "2018"],
     "beta": {
-      "announcement": "On September 25th, 2019, the Bureau released the 2020 FIG and the Supplemental Guide for Quarterly Filers.",
+      "announcement": "The filing period is open. March 1st, 2020 is the deadline to submit your HMDA data.",
       "defaultPeriod": "2019",
       "filingPeriods": ["2019", "2018"]
     }
   },
   "dev": {
-    "announcement": "On September 25th, 2019, the Bureau released the 2020 FIG and the Supplemental Guide for Quarterly Filers.",
+    "announcement": "The filing period is open. March 1st, 2020 is the deadline to submit your HMDA data.",
     "defaultPeriod": "2019",
     "filingPeriods": ["2019", "2018"],
     "beta": {
-      "announcement": "On September 25th, 2019, the Bureau released the 2020 FIG and the Supplemental Guide for Quarterly Filers.",
+      "announcement": "The filing period is open. March 1st, 2020 is the deadline to submit your HMDA data.",
       "defaultPeriod": "2019",
       "filingPeriods": ["2019", "2018"]
     }


### PR DESCRIPTION
Closes https://github.com/cfpb/hmda-homepage/issues/113

## Changes
- Updated Homepage announcement text
- Added 2019 as default filing period
- Added 2019 as an available filing period

## Notes
This will not be needed if we move forward with `hmda-frontend` but this PR mirrors the proposed changes in https://github.com/cfpb/hmda-frontend/pull/51 just in case.