### PR TITLE
Prevent Institutions from Being Create or Modified to Include a public Email Domain

### DIFF
--- a/common/src/main/resources/reference.conf
+++ b/common/src/main/resources/reference.conf
@@ -16,6 +16,11 @@ hmda {
     timeout = 38
   }
 
+  email {
+    publicDomains = "aol.com,att.net,comcast.net,facebook.com,gmail.com,gmx.com,googlemail.com,google.com,hotmail.com,hotmail.co.uk,mac.com,me.com,mail.com,msn.com,live.com,sbcglobal.net,verizon.net,yahoo.com,yahoo.co.uk,email.com,fastmail.fm,games.com,gmx.net,hush.com,hushmail.com,icloud.com,iname.com,inbox.com,lavabit.com,love.com,outlook.com,pobox.com,protonmail.ch,protonmail.com,tutanota.de,tutanota.com,tutamail.com,tuta.io,keemail.me,rocketmail.com,safe-mail.net,wow.com,ygm.com,ymail.com,zoho.com,yandex.com,bellsouth.net,charter.net,cox.net,earthlink.net,juno.com,btinternet.com,virginmedia.com,blueyonder.co.uk,freeserve.co.uk,live.co.uk,ntlworld.com,o2.co.uk,orange.net,sky.com,talktalk.co.uk,tiscali.co.uk,virgin.net,wanadoo.co.uk,bt.com,sina.com,sina.cn,qq.com,naver.com,hanmail.net,daum.net,nate.com,yahoo.co.jp,yahoo.co.kr,yahoo.co.id,yahoo.co.in,yahoo.com.sg,yahoo.com.ph,163.com,yeah.net,126.com,21cn.com,aliyun.com,foxmail.com,hotmail.fr,live.fr,laposte.net,yahoo.fr,wanadoo.fr,orange.fr,gmx.fr,sfr.fr,neuf.fr,free.fr,gmx.de,hotmail.de,live.de,online.de,t-online.de,web.de,yahoo.de,libero.it,virgilio.it,hotmail.it,aol.it,tiscali.it,alice.it,live.it,yahoo.it,email.it,tin.it,poste.it,teletu.it,mail.ru,rambler.ru,yandex.ru,ya.ru,list.ru,hotmail.be,live.be,skynet.be,voo.be,tvcablenet.be,telenet.be,hotmail.com.ar,live.com.ar,yahoo.com.ar,fibertel.com.ar,speedy.com.ar,arnet.com.ar,yahoo.com.mx,live.com.mx,hotmail.es,hotmail.com.mx,prodigy.net.mx,yahoo.ca,hotmail.ca,bell.net,shaw.ca,sympatico.ca,rogers.com,yahoo.com.br,hotmail.com.br,outlook.com.br,uol.com.br,bol.com.br,terra.com.br,ig.com.br,itelefonica.com.br,r7.com,zipmail.com.br,globo.com,globomail.com,oi.com.br"
+    publicDomains = ${?PUBLIC_EMAIL_DOMAINS}
+  }
+
   rules {
     yearly-filing {
       years-allowed = "2018,2019,2020"

--- a/common/src/main/scala/hmda/api/http/EmailUtils.scala
+++ b/common/src/main/scala/hmda/api/http/EmailUtils.scala
@@ -11,6 +11,6 @@ object EmailUtils {
     publicDomains.contains(domain.toLowerCase())
 
   def checkListIfPublicDomain(domains: Seq[String]): Boolean =
-    !(domains.intersect(publicDomains.map(_.toLowerCase())).isEmpty)
+    !(domains.map(_.toLowerCase()).intersect(publicDomains).isEmpty)
 }
 // $COVERAGE-ON$

--- a/common/src/main/scala/hmda/api/http/EmailUtils.scala
+++ b/common/src/main/scala/hmda/api/http/EmailUtils.scala
@@ -8,9 +8,9 @@ object EmailUtils {
   val publicDomains = config.getString("hmda.email.publicDomains").split(",")
 
   def checkIfPublicDomain(domain: String): Boolean =
-    publicDomains.contains(domain)
+    publicDomains.contains(domain.toLowerCase())
 
   def checkListIfPublicDomain(domains: Seq[String]): Boolean =
-    !(domains.intersect(publicDomains).isEmpty)
+    !(domains.intersect(publicDomains.map(_.toLowerCase())).isEmpty)
 }
 // $COVERAGE-ON$

--- a/common/src/main/scala/hmda/api/http/EmailUtils.scala
+++ b/common/src/main/scala/hmda/api/http/EmailUtils.scala
@@ -1,0 +1,16 @@
+package hmda.api.http
+
+import com.typesafe.config.ConfigFactory
+
+// $COVERAGE-OFF$
+object EmailUtils {
+  val config = ConfigFactory.load("reference.conf")
+  val publicDomains = config.getString("hmda.email.publicDomains").split(",")
+
+  def checkIfPublicDomain(domain: String): Boolean =
+    publicDomains.contains(domain)
+
+  def checkListIfPublicDomain(domains: Seq[String]): Boolean =
+    !(domains.intersect(publicDomains).isEmpty)
+}
+// $COVERAGE-ON$

--- a/hmda/src/main/scala/hmda/api/http/admin/InstitutionAdminHttpApi.scala
+++ b/hmda/src/main/scala/hmda/api/http/admin/InstitutionAdminHttpApi.scala
@@ -236,7 +236,7 @@ private class InstitutionAdminHttpApi(config: Config, sharding: ClusterSharding)
       complete((StatusCodes.BadRequest, "Incorrect lei format"))
     } else if (checkAgencyCode && !validAgencyCodeFormat(institution.agency.code)) {
       complete((StatusCodes.BadRequest, "Incorrect agency code format"))
-    } else if (checkListIfPublicDomain(institution.emailDomains)){
+    } else if (checkListIfPublicDomain(institution.emailDomains)) {
       complete((StatusCodes.BadRequest, "Email domain is a public domain"))
     } else route(institution, uri)
 }

--- a/institutions-api/src/main/scala/hmda/institution/api/http/InstitutionQueryHttpApi.scala
+++ b/institutions-api/src/main/scala/hmda/institution/api/http/InstitutionQueryHttpApi.scala
@@ -16,6 +16,7 @@ import hmda.utils.YearUtils._
 import io.circe.generic.auto._
 import slick.basic.DatabaseConfig
 import slick.jdbc.JdbcProfile
+import hmda.api.http.EmailUtils._
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
@@ -128,8 +129,12 @@ private class InstitutionQueryHttpApi(config: Config)(implicit ec: ExecutionCont
   path("institutions") {
     (extractUri & get) { uri =>
       parameter('domain.as[String]) { domain =>
+        if (checkIfPublicDomain(domain)) {
+          returnNotFoundError(uri)
+        } else {
         val f = findByEmailAnyYear(domain)
         completeInstitutionsFuture(f, uri)
+        }
       } ~
         parameters(('domain.as[String], 'lei.as[String], 'respondentName.as[String], 'taxId.as[String])) {
           (domain, lei, respondentName, taxId) =>
@@ -156,8 +161,6 @@ private class InstitutionQueryHttpApi(config: Config)(implicit ec: ExecutionCont
           complete(ToResponseMarshallable(StatusCodes.InternalServerError -> errorResponse))
         }
     }
-
-
 
   private def returnNotFoundError(uri: Uri) = {
     val errorResponse = ErrorResponse(404, StatusCodes.NotFound.defaultMessage, uri.path)


### PR DESCRIPTION
Adds:
1. A list of public email domains in common
2. Checks the above list when an institution is created or modified to prevent inclusion of public domains in institution records
3. Prevents any results being returned when a public email domain is search in the institutions-api