### PR TITLE
[Keycloak] Redirect Institutions API on ProdBeta to Prod

### DIFF
--- a/kubernetes/keycloak/theme-provider/themes/hmda/login/resources/js/register.js
+++ b/kubernetes/keycloak/theme-provider/themes/hmda/login/resources/js/register.js
@@ -103,10 +103,19 @@
 
   }
 
+  // ProdBeta will use Prod data, 
+  // other systems will use data from their host.
+  function deriveInstitutionsApiHost() {
+    if (window.location.host == 'ffiec.beta.cfpb.gov')
+      return 'https://ffiec.cfpb.gov'
+    
+    return ''
+  }
+
   //AJAX call to get data, calls buildList with returned institutions
   function getInstitutions(domain) {
     $.ajax({
-      url: '/v2/public/institutions',
+      url: deriveInstitutionsApiHost() + '/v2/public/institutions',
       statusCode: {
         404: function() {
           $('#institutions')


### PR DESCRIPTION
Closes #4619 

## Changes
When running on ProdBeta the Keycloak registration page will rely on the Institutions API data from ProdDefault.

All other environments will continue to use the Institutions API of the host their running on.