### PR TITLE
Update base docker to eclipse temurin 20 jdk alpine

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -58,7 +58,7 @@ lazy val slickDeps = Seq(slick, slickHikariCP, postgres, h2)
 
 lazy val dockerSettings = Seq(
   Docker / maintainer := "Hmda-Ops",
-  dockerBaseImage := "eclipse-temurin:19-jdk-alpine",
+  dockerBaseImage := "eclipse-temurin:20-jdk-alpine",
   dockerRepository := Some("hmda"),
   dockerCommands := dockerCommands.value.flatMap {
     case cmd@Cmd("FROM",_) => List(cmd, Cmd("RUN", "apk update"),

--- a/kubernetes/hmda-data-browser-api/templates/deployment.yaml
+++ b/kubernetes/hmda-data-browser-api/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
           - /bin/sh
           - -c
           - --
-        image: eclipse-temurin:19-jdk-alpine
+        image: eclipse-temurin:20-jdk-alpine
         name: eclipse-temurin-init
         resources: {}
         terminationMessagePath: /dev/termination-log


### PR DESCRIPTION
- Successfully created docker images for all services
    - Except modified-lar due to an issue with my laptop and a unit test 
- Pushed all images to ECR using the tag `base_docker_to_eclipse_20`
- Deployed hmda-platform, hmda-analytics, and hmda-data-browser-api services to HMDA4 and successfully completed a manual filing test for Bank0