### PR TITLE
Add SBT to cve-scan workflow

### DIFF
--- a/.github/workflows/cve-scan-pr.yml
+++ b/.github/workflows/cve-scan-pr.yml
@@ -15,25 +15,22 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v4
 
+      - name: Setup sbt launcher
+        uses: sbt/setup-sbt@v1
+
       - name: Build Docker image of HMDA platform
         run: |
           env JAVA_OPTS="-Xss256m -Xmx4096m" sbt "project hmda-platform" dockerPublishLocalSkipTests
-        continue-on-error: false
 
       - name: Tag and name Docker image
         run: docker tag hmda/hmda-platform:latest pr-cve-scan:latest
 
-      - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+      - name: Scan image
+        uses: anchore/scan-action@v6
+        with:
+          image: pr-cve-scan:latest
+          output-file: grype-report.txt
 
-      - name: Install Grype
-        run: |
-          brew install grype
-
-      - name: Run Grype scan
-        run: |
-          grype pr-cve-scan:latest > grype-report.txt
-          
       - name: Upload Grype report to artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
- Add SBT to workflow
- Remove unnecessary package manager
- Utilize grype action 