### PR TITLE
[Docs] Fix broken images in ModifiedLarWithExcel.md

### DIFF
--- a/docs/ModifiedLarWithExcel.md
+++ b/docs/ModifiedLarWithExcel.md
@@ -5,37 +5,37 @@ Modified LAR is available as a pipe-delimited text file with the .txt extension 
 
 2. Open Excel. Select the `File` menu, and then `Open`. In the Open menu, double-click on `Browse` and view the Downloads folder. Select the modified LAR file in the Downloads folder as shown below. 
 
-![alt text](https://raw.githubusercontent.com/cfpb/hmda-platform/master/docs/v2/example_images/mlar_tutorial_images/Step2.JPG)
+![alt text](https://raw.githubusercontent.com/cfpb/hmda-platform/master/docs/example_images/mlar_tutorial_images/Step2.JPG)
 
 3. A window will open that tells Excel how to read the file. Select `Delimited` in the first window and click `Next.` 
 
-![alt text](https://raw.githubusercontent.com/cfpb/hmda-platform/master/docs/v2/example_images/mlar_tutorial_images/Step3.JPG)
+![alt text](https://raw.githubusercontent.com/cfpb/hmda-platform/master/docs/example_images/mlar_tutorial_images/Step3.JPG)
 
 4. In the next window, specify the pipe delimiter. Select `Other` under the `Delimiters` column and place a pipe (`|`) character in the text box field. Click `Next.`
 
-![alt text](https://raw.githubusercontent.com/cfpb/hmda-platform/master/docs/v2/example_images/mlar_tutorial_images/Step4.JPG)
+![alt text](https://raw.githubusercontent.com/cfpb/hmda-platform/master/docs/example_images/mlar_tutorial_images/Step4.JPG)
 
 5. In the final window, select `General` for data type, and select `Finish.` 
 At this point, the data will populate into their own cells.
 
-![alt text](https://raw.githubusercontent.com/cfpb/hmda-platform/master/docs/v2/example_images/mlar_tutorial_images/Step5.JPG)
+![alt text](https://raw.githubusercontent.com/cfpb/hmda-platform/master/docs/example_images/mlar_tutorial_images/Step5.JPG)
 
 6. To add a header, right click on the row number to highlight the top row of data, and select `Insert` to add a blank row. 
 
-![alt text](https://raw.githubusercontent.com/cfpb/hmda-platform/master/docs/v2/example_images/mlar_tutorial_images/Step6.JPG)
+![alt text](https://raw.githubusercontent.com/cfpb/hmda-platform/master/docs/example_images/mlar_tutorial_images/Step6.JPG)
 
 7. Select the modified LAR header for the appropriate activity year and open in Excel. These headers are available for 2018 [here](https://github.com/cfpb/hmda-platform/master/docs/v2/spec/2018_Modified_LAR_Header.csv) and for 2017 [here](https://github.com/cfpb/hmda-platform/master/docs/v1/spec/2017_Modified_LAR_Header.csv). To download from Github, click "Raw" at the top of the file.
 
-![alt text](https://raw.githubusercontent.com/cfpb/hmda-platform/master/docs/v2/example_images/mlar_tutorial_images/Step_7_1.JPG) 
+![alt text](https://raw.githubusercontent.com/cfpb/hmda-platform/master/docs/example_images/mlar_tutorial_images/Step_7_1.JPG) 
 
 Right click the raw text file page and save as a csv in the Downloads folder. 
 
-![alt text](https://raw.githubusercontent.com/cfpb/hmda-platform/master/docs/v2/example_images/mlar_tutorial_images/Step_7_2.JPG)
+![alt text](https://raw.githubusercontent.com/cfpb/hmda-platform/master/docs/example_images/mlar_tutorial_images/Step_7_2.JPG)
 
 8. Highlight the first row of the header file, right click, and select `Copy`. 
 
-![alt text](https://raw.githubusercontent.com/cfpb/hmda-platform/master/docs/v2/example_images/mlar_tutorial_images/Step8.JPG)
+![alt text](https://raw.githubusercontent.com/cfpb/hmda-platform/master/docs/example_images/mlar_tutorial_images/Step8.JPG)
 
 9. Navigate back to the modified LAR excel sheet, highlight the first row, right click, and select `Insert Copied Cells`. 
 
-![alt text](https://raw.githubusercontent.com/cfpb/hmda-platform/master/docs/v2/example_images/mlar_tutorial_images/Step9.JPG)
+![alt text](https://raw.githubusercontent.com/cfpb/hmda-platform/master/docs/example_images/mlar_tutorial_images/Step9.JPG)


### PR DESCRIPTION
Closes #4504 
 
[Preview updated version here](https://github.com/cfpb/hmda-platform/blob/649507f386e1a69c16ce3b7d5f2c9b40950a51ae/docs/ModifiedLarWithExcel.md)

|Description|Screenshot|
|---|---|
|Before|<img width="527" alt="broken-image-ref" src="https://user-images.githubusercontent.com/2592907/184934739-594bd05e-ad26-4e5c-aa73-5e9bcfc1ea8c.png">|
|Local markdown preview of updated version|![fixed-image-ref](https://user-images.githubusercontent.com/2592907/184934820-35bd1d40-c74f-4c2b-b265-423e1589a7d6.png)|