### PR TITLE
Admin endpoints

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -130,7 +130,8 @@ lazy val `hmda-platform` = (project in file("hmda"))
           val oldStrategy = (assemblyMergeStrategy in assembly).value
           oldStrategy(x)
       },
-      Revolver.enableDebugging(5006)
+      envVars in reStart ++= Map("CASSANDRA_CLUSTER_HOSTS" -> "localhost", "APP_PORT" -> "2551"),
+      addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full)
     ),
     dockerSettings,
     packageSettings

--- a/hmda/src/main/scala/hmda/api/http/HmdaAdminApi.scala
+++ b/hmda/src/main/scala/hmda/api/http/HmdaAdminApi.scala
@@ -2,13 +2,13 @@ package hmda.api.http
 
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.scaladsl.adapter._
-import akka.actor.typed.{ActorSystem, Behavior}
-import akka.actor.{CoordinatedShutdown, ActorSystem => ClassicActorSystem}
+import akka.actor.typed.{ ActorSystem, Behavior }
+import akka.actor.{ CoordinatedShutdown, ActorSystem => ClassicActorSystem }
 import akka.cluster.sharding.typed.scaladsl.ClusterSharding
 import akka.http.scaladsl.server.Directives._
 import akka.stream.Materializer
 import akka.util.Timeout
-import hmda.api.http.admin.{InstitutionAdminHttpApi, PublishAdminHttpApi, SubmissionAdminHttpApi}
+import hmda.api.http.admin.{ InstitutionAdminHttpApi, PublishAdminHttpApi, StatsAdminHttpApi, SubmissionAdminHttpApi }
 import hmda.api.http.directives.HmdaTimeDirectives._
 import hmda.api.http.routes.BaseHttpApi
 import hmda.auth.OAuth2Authorization
@@ -36,10 +36,15 @@ object HmdaAdminApi {
     val shutdown                             = CoordinatedShutdown(system)
 
     val oAuth2Authorization = OAuth2Authorization(log, config)
-    val institutionRoutes   = InstitutionAdminHttpApi.create(config,sharding)
+    val institutionRoutes   = InstitutionAdminHttpApi.create(config, sharding)
     val publishRoutes       = PublishAdminHttpApi.create(sharding, config)
     val submissionRoutes    = SubmissionAdminHttpApi.create(log, config, sharding)
-    val routes              = BaseHttpApi.routes(name) ~ institutionRoutes(oAuth2Authorization)  ~ publishRoutes(oAuth2Authorization) ~ submissionRoutes(oAuth2Authorization)
+    val statsRoutes         = StatsAdminHttpApi.create(log, config, sharding)
+    val routes = BaseHttpApi.routes(name) ~
+      institutionRoutes(oAuth2Authorization) ~
+      publishRoutes(oAuth2Authorization) ~
+      submissionRoutes(oAuth2Authorization) ~
+      statsRoutes(oAuth2Authorization)
 
     BaseHttpApi.runServer(shutdown, name)(timed(routes), host, port)
     Behaviors.empty

--- a/hmda/src/main/scala/hmda/api/http/admin/StatsAdminHttpApi.scala
+++ b/hmda/src/main/scala/hmda/api/http/admin/StatsAdminHttpApi.scala
@@ -1,0 +1,123 @@
+package hmda.api.http.admin
+
+import akka.NotUsed
+import akka.actor.typed.ActorSystem
+import akka.cluster.sharding.typed.scaladsl.ClusterSharding
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
+import akka.stream.Materializer
+import akka.stream.scaladsl.{ Sink, Source }
+import akka.util.Timeout
+import com.typesafe.config.Config
+import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
+import hmda.api.http.model.{ SignedLeiCountResponse, SignedLeiListResponse, TotalLeiCountResponse, TotalLeiListResponse }
+import hmda.auth.OAuth2Authorization
+import hmda.messages.filing.FilingCommands.GetLatestSignedSubmission
+import hmda.model.filing.submission.Submission
+import hmda.persistence.filing.FilingPersistence
+import hmda.persistence.institution.InstitutionPersistence
+import hmda.query.HmdaQuery
+import hmda.utils.YearUtils
+import hmda.utils.YearUtils.Period
+import org.slf4j.Logger
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+object StatsAdminHttpApi {
+  def create(log: Logger, config: Config, clusterSharding: ClusterSharding)(
+    implicit t: Timeout,
+    ec: ExecutionContext,
+    system: ActorSystem[_],
+    mat: Materializer
+  ): OAuth2Authorization => Route =
+    new StatsAdminHttpApi(log, config, clusterSharding)(t, ec, system, mat).routes
+}
+
+private class StatsAdminHttpApi(log: Logger, config: Config, clusterSharding: ClusterSharding)(
+  implicit t: Timeout,
+  ec: ExecutionContext,
+  system: ActorSystem[_],
+  mat: Materializer
+) {
+  private val hmdaAdminRole: String = config.getString("keycloak.hmda.admin.role")
+
+  val routes: OAuth2Authorization => Route = { (oauth2Authorization: OAuth2Authorization) =>
+    val getLeisCountWithSignedFilling =
+      get
+        .&(path("admin" / "count" / "lei" / Segment / "filed"))
+        .&(oauth2Authorization.authorizeTokenWithRole(hmdaAdminRole)) { (periodStr, _) =>
+          val period = YearUtils.parsePeriod(periodStr).toTry.get
+          val result = getSignedSubmissionsStream(period)
+            .map(_ => 1)
+            .fold(0)(_ + _)
+            .runWith(Sink.head)
+            .map(SignedLeiCountResponse.apply)
+          complete(result)
+        }
+
+    val getLeisListWithSignedFilling =
+      get
+        .&(path("admin" / "list" / "lei" / Segment / "filed"))
+        .&(oauth2Authorization.authorizeTokenWithRole(hmdaAdminRole)) { (periodStr, _) =>
+          val period = YearUtils.parsePeriod(periodStr).toTry.get
+          val result: Future[SignedLeiListResponse] =
+            getSignedSubmissionsStream(period)
+              .map({ case (lei, sub) => SignedLeiListResponse.Elem(lei, sub.id.toString) })
+              .runWith(Sink.seq)
+              .map(SignedLeiListResponse.apply)
+          complete(result)
+        }
+
+    val getTotalLeisCount =
+      get
+        .&(path("admin" / "count" / Segment / "lei"))
+        .&(oauth2Authorization.authorizeTokenWithRole(hmdaAdminRole)) { (periodStr, _) =>
+          val period = YearUtils.parsePeriod(periodStr).toTry.get
+          val result = getTotalLeiStream(period)
+            .map(_ => 1)
+            .fold(0)(_ + _)
+            .runWith(Sink.head)
+            .map(TotalLeiCountResponse.apply)
+          complete(result)
+        }
+
+    val getTotalLeisList =
+      get
+        .&(path("admin" / "list" / Segment / "lei"))
+        .&(oauth2Authorization.authorizeTokenWithRole(hmdaAdminRole)) { (periodStr, _) =>
+          val period = YearUtils.parsePeriod(periodStr).toTry.get
+          val result = getTotalLeiStream(period)
+            .map(_.lei)
+            .runWith(Sink.seq)
+            .map(TotalLeiListResponse.apply)
+          complete(result)
+        }
+
+    getLeisCountWithSignedFilling ~
+      getLeisListWithSignedFilling ~
+      getTotalLeisCount ~
+      getTotalLeisList
+  }
+
+  // stream of (lei -> last signed submission)
+  private def getSignedSubmissionsStream(period: Period): Source[(String, Submission), NotUsed] =
+    HmdaQuery
+      .readJournal(system)
+      .currentPersistenceIds()
+      .mapConcat(x => FilingPersistence.parseEntityId(x).toList)
+      .filter(id => id.period == period)
+      .mapAsync(1)({ id =>
+        val fillingRef = clusterSharding.entityRefFor(FilingPersistence.typeKey, id.mkString)
+        for {
+          signedSubmissionOpt <- fillingRef ? (ref => GetLatestSignedSubmission(ref))
+        } yield signedSubmissionOpt.map(sub => id.lei -> sub)
+      })
+      .mapConcat(_.toList)
+
+  private def getTotalLeiStream(period: Period): Source[InstitutionPersistence.EntityId, NotUsed] =
+    HmdaQuery
+      .readJournal(system)
+      .currentPersistenceIds()
+      .mapConcat(x => InstitutionPersistence.parseEntityId(x).toList)
+      .filter(id => id.year == period.year)
+}

--- a/hmda/src/main/scala/hmda/api/http/model/Stats.scala
+++ b/hmda/src/main/scala/hmda/api/http/model/Stats.scala
@@ -1,0 +1,21 @@
+package hmda.api.http.model
+
+import io.circe.generic.JsonCodec
+
+@JsonCodec
+case class SignedLeiCountResponse(count: Int)
+
+@JsonCodec
+case class SignedLeiListResponse(data: Seq[SignedLeiListResponse.Elem])
+
+object SignedLeiListResponse {
+  @JsonCodec
+  case class Elem(lei: String, submissionId: String)
+}
+
+
+@JsonCodec
+case class TotalLeiCountResponse(count: Int)
+
+@JsonCodec
+case class TotalLeiListResponse(data: Seq[String])


### PR DESCRIPTION
- /admin/count/<filingperiod>/filed -- for a given filing period (i.e. 2018, 2019, 2020, 2020-Q1, 2020-Q2, etc) return a total count of all LEI's that have had at least one filing with code 15 for that filing period.
 - /admin/list/<filingperiod>/filed -- for a given filing period (i.e. 2018, 2019, 2020, 2020-Q1, 2020-Q2, etc) return a list of LEI's along with their submission id for their latest signed submission (code 15). The count of this list will always match the count of previous endpoint.
 -  /admin/count/<filingperiod>/lei -- for a given filing period, return a total number of leis
-  /admin/list/<filingperiod>/lei - for a given filing period, return a list of leis. The count of list from this endpoint will always match the count from previous endpoint.