### PR TITLE
Improvements to authentication

### DIFF
--- a/common/src/main/scala/hmda/auth/OAuth2Authorization.scala
+++ b/common/src/main/scala/hmda/auth/OAuth2Authorization.scala
@@ -30,7 +30,6 @@ class OAuth2Authorization(logger: LoggingAdapter, tokenVerifier: TokenVerifier) 
     }
 
   def authorizeTokenWithLei(lei: String): Directive1[VerifiedToken] = {
-    logger.info(s"Inside authorizeTokenWithLei for ${lei}")
     authorizeToken flatMap {
       case t if t.lei.nonEmpty =>
         if (runtimeMode == "dev") {
@@ -57,7 +56,6 @@ class OAuth2Authorization(logger: LoggingAdapter, tokenVerifier: TokenVerifier) 
 
 
   def authorizeToken: Directive1[VerifiedToken] = {
-    logger.info("Inside authorizeToken")
     bearerToken.flatMap {
       case Some(token) =>
         onComplete(tokenVerifier.verifyToken(token)).flatMap {
@@ -94,7 +92,6 @@ class OAuth2Authorization(logger: LoggingAdapter, tokenVerifier: TokenVerifier) 
   }
 
   private def bearerToken: Directive1[Option[String]] = {
-    logger.info("Getting bearerToken")
     for {
       authBearerHeader <- optionalHeaderValueByType(classOf[Authorization])
                            .map(extractBearerToken)

--- a/common/src/main/scala/hmda/auth/OAuth2Authorization.scala
+++ b/common/src/main/scala/hmda/auth/OAuth2Authorization.scala
@@ -25,8 +25,7 @@ class OAuth2Authorization(logger: LoggingAdapter, tokenVerifier: TokenVerifier) 
         if (runtimeMode == "dev") {
           provide(VerifiedToken())
         } else {
-          reject(AuthorizationFailedRejection)
-            .toDirective[Tuple1[VerifiedToken]]
+          complete(StatusCodes.Forbidden, ErrorResponse(StatusCodes.Forbidden.intValue, "Authorization Token could not be verified", Path(""))).toDirective[Tuple1[VerifiedToken]]
         }
     }
 
@@ -37,15 +36,12 @@ class OAuth2Authorization(logger: LoggingAdapter, tokenVerifier: TokenVerifier) 
         if (runtimeMode == "dev") {
           provide(t)
         } else {
-          logger.info(s"Got token back for ${lei}")
           val leiList = t.lei.split(',')
           if (leiList.contains(lei)) {
-            logger.info(s"Providing for ${lei}")
             provide(t)
           } else {
             logger.info(s"Providing reject for ${lei}")
-            reject(AuthorizationFailedRejection)
-              .toDirective[Tuple1[VerifiedToken]]
+            complete(StatusCodes.Forbidden, ErrorResponse(StatusCodes.Forbidden.intValue, "Authorization Token could not be verified", Path(""))).toDirective[Tuple1[VerifiedToken]]
           }
         }
 
@@ -53,9 +49,8 @@ class OAuth2Authorization(logger: LoggingAdapter, tokenVerifier: TokenVerifier) 
         if (runtimeMode == "dev") {
           provide(VerifiedToken())
         } else {
-          logger.error("Rejecting request in authorizeTokenWithLei")
-          reject(AuthorizationFailedRejection)
-            .toDirective[Tuple1[VerifiedToken]]
+          logger.info("Rejecting request in authorizeTokenWithLei")
+          complete(StatusCodes.Forbidden, ErrorResponse(StatusCodes.Forbidden.intValue, "Authorization Token could not be verified", Path(""))).toDirective[Tuple1[VerifiedToken]]
         }
     }
   }
@@ -85,8 +80,6 @@ class OAuth2Authorization(logger: LoggingAdapter, tokenVerifier: TokenVerifier) 
           }.recover {
             case ex: Throwable =>
               logger.error("Authorization Token could not be verified {}", ex)
-//              reject(AuthorizationFailedRejection)
-//                .toDirective[Tuple1[VerifiedToken]]
               complete(StatusCodes.Forbidden, ErrorResponse(StatusCodes.Forbidden.intValue, "Authorization Token could not be verified", Path(""))).toDirective[Tuple1[VerifiedToken]]
           }.get
         }
@@ -95,7 +88,6 @@ class OAuth2Authorization(logger: LoggingAdapter, tokenVerifier: TokenVerifier) 
           provide(VerifiedToken())
         } else {
           logger.error("No bearer token found")
-//          reject(AuthorizationFailedRejection)
           complete(StatusCodes.Forbidden, ErrorResponse(StatusCodes.Forbidden.intValue, "Authorization Token could not be verified", Path(""))).toDirective[Tuple1[VerifiedToken]]
         }
     }

--- a/common/src/main/scala/hmda/auth/OAuth2Authorization.scala
+++ b/common/src/main/scala/hmda/auth/OAuth2Authorization.scala
@@ -1,11 +1,14 @@
 package hmda.auth
 
 import akka.event.LoggingAdapter
-import akka.http.scaladsl.model.headers.{ Authorization, OAuth2BearerToken }
-import akka.http.scaladsl.server.Directives.{ reject, _ }
+import akka.http.scaladsl.model.Uri.Path
+import akka.http.scaladsl.model.{StatusCode, StatusCodes}
+import akka.http.scaladsl.model.headers.{Authorization, OAuth2BearerToken}
+import akka.http.scaladsl.server.Directives.{reject, _}
 import akka.http.scaladsl.server._
 import com.typesafe.config.ConfigFactory
-
+import hmda.api.http.model.ErrorResponse
+import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
 import scala.collection.JavaConverters._
 
 class OAuth2Authorization(logger: LoggingAdapter, tokenVerifier: TokenVerifier) {
@@ -27,16 +30,20 @@ class OAuth2Authorization(logger: LoggingAdapter, tokenVerifier: TokenVerifier) 
         }
     }
 
-  def authorizeTokenWithLei(lei: String): Directive1[VerifiedToken] =
+  def authorizeTokenWithLei(lei: String): Directive1[VerifiedToken] = {
+    logger.info(s"Inside authorizeTokenWithLei for ${lei}")
     authorizeToken flatMap {
       case t if t.lei.nonEmpty =>
         if (runtimeMode == "dev") {
           provide(t)
         } else {
+          logger.info(s"Got token back for ${lei}")
           val leiList = t.lei.split(',')
           if (leiList.contains(lei)) {
+            logger.info(s"Providing for ${lei}")
             provide(t)
           } else {
+            logger.info(s"Providing reject for ${lei}")
             reject(AuthorizationFailedRejection)
               .toDirective[Tuple1[VerifiedToken]]
           }
@@ -46,13 +53,16 @@ class OAuth2Authorization(logger: LoggingAdapter, tokenVerifier: TokenVerifier) 
         if (runtimeMode == "dev") {
           provide(VerifiedToken())
         } else {
+          logger.error("Rejecting request in authorizeTokenWithLei")
           reject(AuthorizationFailedRejection)
             .toDirective[Tuple1[VerifiedToken]]
         }
     }
+  }
 
 
-  def authorizeToken: Directive1[VerifiedToken] =
+  def authorizeToken: Directive1[VerifiedToken] = {
+    logger.info("Inside authorizeToken")
     bearerToken.flatMap {
       case Some(token) =>
         onComplete(tokenVerifier.verifyToken(token)).flatMap {
@@ -75,24 +85,30 @@ class OAuth2Authorization(logger: LoggingAdapter, tokenVerifier: TokenVerifier) 
           }.recover {
             case ex: Throwable =>
               logger.error("Authorization Token could not be verified {}", ex)
-              reject(AuthorizationFailedRejection)
-                .toDirective[Tuple1[VerifiedToken]]
+//              reject(AuthorizationFailedRejection)
+//                .toDirective[Tuple1[VerifiedToken]]
+              complete(StatusCodes.Forbidden, ErrorResponse(StatusCodes.Forbidden.intValue, "Authorization Token could not be verified", Path(""))).toDirective[Tuple1[VerifiedToken]]
           }.get
         }
       case None =>
         if (runtimeMode == "dev") {
           provide(VerifiedToken())
         } else {
-          reject(AuthorizationFailedRejection)
+          logger.error("No bearer token found")
+//          reject(AuthorizationFailedRejection)
+          complete(StatusCodes.Forbidden, ErrorResponse(StatusCodes.Forbidden.intValue, "Authorization Token could not be verified", Path(""))).toDirective[Tuple1[VerifiedToken]]
         }
     }
+  }
 
-  private def bearerToken: Directive1[Option[String]] =
+  private def bearerToken: Directive1[Option[String]] = {
+    logger.info("Getting bearerToken")
     for {
       authBearerHeader <- optionalHeaderValueByType(classOf[Authorization])
                            .map(extractBearerToken)
       xAuthCookie <- optionalCookie("X-Authorization-Token").map(_.map(_.value))
     } yield authBearerHeader.orElse(xAuthCookie)
+  }
 
   private def extractBearerToken(authHeader: Option[Authorization]): Option[String] =
     authHeader.collect {

--- a/hmda/src/main/scala/hmda/api/http/admin/InstitutionAdminHttpApi.scala
+++ b/hmda/src/main/scala/hmda/api/http/admin/InstitutionAdminHttpApi.scala
@@ -45,9 +45,9 @@ trait InstitutionAdminHttpApi extends HmdaTimeDirectives {
   val config        = ConfigFactory.load()
   val hmdaAdminRole = config.getString("keycloak.hmda.admin.role")
 
-  def institutionWritePath(oAuth2Authorization: OAuth2Authorization): Route =
-    oAuth2Authorization.authorizeTokenWithRole(hmdaAdminRole) { _ =>
-      path("institutions") {
+  def institutionWritePath(oAuth2Authorization: OAuth2Authorization): Route = {
+    path("institutions") {
+      oAuth2Authorization.authorizeTokenWithRole(hmdaAdminRole) { _ =>
         entity(as[Institution]) { institution =>
           timedPost { uri =>
             sanatizeInstitutionIdentifiers(institution, true, uri, postInstitution)
@@ -78,6 +78,7 @@ trait InstitutionAdminHttpApi extends HmdaTimeDirectives {
         }
       }
     }
+  }
 
   private def postInstitution(institution: Institution, uri: Uri): Route = {
     val institutionPersistence = InstitutionPersistence.selectInstitution(sharding, institution.LEI, institution.activityYear)
@@ -138,7 +139,7 @@ trait InstitutionAdminHttpApi extends HmdaTimeDirectives {
 
   // GET institutions/<lei>/year/<year>
   // GET institutions/<lei>/year/<year>/quarter/<quarter>
-  val institutionReadPath: Route =
+  val institutionReadPath: Route = {
     path("institutions" / Segment / "year" / IntNumber) { (lei, year) =>
       timedGet { uri =>
         getInstitution(lei, year, None, uri)
@@ -149,6 +150,7 @@ trait InstitutionAdminHttpApi extends HmdaTimeDirectives {
           }
         }
     }
+  }
 
   private def getInstitution(lei: String, year: Int, quarter: Option[String], uri: Uri): Route = {
     val institutionPersistence                    = selectInstitution(sharding, lei, year)
@@ -192,7 +194,7 @@ trait InstitutionAdminHttpApi extends HmdaTimeDirectives {
   }
 
 
-  def institutionAdminRoutes(oAuth2Authorization: OAuth2Authorization): Route =
+  def institutionAdminRoutes(oAuth2Authorization: OAuth2Authorization): Route = {
     handleRejections(corsRejectionHandler) {
       cors() {
         encodeResponse {
@@ -200,4 +202,5 @@ trait InstitutionAdminHttpApi extends HmdaTimeDirectives {
         }
       }
     }
+  }
 }

--- a/hmda/src/main/scala/hmda/api/http/filing/submissions/SignHttpApi.scala
+++ b/hmda/src/main/scala/hmda/api/http/filing/submissions/SignHttpApi.scala
@@ -50,6 +50,7 @@ trait SignHttpApi extends HmdaTimeDirectives with QuarterlyFilingAuthorization {
           timedGet { uri =>
             getSubmissionForSigning(lei, year, None, seqNr, token.email, uri)
           } ~ timedPost { uri =>
+            log.info("Entered in sign post")
             respondWithHeader(RawHeader("Cache-Control", "no-cache")) {
               entity(as[EditsSign]) { editsSign =>
                 signSubmission(lei, year, None, seqNr, token.email, editsSign.signed, uri)
@@ -57,12 +58,12 @@ trait SignHttpApi extends HmdaTimeDirectives with QuarterlyFilingAuthorization {
             }
           }
         } ~ pathPrefix("quarter" / Quarter / "submissions" / IntNumber / "sign") { (quarter, seqNr) =>
-          oAuth2Authorization.authorizeTokenWithLei(lei) { token =>
             timedGet { uri =>
               quarterlyFilingAllowed(lei, year) {
                 getSubmissionForSigning(lei, year, Option(quarter), seqNr, token.email, uri)
               }
             } ~ timedPost { uri =>
+              log.info("Entered in Quarter Post")
               respondWithHeader(RawHeader("Cache-Control", "no-cache")) {
                 entity(as[EditsSign]) { editsSign =>
                   quarterlyFilingAllowed(lei, year) {
@@ -71,7 +72,6 @@ trait SignHttpApi extends HmdaTimeDirectives with QuarterlyFilingAuthorization {
                 }
               }
             }
-          }
         }
       }
     }
@@ -102,22 +102,27 @@ trait SignHttpApi extends HmdaTimeDirectives with QuarterlyFilingAuthorization {
     signed: Boolean,
     uri: Uri
   ): Route = {
+    log.info("entered in signSubmission")
     val submissionId = SubmissionId(lei, Period(year, quarter), seqNr)
     if (!signed) badRequest(submissionId, uri, "Illegal argument: signed = false")
     else {
+      log.info("entered in signSubmission else")
       val hmdaValidationError                    = selectHmdaValidationError(sharding, submissionId)
       val fSigned: Future[SubmissionSignedEvent] = hmdaValidationError ? (ref => SignSubmission(submissionId, ref, email))
       onComplete(fSigned) {
         case Failure(e) =>
+          log.info(s"Entered in failure: ${e}" )
           failedResponse(StatusCodes.InternalServerError, uri, e)
 
         case Success(submissionSignedEvent) =>
           submissionSignedEvent match {
             case signed @ SubmissionSigned(_, _, status) =>
+              log.info("entered in signed signSubmission")
               val signedResponse = SignedResponse(email, signed.timestamp, signed.receipt, status)
               complete(ToResponseMarshallable(signedResponse))
 
             case SubmissionNotReadyToBeSigned(id) =>
+              log.info("Entered in badRequest signSubmission")
               badRequest(id, uri, s"Submission $id is not ready to be signed")
           }
       }
@@ -128,6 +133,7 @@ trait SignHttpApi extends HmdaTimeDirectives with QuarterlyFilingAuthorization {
     handleRejections(corsRejectionHandler) {
       cors() {
         encodeResponse {
+          log.info("Entered in Sign path")
           signPath(oAuth2Authorization)
         }
       }

--- a/hmda/src/main/scala/hmda/api/http/filing/submissions/UploadHttpApi.scala
+++ b/hmda/src/main/scala/hmda/api/http/filing/submissions/UploadHttpApi.scala
@@ -121,8 +121,8 @@ trait UploadHttpApi extends HmdaTimeDirectives with QuarterlyFilingAuthorization
           .runWith(Sink.ignore)
 
         fUploaded.onComplete{
-          case Success(_) => log.info(s"File uploaded completed for ${submission.id}")
-          case Failure(ex) => log.error(s"File upload FAILED for ${submission.id}", ex)
+          case Success(_) => log.info(s"File upload completed for ${submission.id}")
+          case Failure(ex) => log.error(s"File upload failed for ${submission.id}", ex)
         }
 
         onComplete(fUploaded) {

--- a/hmda/src/main/scala/hmda/api/http/filing/submissions/UploadHttpApi.scala
+++ b/hmda/src/main/scala/hmda/api/http/filing/submissions/UploadHttpApi.scala
@@ -121,8 +121,8 @@ trait UploadHttpApi extends HmdaTimeDirectives with QuarterlyFilingAuthorization
           .runWith(Sink.ignore)
 
         fUploaded.onComplete{
-          case Success(_) => log.info(s"File uploaded for ${submission.id} completed")
-          case Failure(ex) => log.error(s"File uploaded for ${submission.id} failed", ex)
+          case Success(_) => log.info(s"File uploaded completed for ${submission.id}")
+          case Failure(ex) => log.error(s"File upload FAILED for ${submission.id}", ex)
         }
 
         onComplete(fUploaded) {

--- a/hmda/src/main/scala/hmda/api/http/filing/submissions/UploadHttpApi.scala
+++ b/hmda/src/main/scala/hmda/api/http/filing/submissions/UploadHttpApi.scala
@@ -120,6 +120,11 @@ trait UploadHttpApi extends HmdaTimeDirectives with QuarterlyFilingAuthorization
           .via(uploadFile(submission.id, hmdaRaw))
           .runWith(Sink.ignore)
 
+        fUploaded.onComplete{
+          case Success(_) => log.info(s"File uploaded for ${submission.id} completed")
+          case Failure(ex) => log.error(s"File uploaded for ${submission.id} failed", ex)
+        }
+
         onComplete(fUploaded) {
           case Success(_) =>
             val fileName = metadata.fileName


### PR DESCRIPTION
This PR does three things

1. Shows a log message when the file is fully received by the backend. Shows an error message "Entity stream truncation" along with submission-id when the file upload fails because of network error or user related error

2. Removed `reject` when authorization fails but instead sends a `403` complete. A way to test this would be to intentionally pass an incorrect authentication token and notice that the response back is a `403` as opposed to a `405`. 

3. Removes redundant `authorizeTokenWithLei` from SignHttpApi. This _could_ have been the reason for https://github.com/cfpb/hmda-frontend/issues/83