### PR TITLE
Update the docker image for platform services to JDK  14.0.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,7 @@ lazy val slickDeps = Seq(slick, slickHikaryCP, postgres, h2)
 
 lazy val dockerSettings = Seq(
   Docker / maintainer := "Hmda-Ops",
-  dockerBaseImage := "openjdk:14-jdk-slim",
+  dockerBaseImage := "openjdk:14.0.1-jdk-slim",
   dockerRepository := Some("hmda")
 )
 


### PR DESCRIPTION
closes #[dev-ops-1801](https://github.cfpb.gov/HMDA-Operations/hmda-devops/issues/1801)