### PR TITLE
Grab common jquery

### DIFF
--- a/kubernetes/keycloak/theme-provider/themes/hmda/login/template.ftl
+++ b/kubernetes/keycloak/theme-provider/themes/hmda/login/template.ftl
@@ -29,6 +29,7 @@
             <script src="${script}" type="text/javascript"></script>
         </#list>
     </#if>
+    <script src="${resourceCommonUrl}/node_modules/jquery/dist/jquery.min.js" type="text/javascript"></script>
     <!-- Google Tag Manager -->
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],

--- a/kubernetes/keycloak/theme-provider/themes/hmda/login/template.ftl
+++ b/kubernetes/keycloak/theme-provider/themes/hmda/login/template.ftl
@@ -29,7 +29,7 @@
             <script src="${script}" type="text/javascript"></script>
         </#list>
     </#if>
-    <script src="${resourceCommonUrl}/node_modules/jquery/dist/jquery.min.js" type="text/javascript"></script>
+    <script src="${url.resourcesCommonPath}/node_modules/jquery/dist/jquery.min.js" type="text/javascript"></script>
     <!-- Google Tag Manager -->
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],

--- a/kubernetes/keycloak/theme-provider/themes/hmda/login/theme.properties
+++ b/kubernetes/keycloak/theme-provider/themes/hmda/login/theme.properties
@@ -1,5 +1,4 @@
 parent=keycloak
-scripts=common/keycloak/node_modules/jquery/dist/jquery.min.js
 styles=css/uswds.min.css css/hmda.css
 
 # WARNING: These placeholders are overridden on container startup.  Do not commit overridden values.

--- a/kubernetes/keycloak/theme-provider/themes/hmda/login/theme.properties
+++ b/kubernetes/keycloak/theme-provider/themes/hmda/login/theme.properties
@@ -1,5 +1,5 @@
 parent=keycloak
-scripts=node_modules/jquery/dist/jquery.min.js
+scripts=common/keycloak/node_modules/jquery/dist/jquery.min.js
 styles=css/uswds.min.css css/hmda.css
 
 # WARNING: These placeholders are overridden on container startup.  Do not commit overridden values.

--- a/kubernetes/keycloak/values.yaml
+++ b/kubernetes/keycloak/values.yaml
@@ -9,7 +9,7 @@ keycloak:
 
   image:
     repository: jboss/keycloak
-    tag: 10.0.1
+    tag: 11.0.0
     pullPolicy: Always
 
     ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
Alternative to https://github.com/cfpb/hmda-platform/pull/3789

Haven't tested if this will resolve correctly 😅 but jquery does still exist in keycloak, just in a slightly different place, namely
<dev>/auth/resources/shnaj/common/keycloak/node_modules/jquery/dist/jquery.min.js

Might require some relative path shenanigans to get keycloak to resolve this correctly, but I think this is probably the preferred solution to the CDN so we don't have to worry about script order, etc.