### PR TITLE
fix(github-actions): pin versions to sha

### DIFF
--- a/.github/workflows/cve-scan-pr.yml
+++ b/.github/workflows/cve-scan-pr.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup sbt launcher
-        uses: sbt/setup-sbt@v1
+        uses: sbt/setup-sbt@508b753e53cb6095967669e0911487d2b9bc9f41 # v1
 
       - name: Build Docker image of HMDA platform
         run: |
@@ -28,7 +28,7 @@ jobs:
         run: docker tag hmda/hmda-platform:latest pr-cve-scan:latest
 
       - name: Scan image
-        uses: anchore/scan-action@v6
+        uses: anchore/scan-action@1638637db639e0ade3258b51db49a9a137574c3e # v6
         with:
           image: pr-cve-scan:latest
           output-file: grype-report.txt
@@ -37,7 +37,7 @@ jobs:
           output-format: table
 
       - name: Upload Grype report to artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: cve-report
           path: |

--- a/.github/workflows/dockerhub-push.yml
+++ b/.github/workflows/dockerhub-push.yml
@@ -15,10 +15,10 @@ jobs:
     permissions: write-all
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup sbt launcher
-        uses: sbt/setup-sbt@v1
+        uses: sbt/setup-sbt@508b753e53cb6095967669e0911487d2b9bc9f41 # v1
 
       - name: Build image of HMDA Platform only
         run: |
@@ -30,7 +30,7 @@ jobs:
         run: docker tag $(docker images --filter=reference="hmda/hmda-platform:latest" --format "{{.ID}}") ${{ env.REGISTRY }}:${{ github.ref_name }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/ecr-push.yaml
+++ b/.github/workflows/ecr-push.yaml
@@ -8,7 +8,7 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - name: Configure AWS credentials
-          uses: aws-actions/configure-aws-credentials@v4
+          uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
           with:
             aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
             aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
@@ -16,7 +16,7 @@ jobs:
 
         - name: Login to Amazon ECR
           id: login-ecr
-          uses: aws-actions/amazon-ecr-login@v2
+          uses: aws-actions/amazon-ecr-login@19d944daaa35f0fa1d3f7f8af1d3f2e5de25c5b7 # v2
 
         - name: Copy Image to ECR
           run: |

--- a/.github/workflows/helper-functions.yaml
+++ b/.github/workflows/helper-functions.yaml
@@ -18,13 +18,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup sbt launcher
-        uses: sbt/setup-sbt@v1
+        uses: sbt/setup-sbt@508b753e53cb6095967669e0911487d2b9bc9f41 # v1
 
       - name: Setup JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: '17'
           distribution: 'adopt'


### PR DESCRIPTION
Due to some recent supply chain attacks, Lamin would prefer if we locked the github actions to SHAs instead of just the version number. I used the same script that cf.gov [used over here](https://github.cfpb.gov/Design-Development/cfgov/issues/4673#issuecomment-375885), thanks @chosak!

## Changes

- Instead of using a version number, locks github actions to SHAs

## Testing

1. Do the github actions still work? Yes!
2. Do the tests still pass? Yes!
