### PR TITLE
change pod-reader name

### DIFF
--- a/kubernetes/beta/hmda-platform/Chart.yaml
+++ b/kubernetes/beta/hmda-platform/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 appVersion: "2.7.2"
 description: Home Mortgage Disclosure Act (HMDA) Platform
-name: hmda-platform
+name: hmda-platform-beta
 version: 2.7.2

--- a/kubernetes/beta/hmda-platform/templates/clusterrole.yaml
+++ b/kubernetes/beta/hmda-platform/templates/clusterrole.yaml
@@ -2,7 +2,7 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   namespace: beta
-  name: pod-reader
+  name: pod-reader-beta
 rules:
   - apiGroups: [""] # "" indicates the core API group
     resources: ["pods"]

--- a/kubernetes/beta/hmda-platform/templates/clusterrolebinding.yaml
+++ b/kubernetes/beta/hmda-platform/templates/clusterrolebinding.yaml
@@ -1,7 +1,7 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: pod-reader-binding
+  name: pod-reader-binding-beta
   namespace: beta
 subjects:
   - kind: ServiceAccount
@@ -9,5 +9,6 @@ subjects:
     namespace: beta
 roleRef:
   kind: ClusterRole
-  name: pod-reader
+  name: pod-reader-beta
+  namespace: beta
   apiGroup: rbac.authorization.k8s.io

--- a/kubernetes/beta/hmda-platform/templates/service.yaml
+++ b/kubernetes/beta/hmda-platform/templates/service.yaml
@@ -1,7 +1,7 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: hmda-bootstrap
+  name: hmda-bootstrap-beta
 spec:
   # by setting the clusterIp to None we are a "headless service"
   # and thus the svc ("service") DNS record for the single IP but the IPs of all nodes that we select
@@ -32,7 +32,7 @@ metadata:
   name: {{ .Values.service.name }}
 spec:
   selector:
-    app: hmda-platform
+    app: hmda-platform-beta
   type: ClusterIP
   ports:
   - name: {{ .Values.filing.name }}

--- a/kubernetes/beta/hmda-platform/values.yaml
+++ b/kubernetes/beta/hmda-platform/values.yaml
@@ -37,7 +37,7 @@ service:
   type: ClusterIP
   account:
     name: hmda-service-account-beta
-  name: hmda-platform
+  name: hmda-platform-beta
 
 #ambassador:
 #  port: 80


### PR DESCRIPTION
closes #3483 

After this PR, each time the platform is deployed to default or beta the following two rules will always respond in `yes`

```
$ kubectl auth can-i list pods --as=system:serviceaccount:beta:hmda-service-account-beta -n beta
$ yes
$ kubectl auth can-i list pods --as=system:serviceaccount:default:hmda-service-account-default -n default
$ yes
```


