### PR TITLE
Institutions API port configuration

### DIFF
--- a/institutions-api/src/main/resources/application.conf
+++ b/institutions-api/src/main/resources/application.conf
@@ -22,6 +22,7 @@ hmda {
     http {
       host = "0.0.0.0"
       port = 9092
+      port = ${?INSTITUTION_PORT}
       timeout = 5000
     }
   }


### PR DESCRIPTION
Closes #3868

Modify listening port by setting the INSTITUTION_PORT=\<PORT> environment variable.