### PR TITLE
q627 fix number format

### DIFF
--- a/hmda/src/main/scala/hmda/validation/filing/ValidationFlow.scala
+++ b/hmda/src/main/scala/hmda/validation/filing/ValidationFlow.scala
@@ -18,11 +18,13 @@ import hmda.validation.context.ValidationContext
 import hmda.util.streams.FlowUtils._
 import hmda.utils.YearUtils.Period
 import hmda.validation.engine._
+import hmda.util.conversion.ColumnDataFormatter
+
 
 import scala.collection.immutable._
 import scala.concurrent.Future
 
-object ValidationFlow {
+object ValidationFlow extends ColumnDataFormatter{
 
   implicit val larSemigroup = new Semigroup[LoanApplicationRegister] {
     override def combine(x: LoanApplicationRegister, y: LoanApplicationRegister): LoanApplicationRegister =
@@ -141,7 +143,7 @@ object ValidationFlow {
   def addLarFieldInformation(lar: LoanApplicationRegister, errors: List[ValidationError], period: Period): List[ValidationError] =
     errors.map(error => {
       val affectedFields = EditDescriptionLookup.lookupFields(error.editName, period)
-      val fieldMap = ListMap(affectedFields.map(field => (field, lar.valueOf(field))): _*)
+      val fieldMap = ListMap(affectedFields.map(field => (field, if(field == "Loan Amount") toBigDecimalString(lar.valueOf(field)) else lar.valueOf(field))): _*)
       error.copyWithFields(fieldMap)
     })
 


### PR DESCRIPTION
Closes #3573. Fixing number format to not be in scientific notation. 

<img width="217" alt="Screen Shot 2020-03-30 at 2 57 00 PM" src="https://user-images.githubusercontent.com/34528865/77950609-bb39a700-7296-11ea-98ba-f92c2b30711b.png">
