### PR TITLE
Fix platform cluster forming

### DIFF
--- a/hmda/src/main/resources/application-kubernetes.conf
+++ b/hmda/src/main/resources/application-kubernetes.conf
@@ -5,19 +5,28 @@ include "cors.conf"
 akka {
 
   remote {
-    artery {
-      transport = tcp
-      canonical.port = 0 //https://discuss.lightbend.com/t/scalatestroutetest-and-artery-bindexception/5838/2
-      canonical.port = 2551
-      canonical.port = ${?APP_PORT}
-      canonical.hostname = "127.0.0.1"
-      large-message-destinations = ["/temp/*"]
-      advanced {
-        maximum-frame-size = 30000000b
-        maximum-large-frame-size = 30000000b
-      }
+    maximum-payload-bytes = 30000000 bytes
+    netty.tcp {
+      message-frame-size =  30000000b
+      send-buffer-size =  30000000b
+      receive-buffer-size =  30000000b
+      maximum-frame-size = 30000000b
     }
   }
+
+//  remote {
+//    artery {
+//      transport = tcp
+//      canonical.port = 0 //https://discuss.lightbend.com/t/scalatestroutetest-and-artery-bindexception/5838/2
+//      canonical.port = ${?APP_PORT}
+//      canonical.hostname = "127.0.0.1"
+//      large-message-destinations = ["/temp/*"]
+//      advanced {
+//        maximum-frame-size = 30000000b
+//        maximum-large-frame-size = 30000000b
+//      }
+//    }
+//  }
 
 
 

--- a/hmda/src/main/resources/application-kubernetes.conf
+++ b/hmda/src/main/resources/application-kubernetes.conf
@@ -14,22 +14,6 @@ akka {
     }
   }
 
-//  remote {
-//    artery {
-//      transport = tcp
-//      canonical.port = 0 //https://discuss.lightbend.com/t/scalatestroutetest-and-artery-bindexception/5838/2
-//      canonical.port = ${?APP_PORT}
-//      canonical.hostname = "127.0.0.1"
-//      large-message-destinations = ["/temp/*"]
-//      advanced {
-//        maximum-frame-size = 30000000b
-//        maximum-large-frame-size = 30000000b
-//      }
-//    }
-//  }
-
-
-
   diagnostics {
     starvation-detector {
       check-interval = 1s

--- a/hmda/src/main/resources/application-kubernetes.conf
+++ b/hmda/src/main/resources/application-kubernetes.conf
@@ -4,29 +4,29 @@ include "cors.conf"
 
 akka {
 
-//  remote {
-//    maximum-payload-bytes = 30000000 bytes
-//    netty.tcp {
-//      message-frame-size =  30000000b
-//      send-buffer-size =  30000000b
-//      receive-buffer-size =  30000000b
-//      maximum-frame-size = 30000000b
-//    }
-//  }
-
   remote {
-    artery {
-      transport = tcp
-      canonical.port = 0 //https://discuss.lightbend.com/t/scalatestroutetest-and-artery-bindexception/5838/2
-      canonical.port = ${?APP_PORT}
-      canonical.hostname = ${HOSTNAME}
-      large-message-destinations = ["/temp/*"]
+    maximum-payload-bytes = 30000000 bytes
+    netty.tcp {
+      message-frame-size =  30000000b
+      send-buffer-size =  30000000b
+      receive-buffer-size =  30000000b
+      maximum-frame-size = 30000000b
+    }
+  }
+
+//  remote {
+//    artery {
+//      transport = tcp
+//      canonical.port = 0 //https://discuss.lightbend.com/t/scalatestroutetest-and-artery-bindexception/5838/2
+//      canonical.port = ${?APP_PORT}
+//      canonical.hostname = "127.0.0.1"
+//      large-message-destinations = ["/temp/*"]
 //      advanced {
 //        maximum-frame-size = 30000000b
 //        maximum-large-frame-size = 30000000b
 //      }
-    }
-  }
+//    }
+//  }
 
 
 

--- a/hmda/src/main/resources/application-kubernetes.conf
+++ b/hmda/src/main/resources/application-kubernetes.conf
@@ -4,29 +4,29 @@ include "cors.conf"
 
 akka {
 
-  remote {
-    maximum-payload-bytes = 30000000 bytes
-    netty.tcp {
-      message-frame-size =  30000000b
-      send-buffer-size =  30000000b
-      receive-buffer-size =  30000000b
-      maximum-frame-size = 30000000b
-    }
-  }
-
 //  remote {
-//    artery {
-//      transport = tcp
-//      canonical.port = 0 //https://discuss.lightbend.com/t/scalatestroutetest-and-artery-bindexception/5838/2
-//      canonical.port = ${?APP_PORT}
-//      canonical.hostname = "127.0.0.1"
-//      large-message-destinations = ["/temp/*"]
+//    maximum-payload-bytes = 30000000 bytes
+//    netty.tcp {
+//      message-frame-size =  30000000b
+//      send-buffer-size =  30000000b
+//      receive-buffer-size =  30000000b
+//      maximum-frame-size = 30000000b
+//    }
+//  }
+
+  remote {
+    artery {
+      transport = tcp
+      canonical.port = 0 //https://discuss.lightbend.com/t/scalatestroutetest-and-artery-bindexception/5838/2
+      canonical.port = ${?APP_PORT}
+      canonical.hostname = ${HOSTNAME}
+      large-message-destinations = ["/temp/*"]
 //      advanced {
 //        maximum-frame-size = 30000000b
 //        maximum-large-frame-size = 30000000b
 //      }
-//    }
-//  }
+    }
+  }
 
 
 

--- a/hmda/src/main/resources/application-kubernetes.conf
+++ b/hmda/src/main/resources/application-kubernetes.conf
@@ -5,14 +5,19 @@ include "cors.conf"
 akka {
 
   remote {
-    maximum-payload-bytes = 30000000 bytes
-    netty.tcp {
-      message-frame-size =  30000000b
-      send-buffer-size =  30000000b
-      receive-buffer-size =  30000000b
-      maximum-frame-size = 30000000b
+    artery {
+      transport = tcp
+      canonical.port = 0 //https://discuss.lightbend.com/t/scalatestroutetest-and-artery-bindexception/5838/2
+      // canonical.hostname = ${HOSTNAME} // pick default which is InetAddress.getLocalHost.getHostAddress
+      large-message-destinations = ["/temp/*"]
+      advanced {
+        maximum-frame-size = 30000000b
+        maximum-large-frame-size = 30000000b
+      }
     }
   }
+
+
 
   diagnostics {
     starvation-detector {

--- a/hmda/src/main/resources/application.conf
+++ b/hmda/src/main/resources/application.conf
@@ -78,7 +78,6 @@ akka {
   remote.artery {
     transport = tcp
     canonical.port = 0 //https://discuss.lightbend.com/t/scalatestroutetest-and-artery-bindexception/5838/2
-    canonical.port = 2551
     canonical.port = ${?APP_PORT}
     canonical.hostname = "127.0.0.1"
     maximum-frame-size = 30000000b

--- a/hmda/src/main/scala/hmda/HmdaPlatform.scala
+++ b/hmda/src/main/scala/hmda/HmdaPlatform.scala
@@ -1,8 +1,10 @@
 package hmda
 
+import java.net.InetAddress
+
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.scaladsl.adapter._
-import akka.actor.{ ActorSystem => ClassicActorSystem }
+import akka.actor.{ActorSystem => ClassicActorSystem}
 import akka.cluster.typed.Cluster
 import akka.management.cluster.bootstrap.ClusterBootstrap
 import akka.management.scaladsl.AkkaManagement
@@ -11,9 +13,9 @@ import com.typesafe.config.ConfigFactory
 import hmda.api.HmdaApi
 import hmda.persistence.HmdaPersistence
 import hmda.persistence.util.CassandraUtil
-import hmda.publication.{ HmdaPublication, KafkaUtils }
+import hmda.publication.{HmdaPublication, KafkaUtils}
 import hmda.validation.HmdaValidation
-import net.manub.embeddedkafka.{ EmbeddedKafka, EmbeddedKafkaConfig }
+import net.manub.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig}
 import org.slf4j.LoggerFactory
 
 // $COVERAGE-OFF$
@@ -52,6 +54,7 @@ object HmdaPlatform extends App {
 
     case "kubernetes" =>
       log.info(s"HOSTNAME: ${System.getenv("HOSTNAME")}")
+      log.info(s"HOSTADDRESS: " + InetAddress.getLocalHost().getHostAddress())
       ConfigFactory.parseResources("application-kubernetes.conf").resolve()
 
     case "dcos" =>


### PR DESCRIPTION
closes #3799 

This PR `canonical.hostname` so that the default is picked up. The default is [getHostAddress](https://github.com/akka/akka/blob/996f42483523093323c9d30cb41a6005adc38558/akka-remote/src/main/resources/reference.conf#L768) which is an actual IP address of the pod.