### PR TITLE
Throw parsing error for LEI and/or ULI with space in it

### DIFF
--- a/common/src/main/resources/parserFieldValidValues.txt
+++ b/common/src/main/resources/parserFieldValidValues.txt
@@ -1,3 +1,5 @@
+LEI|String with no space
+ULI|String with no space
 LAR Record Identifier|Integer: 2
 Application Date|Integer or NA
 Loan Type|Integer: 1, 2, 3, 4

--- a/common/src/main/resources/parserFieldValidValues.txt
+++ b/common/src/main/resources/parserFieldValidValues.txt
@@ -1,5 +1,5 @@
-LEI|String with no space
-ULI|String with no space
+LEI|String with only letters and numbers
+ULI|String with only letters and numbers
 LAR Record Identifier|Integer: 2
 Application Date|Integer or NA
 Loan Type|Integer: 1, 2, 3, 4

--- a/common/src/main/scala/hmda/model/filing/ParserValidValuesLookup.scala
+++ b/common/src/main/scala/hmda/model/filing/ParserValidValuesLookup.scala
@@ -12,7 +12,6 @@ object ParserValidValuesLookup {
   def parserValidValuesMapCreator(
       file: Iterable[String]): Map[String, String] = {
     file
-      .drop(1)
       .map { s =>
         val values = s.split("\\|", -1).map(_.trim).toList
         val fieldName = values(0)

--- a/common/src/main/scala/hmda/parser/filing/lar/LarFormatValidator.scala
+++ b/common/src/main/scala/hmda/parser/filing/lar/LarFormatValidator.scala
@@ -482,7 +482,7 @@ sealed trait LarFormatValidator extends LarParser {
   ): LarParserValidationResult[LarIdentifier] =
     (
       validateIntField(id, InvalidLarId(id)),
-      validateStr(LEI),
+      validateStrNoSpace(LEI, InvalidLei(LEI)),
       validateStr(NMLSRIdentifier)
     ).mapN(LarIdentifier.apply)
 
@@ -503,7 +503,7 @@ sealed trait LarFormatValidator extends LarParser {
     introductoryRate: String
   ): LarParserValidationResult[Loan] =
     (
-      validateStr(uli),
+      validateStrNoSpace(uli, InvalidULI(uli)),
       validateIntStrOrNAField(applicationDate,
                               InvalidApplicationDate(applicationDate)),
       validateLarCode(LoanTypeEnum, loanType, InvalidLoanType(loanType)),

--- a/common/src/main/scala/hmda/parser/filing/lar/LarParser.scala
+++ b/common/src/main/scala/hmda/parser/filing/lar/LarParser.scala
@@ -23,10 +23,10 @@ trait LarParser {
     }
 
   def validateStrNoSpace(value: String, parserValidationError: ParserValidationError): LarParserValidationResult[String] =
-    if (!value.contains(" "))
-      value.validNel
-    else
+    if (value.contains(" ") || value.contains("|") || value.contains(","))
       parserValidationError.invalidNel
+    else
+      value.validNel
 
   def validateIntStrOrNAField(value: String, parserValidationError: ParserValidationError): LarParserValidationResult[String] =
     if (value == "") {

--- a/common/src/main/scala/hmda/parser/filing/lar/LarParser.scala
+++ b/common/src/main/scala/hmda/parser/filing/lar/LarParser.scala
@@ -22,6 +22,12 @@ trait LarParser {
       case Failure(_) => parserValidationError.invalidNel
     }
 
+  def validateStrNoSpace(value: String, parserValidationError: ParserValidationError): LarParserValidationResult[String] =
+    if (!value.contains(" "))
+      value.validNel
+    else
+      parserValidationError.invalidNel
+
   def validateIntStrOrNAField(value: String, parserValidationError: ParserValidationError): LarParserValidationResult[String] =
     if (value == "") {
       parserValidationError.invalidNel
@@ -72,6 +78,7 @@ trait LarParser {
     } else {
       validateDoubleField(value, parserValidationError).map(x => x.toString)
     }
+
 
   def validateStr(str: String): LarParserValidationResult[String] =
     str.validNel

--- a/common/src/main/scala/hmda/parser/filing/lar/LarParserErrorModel.scala
+++ b/common/src/main/scala/hmda/parser/filing/lar/LarParserErrorModel.scala
@@ -4,6 +4,16 @@ import hmda.parser.ParserErrorModel._
 
 object LarParserErrorModel {
 
+  case class InvalidLei(value: String) extends ParserValidationError {
+    override def fieldName: String = "LEI"
+    override def inputValue: String = value
+  }
+
+  case class InvalidULI(value: String) extends ParserValidationError {
+    override def fieldName: String = "ULI"
+    override def inputValue: String = value
+  }
+
   case class InvalidLarId(value: String) extends ParserValidationError {
     override def fieldName: String = "LAR Record Identifier"
     override def inputValue: String = value


### PR DESCRIPTION
Closes #3407 

This is how the parserError json will respond after this PR

```
    "larErrors": [
        {
            "rowNumber": 2,
            "estimatedULI": "2 Y9CEMKWIJCYXQ2T4ZRWGY",
            "errorMessages": [
                {
                    "fieldName": "LEI",
                    "inputValue": "BANK1LEIFORTES T12345",
                    "validValues": "String with no space"
                },
                {
                    "fieldName": "ULI",
                    "inputValue": "2 Y9CEMKWIJCYXQ2T4ZRWGY",
                    "validValues": "String with no space"
                },
                {
                    "fieldName": "Loan Type",
                    "inputValue": "S",
                    "validValues": "Integer: 1, 2, 3, 4"
                }
            ]
        }
    ],
```