### PR TITLE
Transmittal sign date script

### DIFF
--- a/hmda-sql-doc/current-sign-date.sql
+++ b/hmda-sql-doc/current-sign-date.sql
@@ -1,12 +1,21 @@
--- get the most recent sign_date for every LEI by year 2019
-select max_signed.lei,max_signed.submission_id,max_signed.sign_date from (SELECT lei, submission_id, sign_date ,rank() OVER (PARTITION BY lei ORDER BY sign_date DESC) as number
-	FROM hmda_user.submission_history sub
-	where sub.submission_id like CONCAT('%',sub.lei,'-2019%') and sub.sign_date>0
-	group by lei ,submission_id
-	order by lei,number asc) max_signed where max_signed.number=1;
 -- get the most recent signdate for every LEI by year 2018
 select max_signed.lei,max_signed.submission_id,max_signed.sign_date from (SELECT lei, submission_id, sign_date ,rank() OVER (PARTITION BY lei ORDER BY sign_date DESC) as number
 	FROM hmda_user.submission_history sub
 	where sub.submission_id like CONCAT('%',sub.lei,'-2018%') and sub.sign_date>0
 	group by lei ,submission_id
 	order by lei,number asc) max_signed where max_signed.number=1;
+
+-- update transmittal sheet submission_id and sign_date where LEI matches on max sign date
+
+UPDATE hmda_user.ts2018_test dest
+SET  submission_id=src.submission_id,
+    sign_date=src.sign_date
+ FROM (
+select max_signed.lei,max_signed.submission_id,max_signed.sign_date from (SELECT lei, submission_id, sign_date ,rank() OVER (PARTITION BY lei ORDER BY sign_date DESC) as number
+	FROM hmda_user.submission_history sub
+	where sub.submission_id like CONCAT('%',sub.lei,'-2018%') and sub.sign_date>0
+	group by lei ,submission_id
+	order by lei,number asc) max_signed where max_signed.number=1
+
+) AS src
+WHERE dest.lei=src.lei;

--- a/hmda-sql-doc/current-sign-date.sql
+++ b/hmda-sql-doc/current-sign-date.sql
@@ -1,13 +1,12 @@
 -- get the most recent sign_date for every LEI by year 2019
-select max_signed.* from (SELECT lei, submission_id, sign_date ,rank() OVER (PARTITION BY lei ORDER BY sign_date DESC) as number
+select max_signed.lei,max_signed.submission_id,max_signed.sign_date from (SELECT lei, submission_id, sign_date ,rank() OVER (PARTITION BY lei ORDER BY sign_date DESC) as number
 	FROM hmda_user.submission_history sub
 	where sub.submission_id like CONCAT('%',sub.lei,'-2019%') and sub.sign_date>0
 	group by lei ,submission_id
 	order by lei,number asc) max_signed where max_signed.number=1;
-
--- get the most recent signdate for every LEI by year 2019
-select max_signed.* from (SELECT lei, submission_id, sign_date ,rank() OVER (PARTITION BY lei ORDER BY sign_date DESC) as number
-    	FROM hmda_user.submission_history sub
-    	where sub.submission_id like CONCAT('%',sub.lei,'-2018%') and sub.sign_date>0
-    	group by lei ,submission_id
-    	order by lei,number asc) max_signed where max_signed.number=1;
+-- get the most recent signdate for every LEI by year 2018
+select max_signed.lei,max_signed.submission_id,max_signed.sign_date from (SELECT lei, submission_id, sign_date ,rank() OVER (PARTITION BY lei ORDER BY sign_date DESC) as number
+	FROM hmda_user.submission_history sub
+	where sub.submission_id like CONCAT('%',sub.lei,'-2018%') and sub.sign_date>0
+	group by lei ,submission_id
+	order by lei,number asc) max_signed where max_signed.number=1;

--- a/hmda-sql-doc/current-sign-date.sql
+++ b/hmda-sql-doc/current-sign-date.sql
@@ -1,0 +1,13 @@
+-- get the most recent sign_date for every LEI by year 2019
+select max_signed.* from (SELECT lei, submission_id, sign_date ,rank() OVER (PARTITION BY lei ORDER BY sign_date DESC) as number
+	FROM hmda_user.submission_history sub
+	where sub.submission_id like CONCAT('%',sub.lei,'-2019%') and sub.sign_date>0
+	group by lei ,submission_id
+	order by lei,number asc) max_signed where max_signed.number=1;
+
+-- get the most recent signdate for every LEI by year 2019
+select max_signed.* from (SELECT lei, submission_id, sign_date ,rank() OVER (PARTITION BY lei ORDER BY sign_date DESC) as number
+    	FROM hmda_user.submission_history sub
+    	where sub.submission_id like CONCAT('%',sub.lei,'-2018%') and sub.sign_date>0
+    	group by lei ,submission_id
+    	order by lei,number asc) max_signed where max_signed.number=1;


### PR DESCRIPTION
closes #3366 


Created a select script to find the latest sign date for all leis in a given year . 

Using a backup of the transmittalsheet2018 table I executed an update script to  test an update to ensure the submission_id and sign_date were applied to the correct transmittal sheet row. 

When reviewing please confirm select logic for latest sign date is accurate/efficient. 
