### PR TITLE
header files should be in a header object

### DIFF
--- a/modified-lar/src/main/scala/hmda/publication/lar/publication/ModifiedLarPublisher.scala
+++ b/modified-lar/src/main/scala/hmda/publication/lar/publication/ModifiedLarPublisher.scala
@@ -102,7 +102,7 @@ object ModifiedLarPublisher {
 
           val s3SinkWithHeader = S3
             .multipartUpload(bucket,
-              s"$environment/modified-lar/$filingPeriod/$fileNameHeader",
+              s"$environment/modified-lar/$filingPeriod/header/$fileNameHeader",
               metaHeaders = MetaHeaders(metaHeaders))
             .withAttributes(S3Attributes.settings(s3Settings))
 


### PR DESCRIPTION
Modified lars with header should be going to a separate object with prefix `header`
related to https://github.com/cfpb/hmda-platform/pull/3489