### PR TITLE
[Timed Guards] Open 2021 Quarterly Filing

### DIFF
--- a/kubernetes/config-maps/timed-guards-configmap.yaml
+++ b/kubernetes/config-maps/timed-guards-configmap.yaml
@@ -7,7 +7,7 @@ metadata:
 data:
   yearsAllowed: "2018,2019,2020"
   currentYear: "2020"
-  quarterlyYearsAllowed: "2020"
+  quarterlyYearsAllowed: "2020,2021"
   q1Start: "April 01"
   q1End: "June 30"
   q2Start: "July 01"


### PR DESCRIPTION
For local development and Frontend testing in CI, updating the Platform's default Timed Guards to enable 2021 Quarterly Filing. 