### PR TITLE
Delete check-digit/Dockerfile

### DIFF
--- a/check-digit/Dockerfile
+++ b/check-digit/Dockerfile
@@ -1,6 +1,0 @@
-FROM jdk:contrast
-LABEL MAINTAINER="Hmda-Ops"
-WORKDIR /opt/docker
-EXPOSE 9091 60080
-ENTRYPOINT ["bin/check-digit"]
-CMD []


### PR DESCRIPTION
This file is not used, DockerFile and image are created part of sbt build process