### PR TITLE
[Timed Guards] Do a more thorough job of opening 2021 Quarterly Filing

### DIFF
--- a/common/src/main/resources/reference.conf
+++ b/common/src/main/resources/reference.conf
@@ -32,7 +32,7 @@ hmda {
     }
 
     quarterly-filing {
-      years-allowed = "2020"
+      years-allowed = "2020,2021"
       years-allowed = ${?RULES_QF_FILING_YEARS_ALLOWED}
 
       q1 {

--- a/hmda/src/test/resources/application.conf
+++ b/hmda/src/test/resources/application.conf
@@ -37,7 +37,7 @@ hmda {
     }
 
     quarterly-filing {
-      years-allowed = "2018,2019,2020"
+      years-allowed = "2018,2019,2020,2021"
       years-allowed = ${?RULES_QF_FILING_YEARS_ALLOWED}
 
       q1 {

--- a/institutions-api/src/test/resources/application-createschema.conf
+++ b/institutions-api/src/test/resources/application-createschema.conf
@@ -52,7 +52,7 @@ hmda {
     }
 
     quarterly-filing {
-      years-allowed = "2018,2019,2020"
+      years-allowed = "2018,2019,2020,2021"
       years-allowed = ${?RULES_QF_FILING_YEARS_ALLOWED}
 
       q1 {

--- a/institutions-api/src/test/resources/application.conf
+++ b/institutions-api/src/test/resources/application.conf
@@ -52,7 +52,7 @@ hmda {
     }
 
     quarterly-filing {
-      years-allowed = "2018,2019,2020"
+      years-allowed = "2018,2019,2020,2021"
       years-allowed = ${?RULES_QF_FILING_YEARS_ALLOWED}
 
       q1 {


### PR DESCRIPTION
My [previous PR](https://github.com/cfpb/hmda-platform/pull/4068) was not complete as I've realized that I did not correctly `unset` my configured environment variables (i.e. `RULES_QF_FILING_YEARS_ALLOWED`), so I was not actually testing the default Platform timed guard configuration.  As a result, 2021-Q1 was still closed in the default Platform config. 
 
After being sure to do the above mentioned clearing, and making the attached updates, my testing shows the Platform has 2021-Q1 open by default, as expected.