### PR TITLE
add endpoints. add retry. stop generating quarter after 8 days

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -204,7 +204,7 @@ lazy val `hmda-data-publisher` = (project in file("hmda-data-publisher"))
   .settings(hmdaBuildSettings: _*)
   .settings(
     Seq(
-      libraryDependencies ++= commonDeps ++ akkaDeps ++ akkaHttpDeps ++ circeDeps ++ slickDeps,
+      libraryDependencies ++= commonDeps ++ akkaDeps ++ akkaHttpDeps ++ circeDeps ++ slickDeps ++ enumeratumDeps,
       mainClass in Compile := Some("hmda.publisher.HmdaDataPublisherApp"),
       assemblyJarName in assembly := {
         s"${name.value}.jar"

--- a/hmda-data-publisher/src/main/resources/application.conf
+++ b/hmda-data-publisher/src/main/resources/application.conf
@@ -80,8 +80,16 @@ hmda {
       port = ${?GRPC_REGULATOR_PORT}
     }
   }
-  publisher.validation.reportingUrl = ""
-  publisher.validation.reportingUrl = ${?VALIDATION_REPORTING_URL}
+  publisher {
+    http {
+      host = "0.0.0.0"
+      host = ${?HTTP_REGULATOR_HOST}
+      port = "9190"
+      port = ${?HTTP_REGULATOR_PORT}
+    }
+    validation.reportingUrl = ""
+    validation.reportingUrl = ${?VALIDATION_REPORTING_URL}
+  }
 }
 
 private-aws {

--- a/hmda-data-publisher/src/main/scala/hmda/publisher/api/DataPublisherHttpApi.scala
+++ b/hmda-data-publisher/src/main/scala/hmda/publisher/api/DataPublisherHttpApi.scala
@@ -1,0 +1,60 @@
+package hmda.publisher.api
+
+import akka.actor.ActorRef
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
+import ch.megard.akka.http.cors.scaladsl.CorsDirectives._
+import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
+import hmda.publisher.scheduler.AllSchedulers
+import hmda.publisher.scheduler.schedules.{ Schedule, Schedules }
+
+import scala.concurrent.ExecutionContext
+
+private class DataPublisherHttpApi(
+                                    schedulers: AllSchedulers
+                                  )(implicit ec: ExecutionContext) {
+
+  //trigger/<schedulername>
+  private val triggerScheduler =
+    path("trigger" / Segment) { schedulerName =>
+      post {
+        Schedules.withNameOption(schedulerName) match {
+          case Some(schedule) =>
+            triggerSchedule(schedule)
+            complete(202 -> s"Schedule ${schedulerName} has been triggered")
+          case None =>
+            complete(404 -> s"Scheduler ${schedulerName} not found. Available: ${Schedules.values.map(_.entryName).mkString(", ")}")
+        }
+      }
+    }
+
+  private def triggerSchedule(msg: Schedule): Unit = {
+    import schedulers._
+    val receiver = msg match {
+      case Schedules.PanelScheduler2018        => panelScheduler
+      case Schedules.PanelScheduler2019        => panelScheduler
+      case Schedules.LarPublicScheduler2018    => larPublicScheduler
+      case Schedules.LarPublicScheduler2019    => larPublicScheduler
+      case Schedules.LarScheduler2018          => larScheduler
+      case Schedules.LarScheduler2019          => larScheduler
+      case Schedules.LarSchedulerLoanLimit2019 => larScheduler
+      case Schedules.LarSchedulerQuarterly2020 => larScheduler
+      case Schedules.TsPublicScheduler2018     => tsPublicScheduler
+      case Schedules.TsPublicScheduler2019     => tsPublicScheduler
+      case Schedules.TsScheduler2018           => tsScheduler
+      case Schedules.TsScheduler2019           => tsScheduler
+      case Schedules.TsSchedulerQuarterly2020  => tsScheduler
+    }
+    receiver ! msg
+  }
+
+  def routes: Route =
+    handleRejections(corsRejectionHandler) {
+      cors() {
+        encodeResponse {
+          triggerScheduler
+        }
+      }
+    }
+
+}

--- a/hmda-data-publisher/src/main/scala/hmda/publisher/api/HmdaDataPublisherApi.scala
+++ b/hmda-data-publisher/src/main/scala/hmda/publisher/api/HmdaDataPublisherApi.scala
@@ -1,0 +1,32 @@
+package hmda.publisher.api
+
+import akka.actor.typed.Behavior
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.scaladsl.adapter._
+import akka.actor.{ActorSystem, CoordinatedShutdown}
+import akka.http.scaladsl.server.Directives._
+import hmda.api.http.directives.HmdaTimeDirectives._
+import hmda.api.http.routes.BaseHttpApi
+import hmda.publisher.scheduler.AllSchedulers
+
+import scala.concurrent.ExecutionContext
+
+// $COVERAGE-OFF$
+object HmdaDataPublisherApi {
+  val name = "hmda-data-publisher-api"
+
+  def apply(allSchedulers: AllSchedulers): Behavior[Nothing] = Behaviors.setup[Nothing] { ctx =>
+    implicit val ec: ExecutionContext = ctx.executionContext
+    implicit val classic: ActorSystem = ctx.system.toClassic
+    val shutdown: CoordinatedShutdown = CoordinatedShutdown(ctx.system)
+    val config                        = classic.settings.config
+    val host: String                  = config.getString("hmda.publisher.http.host")
+    val port: Int                     = config.getInt("hmda.publisher.http.port")
+
+    val routes = BaseHttpApi.routes(name) ~ new DataPublisherHttpApi(allSchedulers).routes
+    BaseHttpApi.runServer(shutdown, name)(timed(routes), host, port)
+
+    Behaviors.ignore
+  }
+}
+// $COVERAGE-ON$

--- a/hmda-data-publisher/src/main/scala/hmda/publisher/helper/QuarterTimeBarrier.scala
+++ b/hmda-data-publisher/src/main/scala/hmda/publisher/helper/QuarterTimeBarrier.scala
@@ -1,0 +1,34 @@
+package hmda.publisher.helper
+
+import java.time.{Clock, LocalDate}
+
+import hmda.publisher.validation.PublishingGuard.Period
+import hmda.util.BankFilterUtils.config
+import hmda.util.Filer
+
+class QuarterTimeBarrier(clock: Clock) {
+
+  def runIfStillRelevant[T](quarter: Period.Quarter)(thunk: => T): Option[T] = {
+    val now = LocalDate.now(clock)
+    if (now.isBefore(QuarterTimeBarrier.getEndDateForQuarter(quarter).plusDays(8))) {
+      Some(thunk)
+    } else {
+      None
+    }
+  }
+
+
+}
+
+object QuarterTimeBarrier {
+  private val rulesConfig = Filer.parse(config).fold(error => throw new RuntimeException(s"Failed to parse filing rules in HOCON: $error"), identity)
+
+  def getEndDateForQuarter(quarter: Period.Quarter): LocalDate = {
+    quarter match {
+      case Period.y2020Q1 => LocalDate.ofYearDay(2020,rulesConfig.qf.q1.endDayOfYear)
+      case Period.y2020Q2 => LocalDate.ofYearDay(2020,rulesConfig.qf.q2.endDayOfYear)
+      case Period.y2020Q3 => LocalDate.ofYearDay(2020,rulesConfig.qf.q3.endDayOfYear)
+    }
+  }
+
+}

--- a/hmda-data-publisher/src/main/scala/hmda/publisher/helper/RetryUtils.scala
+++ b/hmda-data-publisher/src/main/scala/hmda/publisher/helper/RetryUtils.scala
@@ -1,0 +1,12 @@
+package hmda.publisher.helper
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration.Duration
+
+object RetryUtils {
+
+  def retry[T](retries: Int, delay: Duration)(f: () => Future[T])(implicit ec: ExecutionContext): Future[T] = {
+    f() recoverWith { case _ if retries > 0 => Future(Thread.sleep(delay.toMillis)).flatMap(_ => retry(retries - 1, delay)(f)) }
+  }
+
+}

--- a/hmda-data-publisher/src/main/scala/hmda/publisher/helper/S3Utils.scala
+++ b/hmda-data-publisher/src/main/scala/hmda/publisher/helper/S3Utils.scala
@@ -1,0 +1,20 @@
+package hmda.publisher.helper
+
+import akka.NotUsed
+import akka.stream.Materializer
+import akka.stream.alpakka.s3.MultipartUploadResult
+import akka.stream.scaladsl.{ Sink, Source }
+import akka.util.ByteString
+
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{ ExecutionContext, Future }
+
+object S3Utils {
+
+  def uploadWithRetry(
+                       source: Source[ByteString, NotUsed],
+                       uploadSink: Sink[ByteString, Future[MultipartUploadResult]]
+                     )(implicit mat: Materializer, ec: ExecutionContext): Future[MultipartUploadResult] =
+    RetryUtils.retry(retries = 3, delay = 1.minute)(() => source.runWith(uploadSink))
+
+}

--- a/hmda-data-publisher/src/main/scala/hmda/publisher/scheduler/AllSchedulers.scala
+++ b/hmda-data-publisher/src/main/scala/hmda/publisher/scheduler/AllSchedulers.scala
@@ -1,0 +1,11 @@
+package hmda.publisher.scheduler
+
+import akka.actor.ActorRef
+
+case class AllSchedulers(
+                          larPublicScheduler: ActorRef,
+                          larScheduler: ActorRef,
+                          panelScheduler: ActorRef,
+                          tsPublicScheduler: ActorRef,
+                          tsScheduler: ActorRef
+                        )

--- a/hmda-data-publisher/src/main/scala/hmda/publisher/scheduler/LarPublicScheduler.scala
+++ b/hmda-data-publisher/src/main/scala/hmda/publisher/scheduler/LarPublicScheduler.scala
@@ -18,6 +18,7 @@ import hmda.publisher.helper.{
   PrivateAWSConfigLoader,
   PublicAWSConfigLoader,
   S3Archiver,
+  S3Utils,
   SnapshotCheck
 }
 import hmda.publisher.query.component.{ PublisherComponent2018, PublisherComponent2019, PublisherComponent2020 }
@@ -126,7 +127,8 @@ class LarPublicScheduler
 
     val resultsPSV = for {
       _            <- S3Archiver.archiveFileIfExists(bucket, key, bucketPrivate, s3Settings)
-      uploadResult <- zipStream.via(Archive.zip()).runWith(s3SinkPSV)
+      source       = zipStream.via(Archive.zip())
+      uploadResult <- S3Utils.uploadWithRetry(source, s3SinkPSV)
     } yield uploadResult
 
     resultsPSV onComplete {

--- a/hmda-data-publisher/src/main/scala/hmda/publisher/scheduler/TsPublicScheduler.scala
+++ b/hmda-data-publisher/src/main/scala/hmda/publisher/scheduler/TsPublicScheduler.scala
@@ -8,19 +8,19 @@ import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import com.typesafe.akka.extension.quartz.QuartzSchedulerExtension
 import hmda.actor.HmdaActor
-import hmda.publisher.helper.{ PrivateAWSConfigLoader, PublicAWSConfigLoader, S3Archiver, SnapshotCheck, TSHeader }
-import hmda.publisher.query.component.{ PublisherComponent2018, PublisherComponent2019, PublisherComponent2020 }
-import hmda.publisher.scheduler.schedules.Schedules.{ TsPublicScheduler2018, TsPublicScheduler2019 }
+import hmda.publisher.helper.{PrivateAWSConfigLoader, PublicAWSConfigLoader, S3Archiver, S3Utils, SnapshotCheck, TSHeader}
+import hmda.publisher.query.component.{PublisherComponent2018, PublisherComponent2019, PublisherComponent2020}
+import hmda.publisher.scheduler.schedules.Schedules.{TsPublicScheduler2018, TsPublicScheduler2019}
 import hmda.query.DbConfiguration.dbConfig
 import hmda.query.ts._
 import hmda.util.BankFilterUtils._
 import akka.stream.alpakka.file.scaladsl.Archive
 import akka.stream.alpakka.file.ArchiveMetadata
 import hmda.publisher.validation.PublishingGuard
-import hmda.publisher.validation.PublishingGuard.{ Period, Scope }
+import hmda.publisher.validation.PublishingGuard.{Period, Scope}
 
 import scala.concurrent.Future
-import scala.util.{ Failure, Success }
+import scala.util.{Failure, Success}
 
 class TsPublicScheduler
   extends HmdaActor
@@ -113,7 +113,8 @@ class TsPublicScheduler
 
     val resultsPSV = for {
       _            <- S3Archiver.archiveFileIfExists(bucket, key, bucketPrivate, s3Settings)
-      uploadResult <- zipStream.via(Archive.zip()).runWith(s3SinkPSV)
+      bytesStream = zipStream.via(Archive.zip())
+      uploadResult <- S3Utils.uploadWithRetry(bytesStream, s3SinkPSV)
     } yield uploadResult
 
     resultsPSV onComplete {

--- a/hmda-data-publisher/src/main/scala/hmda/publisher/scheduler/TsScheduler.scala
+++ b/hmda-data-publisher/src/main/scala/hmda/publisher/scheduler/TsScheduler.scala
@@ -1,28 +1,28 @@
 package hmda.publisher.scheduler
 
-import java.time.LocalDateTime
+import java.time.{Clock, LocalDateTime}
 import java.time.format.DateTimeFormatter
 
 import akka.stream.Materializer
 import akka.stream.alpakka.s3.ApiVersion.ListBucketVersion2
 import akka.stream.alpakka.s3._
 import akka.stream.alpakka.s3.scaladsl.S3
-import akka.stream.scaladsl.{ Sink, Source }
+import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
 import com.typesafe.akka.extension.quartz.QuartzSchedulerExtension
 import com.typesafe.config.ConfigFactory
 import hmda.actor.HmdaActor
-import hmda.publisher.helper.{ PrivateAWSConfigLoader, SnapshotCheck }
-import hmda.publisher.query.component.{ PublisherComponent2018, PublisherComponent2019, PublisherComponent2020 }
-import hmda.publisher.scheduler.schedules.Schedules.{ TsScheduler2018, TsScheduler2019, TsSchedulerQuarterly2020 }
+import hmda.publisher.helper.{PrivateAWSConfigLoader, QuarterTimeBarrier, S3Utils, SnapshotCheck}
+import hmda.publisher.query.component.{PublisherComponent2018, PublisherComponent2019, PublisherComponent2020}
+import hmda.publisher.scheduler.schedules.Schedules.{TsScheduler2018, TsScheduler2019, TsSchedulerQuarterly2020}
 import hmda.publisher.validation.PublishingGuard
-import hmda.publisher.validation.PublishingGuard.{ Period, Scope }
+import hmda.publisher.validation.PublishingGuard.{Period, Scope}
 import hmda.query.DbConfiguration.dbConfig
 import hmda.query.ts._
 import hmda.util.BankFilterUtils._
 
 import scala.concurrent.Future
-import scala.util.{ Failure, Success }
+import scala.util.{Failure, Success}
 
 class TsScheduler
   extends HmdaActor
@@ -43,6 +43,7 @@ class TsScheduler
   def tsRepository2020Q2               = new TransmittalSheetRepository2020Q2(dbConfig)
   def tsRepository2020Q3               = new TransmittalSheetRepository2020Q3(dbConfig)
   val publishingGuard: PublishingGuard = PublishingGuard.create(this)(context.system)
+  val timeBarrier: QuarterTimeBarrier = new QuarterTimeBarrier(Clock.systemDefaultZone())
 
   val awsConfig =
     ConfigFactory.load("application.conf").getConfig("private-aws")
@@ -72,13 +73,14 @@ class TsScheduler
   private def uploadFileToS3(
                               s3Sink: Sink[ByteString, Future[MultipartUploadResult]],
                               transmittalSheets: => Future[Seq[TransmittalSheetEntity]]
-                            ): Future[MultipartUploadResult] =
-    Source
+                            ): Future[MultipartUploadResult] = {
+    val source = Source
       .future(transmittalSheets)
       .mapConcat(_.toList)
       .map(transmittalSheet => transmittalSheet.toRegulatorPSV + "\n")
       .map(ByteString(_))
-      .runWith(s3Sink)
+    S3Utils.uploadWithRetry(source, s3Sink)
+  }
 
   override def receive: Receive = {
 
@@ -134,27 +136,33 @@ class TsScheduler
       val now              = LocalDateTime.now().minusDays(1)
       val formattedDate    = fullDateQuarterly.format(now)
       val s3Path           = s"$environmentPrivate/ts/"
-      def handleQuarter[Table <: TransmittalSheetTableBase](year: Period, repo: TSRepository2020Base[Table], fileNameSuffix: String) =
-        publishingGuard.runIfDataIsValid(year, Scope.Private) {
-          val fileName     = formattedDate + fileNameSuffix
-          val fullFilePath = SnapshotCheck.pathSelector(s3Path, fileName)
-          val s3Sink =
-            S3.multipartUpload(bucketPrivate, fullFilePath)
-              .withAttributes(S3Attributes.settings(s3Settings))
-          def data: Future[Seq[TransmittalSheetEntity]] =
-            repo.getAllSheets(getFilterList(), includeQuarterly)
-          val results: Future[MultipartUploadResult] =
-            uploadFileToS3(s3Sink, data)
-          results onComplete {
-            case Success(result) =>
-              log.info("Pushed to S3: " + s"$bucketPrivate/$fullFilePath" + ".")
-            case Failure(t) =>
-              log.error("An error has occurred getting Quarterly TS Data 2020: " + t.getMessage)
+      def publishQuarter[Table <: TransmittalSheetTableBase](quarter: Period.Quarter, repo: TSRepository2020Base[Table], fileNameSuffix: String) = {
+        timeBarrier.runIfStillRelevant(quarter) {
+          publishingGuard.runIfDataIsValid(quarter, Scope.Private) {
+            val fileName = formattedDate + fileNameSuffix
+            val fullFilePath = SnapshotCheck.pathSelector(s3Path, fileName)
+            val s3Sink =
+              S3.multipartUpload(bucketPrivate, fullFilePath)
+                .withAttributes(S3Attributes.settings(s3Settings))
+
+            def data: Future[Seq[TransmittalSheetEntity]] =
+              repo.getAllSheets(getFilterList(), includeQuarterly)
+
+            val results: Future[MultipartUploadResult] =
+              uploadFileToS3(s3Sink, data)
+            results onComplete {
+              case Success(result) =>
+                log.info("Pushed to S3: " + s"$bucketPrivate/$fullFilePath" + ".")
+              case Failure(t) =>
+                log.error("An error has occurred getting Quarterly TS Data 2020: " + t.getMessage)
+            }
           }
         }
-      handleQuarter(Period.y2020Q1, tsRepository2020Q1, "_quarter_1_2020_ts.txt")
-      handleQuarter(Period.y2020Q2, tsRepository2020Q2, "_quarter_2_2020_ts.txt")
-      handleQuarter(Period.y2020Q3, tsRepository2020Q3, "_quarter_3_2020_ts.txt")
+      }
+
+      publishQuarter(Period.y2020Q1, tsRepository2020Q1, "_quarter_1_2020_ts.txt")
+      publishQuarter(Period.y2020Q2, tsRepository2020Q2, "_quarter_2_2020_ts.txt")
+      publishQuarter(Period.y2020Q3, tsRepository2020Q3, "_quarter_3_2020_ts.txt")
 
   }
 

--- a/hmda-data-publisher/src/main/scala/hmda/publisher/scheduler/schedules/Schedules.scala
+++ b/hmda-data-publisher/src/main/scala/hmda/publisher/scheduler/schedules/Schedules.scala
@@ -1,17 +1,25 @@
 package hmda.publisher.scheduler.schedules
 
-object Schedules {
-  case object PanelScheduler2018
-  case object PanelScheduler2019
-  case object LarScheduler2018
-  case object LarPublicScheduler2018
-  case object LarPublicScheduler2019
-  case object LarScheduler2019
-  case object LarSchedulerLoanLimit2019
-  case object TsScheduler2018
-  case object TsPublicScheduler2018
-  case object TsPublicScheduler2019
-  case object TsScheduler2019
-  case object LarSchedulerQuarterly2020
-  case object TsSchedulerQuarterly2020
+import enumeratum._
+
+import scala.collection.immutable
+
+sealed trait Schedule extends EnumEntry
+
+object Schedules extends Enum[Schedule] {
+  case object PanelScheduler2018        extends Schedule
+  case object PanelScheduler2019        extends Schedule
+  case object LarScheduler2018          extends Schedule
+  case object LarPublicScheduler2018    extends Schedule
+  case object LarPublicScheduler2019    extends Schedule
+  case object LarScheduler2019          extends Schedule
+  case object LarSchedulerLoanLimit2019 extends Schedule
+  case object TsScheduler2018           extends Schedule
+  case object TsPublicScheduler2018     extends Schedule
+  case object TsPublicScheduler2019     extends Schedule
+  case object TsScheduler2019           extends Schedule
+  case object LarSchedulerQuarterly2020 extends Schedule
+  case object TsSchedulerQuarterly2020  extends Schedule
+
+  override def values: immutable.IndexedSeq[Schedule] = findValues
 }

--- a/hmda-data-publisher/src/main/scala/hmda/publisher/validation/PublishingGuard.scala
+++ b/hmda-data-publisher/src/main/scala/hmda/publisher/validation/PublishingGuard.scala
@@ -120,11 +120,13 @@ object PublishingGuard {
 
   sealed trait Period
   object Period {
+    sealed trait Quarter extends Period
+
     case object y2018   extends Period
     case object y2019   extends Period
-    case object y2020Q1 extends Period
-    case object y2020Q2 extends Period
-    case object y2020Q3 extends Period
+    case object y2020Q1 extends Period with Quarter
+    case object y2020Q2 extends Period with Quarter
+    case object y2020Q3 extends Period with Quarter
   }
 
   sealed trait Scope

--- a/hmda-data-publisher/src/test/scala/hmda/publisher/api/DataPublisherHttpApiSpec.scala
+++ b/hmda-data-publisher/src/test/scala/hmda/publisher/api/DataPublisherHttpApiSpec.scala
@@ -1,0 +1,61 @@
+package hmda.publisher.api
+
+import akka.actor.ActorRef
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import akka.testkit.TestProbe
+import akka.util.Timeout
+import com.typesafe.config.ConfigFactory
+import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
+import hmda.model.institution.Institution
+import hmda.publisher.scheduler.AllSchedulers
+import hmda.publisher.scheduler.schedules.{Schedule, Schedules}
+import hmda.query.DbConfiguration._
+import org.scalatest.{BeforeAndAfterAll, MustMatchers, WordSpec}
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.DurationInt
+
+class DataPublisherHttpApiSpec extends WordSpec with MustMatchers with ScalatestRouteTest {
+  implicit val timeout = Timeout(15.seconds)
+
+  "DataPublisherHttpApi" must {
+    "trigger right scheduler" in {
+      Schedules.values.foreach({
+        case Schedules.PanelScheduler2018            =>
+        case x @ Schedules.PanelScheduler2019        => testTrigger(x, _.panelScheduler)
+        case x @ Schedules.LarScheduler2018          => testTrigger(x, _.larScheduler)
+        case x @ Schedules.LarPublicScheduler2018    => testTrigger(x, _.larPublicScheduler)
+        case x @ Schedules.LarPublicScheduler2019    => testTrigger(x, _.larPublicScheduler)
+        case x @ Schedules.LarScheduler2019          => testTrigger(x, _.larScheduler)
+        case x @ Schedules.LarSchedulerLoanLimit2019 => testTrigger(x, _.larScheduler)
+        case x @ Schedules.TsScheduler2018           => testTrigger(x, _.tsScheduler)
+        case x @ Schedules.TsPublicScheduler2018     => testTrigger(x, _.tsPublicScheduler)
+        case x @ Schedules.TsPublicScheduler2019     => testTrigger(x, _.tsPublicScheduler)
+        case x @ Schedules.TsScheduler2019           => testTrigger(x, _.tsScheduler)
+        case x @ Schedules.LarSchedulerQuarterly2020 => testTrigger(x, _.larScheduler)
+        case x @ Schedules.TsSchedulerQuarterly2020  => testTrigger(x, _.tsScheduler)
+      })
+    }
+  }
+
+  def testTrigger(msg: Schedule, schedulerToBeTriggered: AllSchedulers => ActorRef): Unit = {
+    val probes @ List(p1, p2, p3, p4, p5) = List.fill(5)(TestProbe())
+    val allSchedulers = AllSchedulers(
+      p1.ref,
+      p2.ref,
+      p3.ref,
+      p4.ref,
+      p5.ref
+    )
+    val routes    = new DataPublisherHttpApi(allSchedulers).routes
+    val scheduler = schedulerToBeTriggered(allSchedulers)
+    val probe     = probes.find(_.ref == scheduler).get
+    Post(s"/trigger/${msg.entryName}") ~> routes ~> check {
+      status mustBe StatusCodes.Accepted
+    }
+    probe.expectMsg(msg)
+  }
+
+}

--- a/hmda-data-publisher/src/test/scala/hmda/publisher/helper/QuarterTimeBarrierTest.scala
+++ b/hmda-data-publisher/src/test/scala/hmda/publisher/helper/QuarterTimeBarrierTest.scala
@@ -1,0 +1,41 @@
+package hmda.publisher.helper
+
+import java.time.{Clock, Instant, LocalDate, ZoneId, ZoneOffset}
+
+import hmda.publisher.validation.PublishingGuard.Period
+import org.scalatest.FreeSpec
+
+class QuarterTimeBarrierTest extends FreeSpec {
+
+
+  "protect all quarters correctly" in {
+    testQuarter(Period.y2020Q1)
+    testQuarter(Period.y2020Q2)
+    testQuarter(Period.y2020Q3)
+  }
+
+  def testQuarter(quarter: Period.Quarter) = {
+    val endDate = QuarterTimeBarrier.getEndDateForQuarter(quarter)
+    test(endDate.minusDays(100), quarter, shouldRun = true)
+    test(endDate, quarter, shouldRun = true)
+    test(endDate.plusDays(6), quarter, shouldRun = true)
+    test(endDate.plusDays(7), quarter, shouldRun = true)
+    test(endDate.plusDays(8), quarter, shouldRun = false)
+    test(endDate.plusDays(100), quarter, shouldRun = false)
+  }
+
+  def test(now: LocalDate, quarter: Period.Quarter, shouldRun: Boolean) = {
+    val zoneId = ZoneId.systemDefault()
+    val clock = Clock.fixed(now.atTime(12, 0).toInstant(zoneId.getRules.getOffset(Instant.now())), zoneId)
+    val timeBarrier = new QuarterTimeBarrier(clock)
+    val hasRun = timeBarrier.runIfStillRelevant(quarter)(()).isDefined
+    if(hasRun && !shouldRun){
+      fail(s"Protected code shouldn't run but it did. Date: ${now}, period: ${quarter}")
+    } else if (!hasRun && shouldRun) {
+      fail(s"Protected code should run but it didnt. Date: ${now}, period: ${quarter}")
+    }
+  }
+
+
+
+}

--- a/hmda-data-publisher/src/test/scala/hmda/publisher/helper/RetryUtilsTest.scala
+++ b/hmda-data-publisher/src/test/scala/hmda/publisher/helper/RetryUtilsTest.scala
@@ -1,0 +1,26 @@
+package hmda.publisher.helper
+
+import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
+import org.scalatest.{FreeSpec, FunSuite}
+
+import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
+
+class RetryUtilsTest extends FreeSpec {
+
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  "retry" in {
+    var runNumber = 0
+    val ftr = () => Future({
+      runNumber +=1
+      throw new RuntimeException
+    })
+    assertThrows[RuntimeException] {
+      RetryUtils.retry(3, 5.millis)(ftr).futureValue
+    }
+    assert(runNumber == 4)
+
+  }
+
+}


### PR DESCRIPTION
Closes #3900 
Closes #3905
Closes #3906

There are new endpoints to trigger data-publisher file generations : `/trigger/<schedulename>`