### PR TITLE
 better conditions for the pipe removal logic

### DIFF
--- a/common/src/main/scala/hmda/parser/filing/lar/LarCsvParser.scala
+++ b/common/src/main/scala/hmda/parser/filing/lar/LarCsvParser.scala
@@ -9,7 +9,7 @@ object LarCsvParser extends ColumnDataFormatter {
   def apply(s: String, fromCassandra: Boolean = false): Either[List[ParserValidationError], LoanApplicationRegister] = {
 
     val controlCharsRemoved = controlCharacterFilter(s).trim()
-    val trailingPipeRemoved = removeTrailingPipe(controlCharsRemoved)
+    val trailingPipeRemoved = removeTrailingLARPipe(controlCharsRemoved)
     val cleanLarLine = removeBOM(trailingPipeRemoved)
     val values = cleanLarLine.trim.split('|').map(_.trim).toList
 

--- a/common/src/main/scala/hmda/parser/filing/ts/TsCsvParser.scala
+++ b/common/src/main/scala/hmda/parser/filing/ts/TsCsvParser.scala
@@ -2,14 +2,14 @@ package hmda.parser.filing.ts
 
 import hmda.model.filing.ts.TransmittalSheet
 import hmda.parser.ParserErrorModel.ParserValidationError
-import hmda.parser.filing.lar.LarCsvParser.{controlCharacterFilter, removeBOM, removeTrailingPipe}
 import hmda.parser.filing.ts.TsFormatValidator.validateTs
+import hmda.util.conversion.ColumnDataFormatter
 
-object TsCsvParser {
+object TsCsvParser  extends ColumnDataFormatter{
   def apply(s: String, fromCassandra: Boolean = false): Either[List[ParserValidationError], TransmittalSheet] = {
 
     val controlCharsRemoved = controlCharacterFilter(s).trim()
-    val trailingPipeRemoved = removeTrailingPipe(controlCharsRemoved)
+    val trailingPipeRemoved = removeTrailingTSPipe(controlCharsRemoved)
     val cleanTSLine = removeBOM(trailingPipeRemoved)
     val values = cleanTSLine.trim.split("\\|", -1).map(_.trim).toList
 

--- a/common/src/main/scala/hmda/util/conversion/ColumnDataFormatter.scala
+++ b/common/src/main/scala/hmda/util/conversion/ColumnDataFormatter.scala
@@ -7,17 +7,18 @@ import java.util.Date
 trait ColumnDataFormatter {
 
   private val dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS").withZone(ZoneId.systemDefault());
-  private val bomTypes = Seq("""\ufeff""","""ï»¿""","""\efbbbf""","""\ffe""");
+  private val bomTypes = Seq("""\ufeff""", """ï»¿""", """\efbbbf""", """\ffe""");
 
-  def dateToString(option:Option[Long] ): String =
-    if(option !=null) {
+  def dateToString(option: Option[Long]): String =
+    if (option != null) {
 
-      val epochLong = new Date(option.getOrElse(0L) )
-       val entryTime = dateFormatter.format(epochLong.toInstant)
+      val epochLong = new Date(option.getOrElse(0L))
+      val entryTime = dateFormatter.format(epochLong.toInstant)
       entryTime
-    }else{
+    } else {
       "NA"
     }
+
   def extractOpt(option: Option[Any]): Any =
     option.getOrElse("")
 
@@ -27,13 +28,21 @@ trait ColumnDataFormatter {
     } else {
       value
     }
-  def removeTrailingPipe(value: String): String =
-    if (!value.isEmpty && value.endsWith("|")) {
+
+  def removeTrailingLARPipe(value: String): String = {
+  if (!value.isEmpty && value.count(_ == '|') == 110 && value.endsWith("|")) {
+    value.init
+  } else {
+    value
+  }
+}
+  def removeTrailingTSPipe(value: String): String = {
+    if (!value.isEmpty && value.count(_ == '|') == 15 && value.endsWith("|")) {
       value.init
     } else {
       value
     }
-
+  }
   def removeBOM(value: String): String =
     if (!value.isEmpty && bomTypes.exists(value.contains(_)) ){
       bomTypes.foldLeft(value)((dataLine, str) => dataLine.replaceAll(str, ""))


### PR DESCRIPTION
closes #3374 

This check counts the number of valid `|` characters  to be found in TS and LAR rows. If there is more than one trailing pipe beyond the expected we can return it as a formatting error. 